### PR TITLE
Fix: Apply requested changes to transaction - 646

### DIFF
--- a/frontend/src/assets/locales/en/transaction.json
+++ b/frontend/src/assets/locales/en/transaction.json
@@ -71,7 +71,5 @@
     "Recommended": "Recommended",
     "Approved": "Approved"
   },
-  "noComments": "No comments provided.",
-  "noEffectiveDate": "No effective date provided.",
   "for": "for"
 }

--- a/frontend/src/views/Transactions/components/OrgTransactionDetails.jsx
+++ b/frontend/src/views/Transactions/components/OrgTransactionDetails.jsx
@@ -25,6 +25,9 @@ export const OrgTransactionDetails = ({ transactionType, transactionData }) => {
   // Use createDate as the approved date if there is no history
   const approvedDate = approvedDateFromHistory || transactionData.createDate
 
+  // Use the transaction effective date or the approved date if no effective date is provided
+  const effectiveDate = transactionData.transactionEffectiveDate || approvedDate;
+
   // Construct the content based on the transaction type
   const content = (
     <Box component="div" display="flex" flexDirection="column" gap={1}>
@@ -35,11 +38,13 @@ export const OrgTransactionDetails = ({ transactionType, transactionData }) => {
         <strong>{t('txn:complianceUnitsLabel')}</strong> {numberFormatter({ value: transactionData.complianceUnits })}
       </Typography>
       <Typography variant="body2">
-        <strong>{t('txn:effectiveDateLabel')}</strong> {transactionData.transactionEffectiveDate ? dateFormatter({ value: transactionData.transactionEffectiveDate }) : t('txn:noEffectiveDate')}
+        <strong>{t('txn:effectiveDateLabel')}</strong> {dateFormatter({ value: effectiveDate })}
       </Typography>
-      <Typography variant="body2">
-        <strong>{t('txn:commentsTextLabel')}</strong> {transactionData.govComment || t('txn:noComments')}
-      </Typography>
+      {transactionData.govComment && (
+        <Typography variant="body2">
+          <strong>{t('txn:commentsTextLabel')}</strong> {transactionData.govComment}
+        </Typography>
+      )}
       <Typography variant="body2">
         <strong>{t('txn:approvedLabel')}</strong> {dateFormatter({ value: approvedDate })} {t('txn:approvedByDirector')}
       </Typography>

--- a/frontend/src/views/Transactions/components/__tests__/OrgTransactionDetails.test.jsx
+++ b/frontend/src/views/Transactions/components/__tests__/OrgTransactionDetails.test.jsx
@@ -17,8 +17,6 @@ vi.mock('react-i18next', () => ({
         "txn:approvedLabel": "Approved",
         "txn:approvedByDirector": "by the director under the Low Carbon Fuels Act",
         "txn:for": "for",
-        "txn:noComments": "No comments provided.",
-        "txn:noEffectiveDate": "No effective date provided.",
         "txn:adminAdjustmentId": "Administrative adjustment — ID:",
         "txn:initiativeAgreementId": "Initiative agreement — ID:"
       };
@@ -119,8 +117,6 @@ describe('OrgTransactionDetails Component', () => {
     expect(screen.getAllByText(/1/)).toHaveLength(3);
     expect(screen.getByText(/Effective date/)).toBeInTheDocument();
     expect(screen.getAllByText(/2024-06-04/)).toHaveLength(2);
-    expect(screen.getByText(/Comments/)).toBeInTheDocument();
-    expect(screen.getByText(/No comments provided./)).toBeInTheDocument();
     expect(screen.getByText(/Approved/)).toBeInTheDocument();
     expect(screen.getByText(/by the director under the Low Carbon Fuels Act/)).toBeInTheDocument();
   });
@@ -136,8 +132,6 @@ describe('OrgTransactionDetails Component', () => {
     expect(screen.getByText(/50,000/)).toBeInTheDocument();
     expect(screen.getByText(/Effective date/)).toBeInTheDocument();
     expect(screen.getByText(/2023-01-01/)).toBeInTheDocument();
-    expect(screen.getByText(/Comments/)).toBeInTheDocument();
-    expect(screen.getByText(/No comments provided./)).toBeInTheDocument();
     expect(screen.getByText(/Approved/)).toBeInTheDocument();
     expect(screen.getByText(/by the director under the Low Carbon Fuels Act/)).toBeInTheDocument();
   });
@@ -158,8 +152,6 @@ describe('OrgTransactionDetails Component', () => {
     expect(screen.getAllByText(/1/)).toHaveLength(3);
     expect(screen.getByText(/Effective date/)).toBeInTheDocument();
     expect(screen.getAllByText(/2024-06-04/)).toHaveLength(2);
-    expect(screen.getByText(/Comments/)).toBeInTheDocument();
-    expect(screen.getByText(/No comments provided./)).toBeInTheDocument();
     expect(screen.getByText(/Approved/)).toBeInTheDocument();
     expect(screen.getByText(/by the director under the Low Carbon Fuels Act/)).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR applies the requested changes to the transaction, including hiding the comments label when no comments are provided and duplicating the approved date if no effective date is entered.

Closes #646