### PR TITLE
Feat: Add organization name display in top banner - 154

### DIFF
--- a/backend/lcfs/db/seeders/common/organization_seeder.py
+++ b/backend/lcfs/db/seeders/common/organization_seeder.py
@@ -14,7 +14,7 @@ async def seed_organizations(session):
 
     organizations_to_seed = [
         {
-            "name": "BC Government",
+            "name": "Government of British Columbia",
             "organization_status_id": 1,
             "organization_type_id": 1
         },

--- a/frontend/src/layouts/navbar/Navbar.jsx
+++ b/frontend/src/layouts/navbar/Navbar.jsx
@@ -2,6 +2,7 @@
 import BCNavbar from '@/components/BCNavbar'
 import HeaderComponent from '@/layouts/navbar/components/HeaderComponent'
 import MenuBarComponent from './components/MenuBarComponent'
+import useUserStore from '@/store/useUserStore'
 
 // Nav Links
 const routes = [
@@ -14,11 +15,13 @@ const routes = [
 ]
 
 const Navbar = () => {
+  const user = useUserStore((state) => state.user)
+
   return (
     <BCNavbar
       title="Low Carbon Fuel Standard"
       balance="50,000"
-      organizationName="BC Government"
+      organizationName={user?.organization?.name}
       routes={routes}
       beta={true}
       headerRightPart={<HeaderComponent key="headerRight" />}

--- a/frontend/src/views/organization/AddOrganization.jsx
+++ b/frontend/src/views/organization/AddOrganization.jsx
@@ -267,8 +267,8 @@ export const AddOrganization = () => {
           <Grid item xs={12}>
             <Box sx={{ bgcolor: 'background.grey', p: 3 }}>
               <Grid container spacing={2}>
-                <Grid item xs={6}>
-                  <Box sx={{ mr: 4 }}>
+                <Grid item xs={12} md={6}>
+                  <Box sx={{ mr: { sm: 0, md: 4 } }}>
                     <Box mb={2}>
                       <InputLabel htmlFor="orgLegalName" sx={{ pb: 1 }}>
                         Legal Name of Organization:
@@ -362,7 +362,7 @@ export const AddOrganization = () => {
                     </Box>
                   </Box>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={12} md={6}>
                   <Box>
                     <Box mb={2}>
                       <FormControl fullWidth>


### PR DESCRIPTION
This PR adds the organization's name to the top banner of the app.
It also includes a minor refactor for responsive spacing in the "Add Organization" form.

Closes #154