### PR TITLE
Feat: Ensure Blank Initial State for Agreement Date - 461

### DIFF
--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -82,7 +82,7 @@ export const AddEditViewTransfer = () => {
     mode: 'onChange',
     defaultValues: {
       fromOrganizationId: currentUser?.organization?.organizationId,
-      agreementDate: new Date().toISOString().split('T')[0],
+      agreementDate: '',
       toOrganizationId: null,
       quantity: null,
       pricePerUnit: null,

--- a/frontend/src/views/Transfers/components/AgreementDate.jsx
+++ b/frontend/src/views/Transfers/components/AgreementDate.jsx
@@ -29,7 +29,7 @@ export const AgreementDate = () => {
           data-test="transfer-agreement-date"
           {...register('agreementDate')}
           type="date"
-          defaultValue={maxDate}
+          placeholder="yyyy-mm-dd"
           inputProps={{
             max: maxDate,
             'data-testid': 'transfer-agreement-date-input'


### PR DESCRIPTION
This PR modifies the agreement date field to be blank by default when creating new transfers, aligning with the updated form requirements. It also implements placeholder text to guide users on the required date format ("yyyy-mm-dd").

Closes #461