### PR TITLE
fix: vite mui icons bug

### DIFF
--- a/frontend/src/layouts/Layout.jsx
+++ b/frontend/src/layouts/Layout.jsx
@@ -5,7 +5,7 @@ import Footer from '@/components/Footer'
 import BCTypography from '@/components/BCTypography'
 
 import Navbar from '@/layouts/navbar/Navbar'
-import NavigateNextIcon from '@mui/icons-material/NavigateNext'
+import { NavigateNext as NavigateNextIcon } from '@mui/icons-material'
 import RequireAuth from '@/components/RequireAuth'
 import * as appRoutes from '@/constants/routes'
 


### PR DESCRIPTION
Theres a bug going on with vite + mui that causes some rendering errors.
destructuring the import for mui icons seems to fix it.
This pattern should be used from now on for mui icons