### PR TITLE
Fix: Disable AG Grid Export to XLS on Transactions Page

### DIFF
--- a/frontend/src/views/Transactions/Transactions.jsx
+++ b/frontend/src/views/Transactions/Transactions.jsx
@@ -225,8 +225,6 @@ export const Transactions = () => {
           handleGridKey={handleGridKey}
           handleRowClicked={handleRowClicked}
           enableCopyButton={false}
-          enableExportButton={false}
-          exportName={t('txn:title')}
           highlightedRowId={highlightedId}
         />
       </BCBox>


### PR DESCRIPTION
This PR disables the export to XLS functionality in AG Grid on the transactions page.