### PR TITLE
Feat: Org Balance Widget on BCeID Dashboard - 207

### DIFF
--- a/frontend/src/assets/locales/en/organization.json
+++ b/frontend/src/assets/locales/en/organization.json
@@ -47,5 +47,11 @@
   "orgDetailsLabel": "Organization Details",
   "orgDetailsLoadingMsg": "Loading organization details...",
   "createNewUsrLabel": "Create new BCeID account",
-  "selectOrgLabel": "Select an Organization"
+  "selectOrgLabel": "Select an Organization",
+  "loadingBalanceDetails": "Loading balance details...",
+  "unableToFetchBalanceDetails": "Unable to fetch balance details.",
+  "hasABalanceOf": "has a balance of",
+  "complianceUnits": "compliance units",
+  "inReserve": "in reserve",
+  "inReserveTooltip": "In-reserve are the portion of compliance units in your balance that are currently pending the completion of a transaction. For example, transferring credits to another organization or a compliance report awaiting assessment by the director. Compliance units that are in-reserve cannot be transferred or otherwise used until the pending transaction has been completed."
 }

--- a/frontend/src/views/Dashboard/Dashboard.jsx
+++ b/frontend/src/views/Dashboard/Dashboard.jsx
@@ -2,13 +2,16 @@ import { Role } from '@/components/Role'
 import { govRoles, nonGovRoles } from '@/constants/roles'
 import { Box } from '@mui/material'
 import { OrgDetailsWidget } from './components/bceidWidgets/OrgDetailsWidget'
+import { BCeIDBalance } from './components/bceidWidgets/BCeIDBalance'
 import { AdminLinksCard } from './components/idirWidgets/AdminLinksCard'
 
 export const Dashboard = () => {
   return (
     <Box display="grid" gridTemplateColumns="1fr 3fr" gap={3}>
-      <Box p={2.5} bgcolor="background.grey">
-        placeholder
+      <Box display="flex" flexDirection="column" gap={3}>
+        <Role roles={nonGovRoles}>
+          <BCeIDBalance />
+        </Role>
       </Box>
       <Box
         display="grid"

--- a/frontend/src/views/Dashboard/components/bceidWidgets/BCeIDBalance.jsx
+++ b/frontend/src/views/Dashboard/components/bceidWidgets/BCeIDBalance.jsx
@@ -1,13 +1,61 @@
-import withRole from '@/utils/withRole'
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Tooltip, Fade } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
+import BCTypography from '@/components/BCTypography';
+import Loading from '@/components/Loading';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useCurrentOrgBalance } from '@/hooks/useOrganization';
 
-export const BCeIDBalance = (props) => <>BCeIDBalance</>
+export const BCeIDBalance = () => {
+  const { t } = useTranslation(['org']);
+  const { data: currentUser, isLoading: isUserLoading, isError: isUserError } = useCurrentUser();
+  const { data: orgBalance, isLoading: isBalanceLoading, isError: isBalanceError } = useCurrentOrgBalance();
 
-BCeIDBalance.defaultProps = {
-  organization: {},
-  organizations: []
-}
+  const Content = () => {
+    if (isUserLoading || isBalanceLoading) {
+      return <Loading message={t('org:loadingBalanceDetails')} />;
+    } else if (isUserError || isBalanceError || !orgBalance) {
+      return (
+        <BCTypography color="error" variant="body1" style={{ padding: '16px' }}>
+          {t('org:unableToFetchBalanceDetails')}
+        </BCTypography>
+      );
+    } else {
+      return (
+        <>
+          <BCTypography style={{ fontSize: '18px', color: '#003366', marginBottom: '-2px' }} gutterBottom>
+            <strong>{currentUser?.organization?.name || t('org:org')}</strong>
+          </BCTypography>
+          <BCTypography style={{ fontSize: '16px', color: '#003366', marginBottom: '-4px' }}>
+            {t('org:hasABalanceOf')}
+          </BCTypography>
+          <BCTypography style={{ fontSize: '32px', color: '#578260', marginBottom: '-4px' }} component="span">
+            {orgBalance.totalBalance.toLocaleString()}
+          </BCTypography>
+          <BCTypography style={{ fontSize: '18px', color: '#003366', marginBottom: '-5px' }}>
+            <strong>{t('org:complianceUnits')}</strong>
+          </BCTypography>
+          <Box display="flex" alignItems="center" mt={1}>
+            <BCTypography style={{ fontSize: '22px', color: '#578260' }} component="span">
+              ({orgBalance.reservedBalance.toLocaleString()} {t('org:inReserve')})
+            </BCTypography>
+            <Tooltip
+                title={t('org:inReserveTooltip')}
+                TransitionComponent={Fade}
+                arrow
+              >
+              <InfoIcon style={{ marginLeft: '4px', color: '#578260' }} />
+            </Tooltip>
+          </Box>
+        </>
+      );
+    }
+  };
 
-const AllowedRoles = ['Transfer']
-const BCeIDBalanceWithRole = withRole(BCeIDBalance, AllowedRoles)
-
-export default BCeIDBalanceWithRole
+  return (
+    <Box p={2} paddingTop={4} paddingBottom={4} bgcolor="background.grey" display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+      <Content />
+    </Box>
+  );
+};


### PR DESCRIPTION
This PR introduces the organization balance widget on the BCeID dashboard, displaying the compliance balance of organizations and adding a tooltip for in-reserve credits.

Closes #207
