### PR TITLE
Feat: Add new transfer button and landing page - 212

### DIFF
--- a/frontend/src/constants/roles.js
+++ b/frontend/src/constants/roles.js
@@ -6,7 +6,7 @@ export const roles = {
   compliance_manager: 'Compliance Manager',
   director: 'Director',
   manage_users: 'Manage Users',
-  transfers: 'Transfers',
+  transfers: 'Transfer',
   compliance_reporting: 'Compliance Reporting',
   signing_authority: 'Signing Authority',
   read_only: 'Read Only'

--- a/frontend/src/views/AddTransaction.jsx
+++ b/frontend/src/views/AddTransaction.jsx
@@ -1,3 +1,10 @@
+// Components
+import BCTypography from '@/components/BCTypography'
+
 export const AddTransaction = () => {
-  return <div>AddTransaction</div>
+  return <>
+    <BCTypography variant="h5">New Transfer</BCTypography>
+    <BCTypography>A transfer is not effective until it is recorded by the Director.</BCTypography>
+    <BCTypography>Transfers must indicate whether they are for consideration, and if so, the fair market value of the consideration in Canadian dollars per compliance unit.</BCTypography>
+  </>
 }

--- a/frontend/src/views/Transactions.jsx
+++ b/frontend/src/views/Transactions.jsx
@@ -1,3 +1,47 @@
+import { useNavigate } from 'react-router-dom'
+import { Stack } from '@mui/material'
+
+// Font Awesome
+import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+// Hooks
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+
+// Constants
+import { ROUTES } from '@/constants/routes'
+import { roles } from '@/constants/roles'
+
+// Components
+import BCButton from '@/components/BCButton'
+import BCTypography from '@/components/BCTypography'
+
 export const Transactions = () => {
-  return <div>Transactions</div>
+  const navigate = useNavigate()
+  const { hasRoles } = useCurrentUser();
+
+  return <>
+    <BCTypography variant="h5">Transactions</BCTypography>
+    <Stack
+        direction={{ md: 'coloumn', lg: 'row' }}
+        spacing={{ xs: 2, sm: 2, md: 3 }}
+        useFlexGap
+        flexWrap="wrap"
+        m={2}
+      >
+      {hasRoles(roles.transfers) && (
+          <BCButton
+          variant="contained"
+          size="small"
+          color="primary"
+          startIcon={
+            <FontAwesomeIcon icon={faCirclePlus} className="small-icon" />
+          }
+          onClick={() => navigate(ROUTES.TRANSACTIONS_ADD)}
+        >
+          <BCTypography variant="subtitle2">New Transfer</BCTypography>
+        </BCButton>
+      )}
+      </Stack>
+  </>
 }


### PR DESCRIPTION
This pull request adds a 'New Transfer' button to the Transactions page, available exclusively for users with the 'Transfers' role.

The updated `useCurrentUser` hook now aligns better with user authentication, simplifies handling success and errors, and adds a clear, documented function for checking user roles.

Closes #212