### PR TITLE
Fix: Update Pill Capitalization for Consistency - 504

### DIFF
--- a/frontend/src/components/BCBadge/BCBadgeRoot.jsx
+++ b/frontend/src/components/BCBadge/BCBadgeRoot.jsx
@@ -123,7 +123,7 @@ const BCBadgeRoot = styled(Badge)(({ theme, ownerState }) => {
       padding: paddings[size] || paddings.xs,
       fontSize: fontSizeValue,
       fontWeight: fontWeightBold,
-      textTransform: 'uppercase',
+      textTransform: 'none',
       lineHeight: 1,
       textAlign: 'center',
       whiteSpace: 'nowrap',


### PR DESCRIPTION
This PR updates the capitalization of pill labels to align with styling preferences across the application. Instead of all caps, only the first letter of the first word will be capitalized.

Closes #504