### PR TITLE
Feat: Highlight Transaction Row on Status Change - 497

### DIFF
--- a/frontend/src/components/BCDataGrid/BCDataGridServer.jsx
+++ b/frontend/src/components/BCDataGrid/BCDataGridServer.jsx
@@ -63,6 +63,7 @@ const BCDataGridServer = ({
   handleRowClicked,
   paginationPageSize,
   paginationPageSizeSelector,
+  highlightedRowId,
   ...others
 }) => {
   // State declarations
@@ -213,7 +214,12 @@ const BCDataGridServer = ({
     suppressCsvExport: false,
     // enableCellTextSelection: true, // enables text selection on the grid
     // ensureDomOrder: true,
-    onRowClicked: handleRowClicked
+    onRowClicked: handleRowClicked,
+    getRowStyle: highlightedRowId ? (params) => {
+      if (params.node.id === highlightedRowId) {
+        return { backgroundColor: '#fade81' };
+      }
+    } : undefined
   }))
 
   // Memorized default column definition parameters

--- a/frontend/src/views/Transactions/Transactions.jsx
+++ b/frontend/src/views/Transactions/Transactions.jsx
@@ -10,7 +10,7 @@ import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Box } from '@mui/material'
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Role } from '@/components/Role'
 import { transactionsColDefs } from './_schema'
@@ -26,6 +26,9 @@ export const Transactions = () => {
   const gridRef = useRef()
   const { data: currentUser, hasRoles } = useCurrentUser()
 
+  const [searchParams] = useSearchParams();
+  const highlightedId = searchParams.get('hid');
+
   const [isDownloadingTransactions, setIsDownloadingTransactions] =
     useState(false)
   const [alertMessage, setAlertMessage] = useState('')
@@ -39,7 +42,7 @@ export const Transactions = () => {
     overlayNoRowsTemplate: t('txn:noTxnsFound')
   }
   const getRowId = useCallback((params) => {
-    return params.data.transactionId + params.data.transactionType
+    return params.data.transactionType.toLowerCase() + '-' + params.data.transactionId
   }, [])
 
   const defaultSortModel = [{ field: 'createDate', direction: 'desc' }]
@@ -171,6 +174,7 @@ export const Transactions = () => {
           handleGridKey={handleGridKey}
           handleRowClicked={handleRowClicked}
           enableCopyButton={false}
+          highlightedRowId={highlightedId}
         />
       </BCBox>
     </>

--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -202,7 +202,7 @@ export const AddEditViewTransfer = () => {
         // this way the balance in the header will be correct
         setRefreshBalanceTrigger((prev) => !prev)
         // Navigate to the transactions list view
-        navigate(TRANSACTIONS, {
+        navigate(TRANSACTIONS + `/?hid=transfer-${response.data.transferId}`, {
           state: {
             message: t('transfer:actionMsgs.successText', {
               status: response.data.currentStatus.status.toLowerCase()
@@ -219,16 +219,16 @@ export const AddEditViewTransfer = () => {
       if (errorMsg) {
         setAlertMessage(errorMsg)
       } else {
-        setAlertMessage(
-          transferId
-            ? t('transfer:actionMsgs.errorUpdateText')
-            : t('transfer:actionMsgs.errorCreateText')
-        )
-      }
-      setAlertSeverity('error')
-      alertRef.current.triggerAlert()
-      // Scroll back to the top of the page
-      window.scrollTo(0, 0)
+      setAlertMessage(
+        transferId
+          ? t('transfer:actionMsgs.errorUpdateText')
+          : t('transfer:actionMsgs.errorCreateText')
+      )
+    }
+    setAlertSeverity('error')
+    alertRef.current.triggerAlert()
+    // Scroll back to the top of the page
+    window.scrollTo(0, 0)
     }
   })
 


### PR DESCRIPTION
This PR introduces the feature to highlight transaction rows in the Transactions page after a state/status change.

Currently, the updated transaction row is highlighted only when returning to the transactions page. If the row is on a page other than the first, users must navigate to it themselves. I also developed a feature for automatically navigating to the page containing the transaction, but it consumed a lot of resources. This required running all queries within `web/api/transaction/repo.py::get_transactions_paginated` to find the transaction's exact position. Please advise if this feature should still be added.

Closes #497
