### PR TITLE
Fix: Capitalize Status Labels - 504

### DIFF
--- a/frontend/src/utils/cellRenderers.jsx
+++ b/frontend/src/utils/cellRenderers.jsx
@@ -32,7 +32,7 @@ export const StatusRenderer = (props) => {
         sx={{ width: '100%', height: '100%' }}
       >
         <BCBadge
-          badgeContent={props.data.isActive ? 'active' : 'inactive'}
+          badgeContent={props.data.isActive ? 'Active' : 'Inactive'}
           color={props.data.isActive ? 'success' : 'smoky'}
           variant="gradient"
           size="md"

--- a/frontend/src/views/Users/AddEditUser/AddEditUser.jsx
+++ b/frontend/src/views/Users/AddEditUser/AddEditUser.jsx
@@ -80,7 +80,7 @@ export const AddEditUser = ({ userType }) => {
   const bceidRoles = watch('bceidRoles')
 
   useEffect(() => {
-    if (status !== 'active') {
+    if (status !== 'Active') {
       setDisabled(true)
     } else {
       setDisabled(false)
@@ -117,7 +117,7 @@ export const AddEditUser = ({ userType }) => {
         userName: data?.keycloakUsername,
         phone: data?.phone,
         mobile: data?.mobilePhone,
-        status: data?.isActive ? 'active' : 'inactive',
+        status: data?.isActive ? 'Active' : 'Inactive',
         readOnly: dataRoles
           .filter((r) => r === roles.read_only.toLocaleLowerCase())
           .join(''),
@@ -154,10 +154,10 @@ export const AddEditUser = ({ userType }) => {
       email: data.altEmail === '' ? null : data.altEmail,
       phone: data.phone,
       mobilePhone: data.mobile,
-      isActive: data.status === 'active',
+      isActive: data.status === 'Active',
       organizationId: orgID || currentUser.organizationId,
       roles:
-        data.status === 'active'
+        data.status === 'Active'
           ? [
               ...data.adminRole,
               ...(data.readOnly === '' ? data.bceidRoles : []),

--- a/frontend/src/views/Users/AddEditUser/_schema.js
+++ b/frontend/src/views/Users/AddEditUser/_schema.js
@@ -100,7 +100,7 @@ export const defaultValues = {
   altEmail: '',
   phone: '',
   mobile: '',
-  status: 'active',
+  status: 'Active',
   adminRole: [],
   idirRole: '',
   bceidRoles: [],
@@ -110,11 +110,11 @@ export const defaultValues = {
 export const statusOptions = (t) => [
   {
     label: t('admin:userForm.activeLabel'),
-    value: 'active'
+    value: 'Active'
   },
   {
     label: t('admin:userForm.inactiveLabel'),
-    value: 'inactive'
+    value: 'Inactive'
   }
 ]
 


### PR DESCRIPTION
This PR changes the capitalization of 'active' and 'inactive' status labels to start with an uppercase letter, aligning them with other labels for consistency. This issue was identified during testing.

Closes #504
