### PR TITLE
Fix: Ensure reserve units display as positive values - 645

### DIFF
--- a/frontend/src/layouts/MainLayout/components/SupplierBalance.jsx
+++ b/frontend/src/layouts/MainLayout/components/SupplierBalance.jsx
@@ -18,7 +18,7 @@ const SupplierBalance = () => {
 
   const { data: orgBalance } = useCurrentOrgBalance()
   const formattedTotalBalance = orgBalance?.totalBalance != null ? numberFormatter({ value: orgBalance.totalBalance }) : 'N/A'
-  const formattedReservedBalance = orgBalance?.reservedBalance != null ? numberFormatter({ value: orgBalance.reservedBalance }) : 'N/A'
+  const formattedReservedBalance = orgBalance?.reservedBalance != null ? numberFormatter({ value: Math.abs(orgBalance.reservedBalance) }) : 'N/A'
 
   const toggleBalanceVisibility = () => {
     setShowBalance(!showBalance)

--- a/frontend/src/views/Dashboard/components/cards/bceid/OrgBalanceCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/bceid/OrgBalanceCard.jsx
@@ -22,6 +22,9 @@ export const OrgBalanceCard = () => {
         </BCTypography>
       );
     } else {
+      // Ensure reservedBalance is displayed as positive
+      const formattedReservedBalance = Math.abs(orgBalance.reservedBalance).toLocaleString();
+
       return (
         <>
           <BCTypography style={{ fontSize: '18px', color: '#003366', marginBottom: '-2px' }} gutterBottom>
@@ -38,7 +41,7 @@ export const OrgBalanceCard = () => {
           </BCTypography>
           <Box display="flex" alignItems="center" mt={1}>
             <BCTypography style={{ fontSize: '22px', color: '#578260' }} component="span">
-              ({orgBalance.reservedBalance.toLocaleString()} {t('org:inReserve')})
+              ({formattedReservedBalance} {t('org:inReserve')})
             </BCTypography>
             <Tooltip
                 title={t('org:inReserveTooltip')}


### PR DESCRIPTION
This PR resolves the issue where reserve compliance units were displayed as negative values, ensuring they are now shown as positive values.

Closes #645
