### PR TITLE
LCFS - Fuel drop-down menu options for new fuel code entries #485 - b…

### DIFF
--- a/backend/lcfs/db/seeders/common/fuel_type_seeder.py
+++ b/backend/lcfs/db/seeders/common/fuel_type_seeder.py
@@ -83,7 +83,7 @@ async def seed_fuel_types(session):
             "fossil_derived": True
         },
         {
-            "fuel_type": 'Fossil-derived jet-fuel',
+            "fuel_type": 'Fossil-derived jet fuel',
             "fossil_derived": True
         },
     ]

--- a/frontend/src/views/FuelCodes/AddFuelCode/_schema.jsx
+++ b/frontend/src/views/FuelCodes/AddFuelCode/_schema.jsx
@@ -69,7 +69,9 @@ export const fuelCodeSchema = (t, optionsData) =>
     fuel: yup
       .string()
       .oneOf(
-        optionsData.fuelTypes.map((obj) => obj.fuelType),
+        optionsData.fuelTypes
+          .filter((fuel) => !fuel.fossilDerived)
+          .map((obj) => obj.fuelType),
         t('fuelCode:validateMsg.fuel')
       )
       .required(
@@ -266,7 +268,9 @@ export const fuelCodeColDefs = (t, optionsData) => [
       params.value ||
       (!params.value && <Typography variant="body4">Select</Typography>),
     cellEditorParams: {
-      options: optionsData.fuelTypes.map((obj) => obj.fuelType),
+      options: optionsData.fuelTypes
+        .filter((fuel) => !fuel.fossilDerived)
+        .map((obj) => obj.fuelType),
       multiple: false, // ability to select multiple values from dropdown
       disableCloseOnSelect: false, // if multiple is true, this will prevent closing dropdown on selecting an option
       freeSolo: false, // this will allow user to type in the input box or choose from the dropdown


### PR DESCRIPTION
Bug fix - https://github.com/bcgov/lcfs/issues/485#issuecomment-2096685594

(The option to choose fossil-derived diesel, fossil-derived gasoline and fossil-derived jet-fuel should be restricted on the front end in this new fuel code table. They will be used in different report functions, but not for fuel codes here.

Also, the "-" between 'jet' and 'fuel' here was a typo. It should just read 'fossil-derived jet fuel'.)