### PR TITLE
Fix: Correct Postal Code Validation on LCFS2 Save - 467

### DIFF
--- a/frontend/src/views/Organizations/AddEditOrg/_schema.js
+++ b/frontend/src/views/Organizations/AddEditOrg/_schema.js
@@ -29,7 +29,7 @@ export const schemaValidation = Yup.object({
   orgPostalCodeZipCode: Yup.string()
     .required('Postal / ZIP Code is required.')
     .matches(
-      /^(?!.*[DFIOQU])[A-VXY][0-9][A-Z]\s?[0-9][A-Z][0-9]$|^\d{5}(-\d{4})?$/i,
+      /^((\d{5}-\d{4})|(\d{5})|([A-Z]\d[A-Z]\s?\d[A-Z]\d))$/i,
       'Please enter a valid Postal / ZIP Code.'
     ),
   orgAttorneyStreetAddress: Yup.string().required(
@@ -39,7 +39,7 @@ export const schemaValidation = Yup.object({
   orgAttorneyPostalCodeZipCode: Yup.string()
     .required('Postal / ZIP Code is required.')
     .matches(
-      /^(?!.*[DFIOQU])[A-VXY][0-9][A-Z]\s?[0-9][A-Z][0-9]$|^\d{5}(-\d{4})?$/i,
+      /^((\d{5}-\d{4})|(\d{5})|([A-Z]\d[A-Z]\s?\d[A-Z]\d))$/i,
       'Please enter a valid Postal / ZIP Code.'
     )
 })


### PR DESCRIPTION
This PR addresses the postal code validation error that occurs when saving the LCFS2 organization profile. The fix ensures that both Canadian postal codes and US ZIP codes  are supported in the following formats:

Canadian Postal Codes:
- A1A 1A1: Letter, digit, letter, **[space]**, digit, letter, digit.
- A1A1A1: Letter, digit, letter, digit, letter, digit.

US ZIP Codes:
- 12345: Five digits.
- 12345-6789: Five digits followed by a hyphen and four digits.

With these changes, users can now edit and successfully save changes without encountering the postal code error.

Closes #467
