### PR TITLE
Fix: Update "New Transaction" Button Label - 212

### DIFF
--- a/frontend/src/views/Transactions/Transactions.jsx
+++ b/frontend/src/views/Transactions/Transactions.jsx
@@ -72,7 +72,7 @@ export const Transactions = () => {
               startIcon={<FontAwesomeIcon icon={faCirclePlus} size="2x" />}
               onClick={() => navigate(ROUTES.TRANSFERS_ADD)}
             >
-              <BCTypography variant="subtitle2">New transaction</BCTypography>
+              <BCTypography variant="subtitle2">New transfer</BCTypography>
             </BCButton>
           </Role>
         )}


### PR DESCRIPTION
This PR updates the label of the "New Transaction" button to "New Transfer" for BCeID users on the Transactions page, enhancing user understanding and consistency within the application. 

Closes #212