### PR TITLE
Fix: org view 160

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -101,7 +101,7 @@ const router = createBrowserRouter([
       {
         path: ROUTES.ORGANIZATIONS,
         element: <Organizations />,
-        handle: { title: 'Organizations' }
+        handle: { title: 'Organizations', crumb: () => `Organizations` }
       },
       {
         path: ROUTES.ORGANIZATIONS_ADD,

--- a/frontend/src/views/Organizations/ViewOrganization/_schema.js
+++ b/frontend/src/views/Organizations/ViewOrganization/_schema.js
@@ -9,8 +9,7 @@ export const organizationsColDefs = (t) => [
   {
     colId: 'name',
     field: 'name',
-    headerName: t('org:orgColLabels.orgName'),
-    width: 400
+    headerName: t('org:orgColLabels.orgName')
   },
   {
     colId: 'complianceUnits',
@@ -38,7 +37,6 @@ export const organizationsColDefs = (t) => [
     colId: 'status',
     field: 'status',
     headerName: t('org:orgColLabels.status'),
-    width: 200,
     valueGetter: (params) => params.data.org_status.status,
     cellRenderer: OrgStatusRenderer,
     cellClass: 'vertical-middle',


### PR DESCRIPTION
- fix: org creation error fixed in #222 
- refactor: org creation improvements in #222 
- fix: grid column width
- feat: breadcrumb added

notes:
- in reserve and compliance units are generated at random every render. This can be replaced with actual values once these values are saved to the organizations.