### PR TITLE
Feat: Sort Organizations Alphabetically in Dropdown - 502

### DIFF
--- a/backend/lcfs/web/api/organizations/repo.py
+++ b/backend/lcfs/web/api/organizations/repo.py
@@ -168,6 +168,7 @@ class OrganizationsRepository(BaseRepository):
                 joinedload(Organization.org_type),
                 joinedload(Organization.org_status),
             )
+            .order_by(Organization.name)
         )
 
         # Execute the query


### PR DESCRIPTION
This PR implements alphabetical sorting for the 'Select an Organization' drop-down within the transfer feature.

Closes #502