### PR TITLE
Fix: Cleanup Intro Sentence on New Transfer Page - 214

### DIFF
--- a/frontend/src/views/Transfers/AddEditTransfer/AddEditTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditTransfer/AddEditTransfer.jsx
@@ -152,14 +152,14 @@ export const AddEditTransfer = () => {
         </BCTypography>
 
         <BCTypography>
-          A transfer is not effective until it is recorded by the Director.
+          A transfer is not effective until it is recorded by the director.
         </BCTypography>
         <BCTypography>
           Transfers must indicate whether they are for consideration, and if so,
           the fair market value of the consideration in Canadian dollars per
           compliance unit.
         </BCTypography>
-        <BCTypography>&nbsp</BCTypography>
+        <BCTypography>&nbsp;</BCTypography>
 
         {isError && (
           <BCAlert severity="error">


### PR DESCRIPTION
This PR corrects the introductory sentence on the new transfer page by removing an extraneous `&nbsp;` and ensuring "director" is in lowercase.

Closes #214
