### PR TITLE
Feat: Implement transaction internal comments on new transaction page - 347

### DIFF
--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -38,6 +38,7 @@ class InitiativeAgreementBaseSchema(BaseSchema):
     transaction_effective_date: Optional[date] = None
     to_organization_id: int
     gov_comment: Optional[str] = None
+    internal_comment: Optional[str] = None
 
     @field_validator('compliance_units')
     def validate_compliance_units(cls, v):

--- a/backend/lcfs/web/api/internal_comment/schema.py
+++ b/backend/lcfs/web/api/internal_comment/schema.py
@@ -14,8 +14,8 @@ class BaseConfig:
 # --------------------------------------
 class EntityTypeEnum(str, Enum):
     TRANSFER = "Transfer"
-    INITIATIVE_AGREEMENT = "InitiativeAgreement"
-    ADMIN_ADJUSTMENT = "AdminAdjustment"
+    INITIATIVE_AGREEMENT = "initiativeAgreement"
+    ADMIN_ADJUSTMENT = "administrativeAdjustment"
     ASSESSMENT = "Assessment"
 
 class AudienceScopeEnum(str, Enum):

--- a/frontend/src/components/InternalComments/InternalCommentForm.jsx
+++ b/frontend/src/components/InternalComments/InternalCommentForm.jsx
@@ -11,13 +11,19 @@ import BCBox from '@/components/BCBox'
 import BCButton from '@/components/BCButton'
 import BCTypography from '@/components/BCTypography'
 
-const InternalCommentForm = ({ title, initialCommentText = '', onSubmit, onCancel, isEditing = false, showAddCommentBtn = true }) => {
+const InternalCommentForm = ({ title, initialCommentText = '', onSubmit, onCancel, isEditing = false, showAddCommentBtn = true, onCommentChange }) => {
   const { t } = useTranslation(['internalComment'])
   const [commentText, setCommentText] = useState(initialCommentText);
 
   useEffect(() => {
     setCommentText(initialCommentText);
   }, [initialCommentText, isEditing]);
+
+  useEffect(() => {
+    if (onCommentChange) {
+      onCommentChange(commentText);
+    }
+  }, [commentText, onCommentChange]);
 
   return (
     <>
@@ -83,6 +89,8 @@ InternalCommentForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   isEditing: PropTypes.bool,
+  showAddCommentBtn: PropTypes.bool,
+  onCommentChange: PropTypes.func,
 };
 
 export default InternalCommentForm;

--- a/frontend/src/components/InternalComments/InternalCommentList.jsx
+++ b/frontend/src/components/InternalComments/InternalCommentList.jsx
@@ -13,7 +13,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
 
-const InternalCommentList = ({ comments, onAddComment, onEditComment, addCommentFormKey, showAddCommentBtn = true }) => {
+const InternalCommentList = ({ comments, onAddComment, onEditComment, addCommentFormKey, showAddCommentBtn = true, onCommentChange }) => {
   const { t } = useTranslation(['internalComment'])
   const { data: currentUser, hasAnyRole } = useCurrentUser()
   const [editCommentId, setEditCommentId] = useState(null);
@@ -136,6 +136,7 @@ const InternalCommentList = ({ comments, onAddComment, onEditComment, addComment
               onSubmit={onAddComment}
               key={addCommentFormKey}
               showAddCommentBtn={showAddCommentBtn}
+              onCommentChange={onCommentChange}
             />
           </BCBox>
         )}
@@ -155,6 +156,7 @@ InternalCommentList.propTypes = {
   ).isRequired,
   onAddComment: PropTypes.func.isRequired,
   onEditComment: PropTypes.func.isRequired,
+  onCommentChange: PropTypes.func,
 };
 
 export default InternalCommentList;

--- a/frontend/src/components/InternalComments/index.jsx
+++ b/frontend/src/components/InternalComments/index.jsx
@@ -10,7 +10,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import InternalCommentList from './InternalCommentList';
 import Loading from '@/components/Loading'
 
-const InternalComments = ({ entityType, entityId }) => {
+const InternalComments = ({ entityType, entityId, onCommentChange }) => {
   const { t } = useTranslation(['internalComment'])
   const apiService = useApiService()
   const { hasAnyRole } = useCurrentUser()
@@ -67,22 +67,24 @@ const InternalComments = ({ entityType, entityId }) => {
     if (!showAddCommentBtn)
       return;
 
-    const loadComments = async () => {
-      setIsLoading(true);
-      try {
-        // const fetchedComments = await fetchComments(entityType, entityId);
-        const response = await apiService.get(`/internal_comments/${entityType}/${entityId}`);
-        const fetchedComments = response.data;
-        const sortedComments = fetchedComments.sort((a, b) => b.internalCommentId - a.internalCommentId);
-        setComments(sortedComments);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+    if (entityType && entityId) {
+      const loadComments = async () => {
+        setIsLoading(true);
+        try {
+          // const fetchedComments = await fetchComments(entityType, entityId);
+          const response = await apiService.get(`/internal_comments/${entityType}/${entityId}`);
+          const fetchedComments = response.data;
+          const sortedComments = fetchedComments.sort((a, b) => b.internalCommentId - a.internalCommentId);
+          setComments(sortedComments);
+        } catch (err) {
+          setError(err.message);
+        } finally {
+          setIsLoading(false);
+        }
+      };
 
-    loadComments();
+      loadComments();
+    }
   }, [entityType, entityId]);
 
   // Adds a newly created comment to the local state.
@@ -129,6 +131,7 @@ const InternalComments = ({ entityType, entityId }) => {
       onEditComment={handleEditComment}
       addCommentFormKey={addCommentKey}
       showAddCommentBtn={showAddCommentBtn}
+      onCommentChange={onCommentChange}
     />
   );
 };
@@ -137,8 +140,9 @@ InternalComments.propTypes = {
   entityType: PropTypes.string.isRequired,
   entityId: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.oneOf([null])
-  ])
+    PropTypes.oneOf([null]),
+  ]),
+  onCommentChange: PropTypes.func,
 };
 
 export default InternalComments;

--- a/frontend/src/views/Transactions/AddEditViewTransaction.jsx
+++ b/frontend/src/views/Transactions/AddEditViewTransaction.jsx
@@ -60,6 +60,7 @@ export const AddEditViewTransaction = () => {
   const [alertMessage, setAlertMessage] = useState('')
   const [alertSeverity, setAlertSeverity] = useState('info')
   const [txnType, setTxnType] = useState(null);
+  const [internalComment, setInternalComment] = useState('')
 
   const { handleSuccess, handleError } = useTransactionMutation(
     t, 
@@ -96,6 +97,10 @@ export const AddEditViewTransaction = () => {
       govComment: null,
     }
   })
+
+  const handleCommentChange = (newComment) => {
+    setInternalComment(newComment)
+  }
 
   useEffect(() => {
     const path = window.location.pathname
@@ -210,9 +215,10 @@ export const AddEditViewTransaction = () => {
         t,
         setModalData,
         createUpdateAdminAdjustment,
-        createUpdateInitiativeAgreement
+        createUpdateInitiativeAgreement,
+        internalComment
       }),
-    [transactionId, txnType, methods, t, setModalData, createUpdateAdminAdjustment, createUpdateInitiativeAgreement, hasRoles]
+    [transactionId, txnType, methods, t, setModalData, createUpdateAdminAdjustment, createUpdateInitiativeAgreement, hasRoles, internalComment]
   )
 
   if (transactionId && isTransactionDataLoading)
@@ -305,18 +311,20 @@ export const AddEditViewTransaction = () => {
         )}
 
         {/* Internal Comments */}
-        {/* {mode !== 'add' &&
-          <BCBox mt={4}>
-            <Typography variant="h6" color="primary">
-              {t(`txn:internalCommentsOptional`)}
-            </Typography>
-            <BCBox>
-              <Role roles={govRoles}>
-                <InternalComments entityType={txnType} entityId={transactionId ?? null} />
-              </Role>
-            </BCBox>
+        <BCBox mt={4}>
+          <Typography variant="h6" color="primary">
+            {t(`txn:internalCommentsOptional`)}
+          </Typography>
+          <BCBox>
+            <Role roles={govRoles}>
+              <InternalComments
+                entityType={txnType}
+                entityId={transactionId ?? null}
+                onCommentChange={handleCommentChange}
+              />
+            </Role>
           </BCBox>
-        } */}
+        </BCBox>
 
         {/* Transaction History */}
         {transactionId &&

--- a/frontend/src/views/Transactions/_schema.yup.js
+++ b/frontend/src/views/Transactions/_schema.yup.js
@@ -30,5 +30,6 @@ export const AddEditTransactionSchema = Yup.object({
         })
         .nullable()
         .default(null),
-    toOrgComment: Yup.string()
+    toOrgComment: Yup.string(),
+    internalComment: Yup.string()
 })

--- a/frontend/src/views/Transactions/buttonConfigs.jsx
+++ b/frontend/src/views/Transactions/buttonConfigs.jsx
@@ -47,7 +47,8 @@ export const buttonClusterConfigFn = ({
   t,
   setModalData,
   createUpdateAdminAdjustment,
-  createUpdateInitiativeAgreement
+  createUpdateInitiativeAgreement,
+  internalComment
 }) => {
   const transactionButtons = {
     saveDraft: {
@@ -61,6 +62,7 @@ export const buttonClusterConfigFn = ({
         mutationFn({
           data: {
             ...formData,
+            internalComment: internalComment,
             currentStatus: TRANSACTION_STATUSES.DRAFT
           }
         })
@@ -103,6 +105,7 @@ export const buttonClusterConfigFn = ({
             await mutationFn({
               data: {
                 ...formData,
+                internalComment: internalComment,
                 currentStatus: TRANSACTION_STATUSES.RECOMMENDED
               }
             })


### PR DESCRIPTION
This PR implements the transaction internal comments feature on the new transaction page with conditional button visibility based on the step in the transaction creation process.

Closes #347