### PR TITLE
Feat: Clean up transfer visibility by status - 491

### DIFF
--- a/backend/lcfs/db/migrations/versions/2024-04-03-14-18_abcdef123456.py
+++ b/backend/lcfs/db/migrations/versions/2024-04-03-14-18_abcdef123456.py
@@ -1,0 +1,40 @@
+"""Add visibility control columns to transfer_status table
+
+Revision ID: abcdef123456
+Revises: df41556bd1ee
+Create Date: 2024-04-03 14:18:25.430681
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "abcdef123456"
+down_revision = "df41556bd1ee"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('transfer_status',
+                  sa.Column('visible_to_transferor',
+                            sa.Boolean(),
+                            nullable=True,
+                            server_default=sa.text('FALSE'),
+                            comment='Visibility for transferor entities'))
+    op.add_column('transfer_status',
+                  sa.Column('visible_to_transferee',
+                            sa.Boolean(),
+                            nullable=True,
+                            server_default=sa.text('FALSE'),
+                            comment='Visibility for transferee entities'))
+    op.add_column('transfer_status',
+                  sa.Column('visible_to_government',
+                            sa.Boolean(),
+                            nullable=True,
+                            server_default=sa.text('FALSE'),
+                            comment='Visibility for government entities'))
+
+def downgrade() -> None:
+    op.drop_column('transfer_status', 'visible_to_transferor')
+    op.drop_column('transfer_status', 'visible_to_transferee')
+    op.drop_column('transfer_status', 'visible_to_government')

--- a/backend/lcfs/db/models/TransactionView.py
+++ b/backend/lcfs/db/models/TransactionView.py
@@ -1,5 +1,11 @@
-from sqlalchemy import Column, Integer, String, Float
+import enum
+from sqlalchemy import Column, Integer, String, Float, DateTime
 from lcfs.db.base import BaseModel
+
+class TransactionViewTypeEnum(enum.Enum):
+    Transfer = "Transfer"
+    InitiativeAgreement = "InitiativeAgreement"
+    AdminAdjustment = "AdminAdjustment"
 
 # This class represents a database view for transactions. It is intended to consolidate
 # and simplify access to various transaction-related data by providing a unified interface
@@ -25,5 +31,5 @@ class TransactionView(BaseModel):
     quantity = Column(Integer)
     price_per_unit = Column(Float)
     status = Column(String)
-    create_date = Column(String)
-    update_date = Column(String)
+    create_date = Column(DateTime)
+    update_date = Column(DateTime)

--- a/backend/lcfs/db/models/TransferStatus.py
+++ b/backend/lcfs/db/models/TransferStatus.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Enum
+from sqlalchemy import Column, Integer, Enum, Boolean
 from lcfs.db.base import BaseModel, Auditable, DisplayOrder
 import enum
 
@@ -20,3 +20,6 @@ class TransferStatus(BaseModel, Auditable, DisplayOrder):
 
     transfer_status_id = Column(Integer, primary_key=True, autoincrement=True)
     status = Column(Enum(TransferStatusEnum, name="transfer_type_enum", create_type=True), comment="Transfer Status")
+    visible_to_transferor = Column(Boolean, default=False, comment="Visibility for transferor entities")
+    visible_to_transferee = Column(Boolean, default=False, comment="Visibility for transferee entities")
+    visible_to_government = Column(Boolean, default=False, comment="Visibility for government entities")

--- a/backend/lcfs/db/seeders/common/transfer_status_seeder.py
+++ b/backend/lcfs/db/seeders/common/transfer_status_seeder.py
@@ -13,15 +13,60 @@ async def seed_transfer_statuses(session):
     """
 
     transfer_statuses_to_seed = [
-        {"status": TransferStatusEnum.Draft},
-        {"status": TransferStatusEnum.Deleted},
-        {"status": TransferStatusEnum.Sent},
-        {"status": TransferStatusEnum.Submitted},
-        {"status": TransferStatusEnum.Recommended},
-        {"status": TransferStatusEnum.Recorded},
-        {"status": TransferStatusEnum.Refused},
-        {"status": TransferStatusEnum.Declined},
-        {"status": TransferStatusEnum.Rescinded}
+        {
+            "status": TransferStatusEnum.Draft,
+            "visible_to_transferor": True,
+            "visible_to_transferee": False,
+            "visible_to_government": False
+        },
+        {
+            "status": TransferStatusEnum.Deleted,
+            "visible_to_transferor": False,
+            "visible_to_transferee": False,
+            "visible_to_government": False
+        },
+        {
+            "status": TransferStatusEnum.Sent,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": False
+        },
+        {
+            "status": TransferStatusEnum.Submitted,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": True
+        },
+        {
+            "status": TransferStatusEnum.Recommended,
+            "visible_to_transferor": False,
+            "visible_to_transferee": False,
+            "visible_to_government": True
+        },
+        {
+            "status": TransferStatusEnum.Recorded,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": True
+        },
+        {
+            "status": TransferStatusEnum.Refused,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": True
+        },
+        {
+            "status": TransferStatusEnum.Declined,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": False
+        },
+        {
+            "status": TransferStatusEnum.Rescinded,
+            "visible_to_transferor": True,
+            "visible_to_transferee": True,
+            "visible_to_government": True
+        }
     ]
 
     try:

--- a/backend/lcfs/db/seeders/test_seeder.py
+++ b/backend/lcfs/db/seeders/test_seeder.py
@@ -24,8 +24,8 @@ async def seed_test():
             await seed_test_organizations(session)
             await seed_test_user_profiles(session)
             await seed_test_user_roles(session)
-            await seed_test_transactions(session)
-            await seed_test_transfers(session)
+            # await seed_test_transactions(session)
+            # await seed_test_transfers(session)
             logger.info("Test database seeding completed successfully.")
         except Exception as e:
             logger.error(f"An error occurred during seeding: {e}")

--- a/backend/lcfs/tests/transaction/test_transaction_repo.py
+++ b/backend/lcfs/tests/transaction/test_transaction_repo.py
@@ -1,35 +1,309 @@
 import pytest
-from sqlalchemy import text
-from lcfs.web.api.transaction.repo import TransactionRepository  # Ensure this path is correct
-from lcfs.tests.transaction.transaction_payloads import (
-    transaction_orm_model, transaction_orm_model_2
-)
 from lcfs.web.api.base import SortOrder
+from lcfs.web.api.transaction.repo import EntityType, TransactionRepository
+from lcfs.db.models.TransferStatus import TransferStatusEnum
+from lcfs.tests.transaction.transaction_payloads import *
+
 
 @pytest.fixture
 def transaction_repo(dbsession):
     return TransactionRepository(db=dbsession)
 
-# Test retrieving paginated transactions
 @pytest.mark.anyio
-async def test_get_transactions_paginated(dbsession, transaction_repo):
-    # Add test transactions to the session
-    dbsession.add_all([transaction_orm_model, transaction_orm_model_2])
+async def test_transactions_in_draft_status_are_visible_to_transferor(dbsession, transaction_repo):
+    dbsession.add_all([
+        draft_transfer_orm
+    ])
     await dbsession.commit()
     
     conditions = []
     sort_orders = [SortOrder(field='transaction_id', direction='asc')]
     
-    transactions, total_count = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
     
-    assert len(transactions) >= 2
-    assert total_count >= 2
-    assert transactions[0].transaction_id < transactions[1].transaction_id  # Ascending order check
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
 
+    assert len(transactions_transferee) == 0
+    assert total_count_transferee == 0
 
-# Test retrieving transaction statuses
+    assert len(transactions_gov) == 0
+    assert total_count_gov == 0
+
 @pytest.mark.anyio
-async def test_get_transaction_statuses(dbsession, transaction_repo):
-    statuses = await transaction_repo.get_transaction_statuses()
-    # Assert based on expected outcomes
-    assert len(statuses) > 0  # Assuming there's at least one status in your test DB
+async def test_transactions_in_deleted_status_are_not_visible_to_any_entity(dbsession, transaction_repo):
+    dbsession.add_all([
+        deleted_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 0
+    assert total_count_transferor == 0
+
+    assert len(transactions_transferee) == 0
+    assert total_count_transferee == 0
+
+    assert len(transactions_gov) == 0
+    assert total_count_gov == 0
+
+@pytest.mark.anyio
+async def test_transactions_in_sent_status_are_visible_to_transferor_and_transferee(dbsession, transaction_repo):
+    dbsession.add_all([
+        sent_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 0
+    assert total_count_gov == 0
+
+@pytest.mark.anyio
+async def test_transactions_in_submitted_status_are_visible_to_all_entities(dbsession, transaction_repo):
+    dbsession.add_all([
+        submitted_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_transactions_in_recommended_status_are_visible_to_government_only(dbsession, transaction_repo):
+    dbsession.add_all([
+        recommended_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 0
+    assert total_count_transferor == 0
+
+    assert len(transactions_transferee) == 0
+    assert total_count_transferee == 0
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_transactions_in_recorded_status_are_visible_to_all_entities(dbsession, transaction_repo):
+    dbsession.add_all([
+        recorded_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_transactions_in_refused_status_are_visible_to_all_entities(dbsession, transaction_repo):
+    dbsession.add_all([
+        refused_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_transactions_in_declined_status_are_visible_to_transferor_and_transferee(dbsession, transaction_repo):
+    dbsession.add_all([
+        declined_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 0
+    assert total_count_gov == 0
+
+@pytest.mark.anyio
+async def test_transactions_in_rescinded_status_are_visible_to_all_entities(dbsession, transaction_repo):
+    dbsession.add_all([
+        rescinded_transfer_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 1
+    assert total_count_transferee == 1
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_initiative_agreement_transactions_visible(dbsession, transaction_repo):
+    dbsession.add_all([
+        initiative_agreement_status_orm,
+        initiative_agreement_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 0
+    assert total_count_transferee == 0
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+@pytest.mark.anyio
+async def test_admin_adjustment_transactions_visible(dbsession, transaction_repo):
+    dbsession.add_all([
+        admin_adjustment_status_orm,
+        admin_adjustment_orm
+    ])
+    await dbsession.commit()
+    
+    conditions = []
+    sort_orders = [SortOrder(field='transaction_id', direction='asc')]
+    
+    transactions_transferor, total_count_transferor = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 1)
+    transactions_transferee, total_count_transferee = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders, 2)
+    transactions_gov, total_count_gov = await transaction_repo.get_transactions_paginated(0, 10, conditions, sort_orders)
+    
+    assert len(transactions_transferor) == 1
+    assert total_count_transferor == 1
+
+    assert len(transactions_transferee) == 0
+    assert total_count_transferee == 0
+
+    assert len(transactions_gov) == 1
+    assert total_count_gov == 1
+
+# description
+@pytest.mark.anyio
+async def test_get_visible_statuses_for_transferor(dbsession, transaction_repo):
+    visible_statuses = await transaction_repo.get_visible_statuses(EntityType.Transferor)
+    expected_statuses = [
+        TransferStatusEnum.Draft,
+        TransferStatusEnum.Sent,
+        TransferStatusEnum.Submitted,
+        TransferStatusEnum.Recorded,
+        TransferStatusEnum.Refused,
+        TransferStatusEnum.Declined,
+        TransferStatusEnum.Rescinded
+    ]
+
+    # Verify that only the expected statuses are returned for a transferor
+    assert set(visible_statuses) == set(expected_statuses), "Unexpected statuses returned for transferor"
+
+@pytest.mark.anyio
+async def test_get_visible_statuses_for_transferee(dbsession, transaction_repo):
+    visible_statuses = await transaction_repo.get_visible_statuses(EntityType.Transferee)
+    expected_statuses = [
+        TransferStatusEnum.Sent,
+        TransferStatusEnum.Submitted,
+        TransferStatusEnum.Recorded,
+        TransferStatusEnum.Refused,
+        TransferStatusEnum.Declined,
+        TransferStatusEnum.Rescinded
+    ]
+    # Verify that only the expected statuses are returned for a transferee
+    assert set(visible_statuses) == set(expected_statuses), "Unexpected statuses returned for transferee"
+
+@pytest.mark.anyio
+async def test_get_visible_statuses_for_government(dbsession, transaction_repo):
+    visible_statuses = await transaction_repo.get_visible_statuses(EntityType.Government)
+    expected_statuses = [
+        TransferStatusEnum.Submitted,
+        TransferStatusEnum.Recommended,
+        TransferStatusEnum.Recorded,
+        TransferStatusEnum.Refused,
+        TransferStatusEnum.Rescinded
+    ]
+    # Verify that only the expected statuses are returned for the government
+    assert set(visible_statuses) == set(expected_statuses), "Unexpected statuses returned for government"

--- a/backend/lcfs/tests/transaction/transaction_payloads.py
+++ b/backend/lcfs/tests/transaction/transaction_payloads.py
@@ -1,27 +1,147 @@
 from datetime import datetime
-from lcfs.db.models.Transfer import Transfer
+from lcfs.db.models.Transfer import Transfer, TransferRecommendationEnum
+from lcfs.db.models.InitiativeAgreementStatus import InitiativeAgreementStatusEnum, InitiativeAgreementStatus
+from lcfs.db.models.InitiativeAgreement import InitiativeAgreement
+from lcfs.db.models.AdminAdjustmentStatus import AdminAdjustmentStatusEnum, AdminAdjustmentStatus
+from lcfs.db.models.AdminAdjustment import AdminAdjustment
 
-agreement_date = datetime.strptime("2023-01-01", "%Y-%m-%d").date()
+# Utility function to format datetime for consistency
+def formatted_date():
+    return datetime.strptime("2023-01-01", "%Y-%m-%d").date()
 
-# transfer orm models
-agreement_date = datetime.strptime("2023-01-01", "%Y-%m-%d").date()
-transaction_orm_model = Transfer(
+# Transfer ORM Models
+draft_transfer_orm = Transfer(
     from_organization_id=1,
     to_organization_id=2,
-    current_status_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
     transfer_category_id=1,
-    agreement_date=agreement_date,
-    quantity=100,
-    price_per_unit=10.0
+    current_status_id=1,
+    recommendation=TransferRecommendationEnum.Record
 )
 
-agreement_date = datetime.strptime("2024-02-02", "%Y-%m-%d").date()
-transaction_orm_model_2 = Transfer(
-    from_organization_id=2,
-    to_organization_id=1,
-    current_status_id=2,
-    transfer_category_id=1,
-    agreement_date=agreement_date,
+deleted_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
     quantity=20,
-    price_per_unit=2.0
+    transfer_category_id=1,
+    current_status_id=2,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+sent_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=3,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+submitted_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=4,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+recommended_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=5,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+recorded_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=6,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+refused_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=7,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+declined_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=8,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+rescinded_transfer_orm = Transfer(
+    from_organization_id=1,
+    to_organization_id=2,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=9,
+    recommendation=TransferRecommendationEnum.Record
+)
+
+# InitiativeAgreementStatus ORM Models
+initiative_agreement_status_orm = InitiativeAgreementStatus(
+    initiative_agreement_status_id=1,
+    status=InitiativeAgreementStatusEnum.Draft
+)
+
+# InitiativeAgreement ORM Models
+initiative_agreement_orm = InitiativeAgreement(
+    initiative_agreement_id=1,
+    compliance_units=10,
+    to_organization_id=1,
+    current_status_id=1
+)
+
+# AdminAdjustmentStatus ORM Models
+admin_adjustment_status_orm = AdminAdjustmentStatus(
+    admin_adjustment_status_id=1,
+    status=AdminAdjustmentStatusEnum.Draft
+)
+
+# AdminAdjustment ORM Models
+admin_adjustment_orm = AdminAdjustment(
+    admin_adjustment_id=1,
+    compliance_units=20,
+    to_organization_id=1,
+    current_status_id=1
 )

--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -64,6 +64,7 @@ class TransactionRepository(BaseRepository):
                 TransactionView.status.in_([status.value for status in visible_statuses_transferee])
             )
 
+            # TODO: Additional visibility checks needed for other transaction types.
             # For transactions that are not of type "Transfer", include them without visibility filtering
             non_transfer_condition = and_(
                 TransactionView.transaction_type != 'Transfer',
@@ -81,6 +82,7 @@ class TransactionRepository(BaseRepository):
                 TransactionView.status.in_([status.value for status in visible_statuses_government])
             )
 
+            # TODO: Additional visibility checks needed for other transaction types.
             # Include non-"Transfer" transactions for government without applying visibility filtering
             gov_non_transfer_condition = TransactionView.transaction_type != 'Transfer'
 


### PR DESCRIPTION
This PR addresses the requirement to clean up the visibility of transfers based on their status, ensuring that transfers are only visible to the appropriate parties (transferor, transferee, government) at the correct times.

<img width="1382" alt="Screen Shot 2024-04-05 at 5 56 13 AM" src="https://github.com/bcgov/lcfs/assets/2143103/0c1a5236-5c1b-4b91-9742-bf15a4999260">

Closes #491
