### PR TITLE
Fix: Ensure in reserve units do not display as negative values - 645

### DIFF
--- a/frontend/src/views/Organizations/ViewOrganization/ViewOrganization.jsx
+++ b/frontend/src/views/Organizations/ViewOrganization/ViewOrganization.jsx
@@ -188,7 +188,7 @@ export const ViewOrganization = () => {
               </BCTypography>
               <Typography variant="body4">
                 {orgBalaceInfo?.totalBalance.toLocaleString()} (
-                {orgBalaceInfo?.reservedBalance.toLocaleString()})
+                {Math.abs(orgBalaceInfo?.reservedBalance).toLocaleString()})
               </Typography>
             </Role>
           </BCBox>

--- a/frontend/src/views/Organizations/ViewOrganization/_schema.js
+++ b/frontend/src/views/Organizations/ViewOrganization/_schema.js
@@ -25,7 +25,7 @@ export const organizationsColDefs = (t) => [
     field: 'reserve',
     headerName: t('org:orgColLabels.inReserve'),
     valueFormatter: numberFormatter,
-    valueGetter: (params) => params.data.reservedBalance,
+    valueGetter: (params) => Math.abs(params.data.reservedBalance),
     width: 300,
     cellRenderer: LinkRenderer,
     // Temporary measures

--- a/frontend/src/views/Transactions/components/OrganizationList.jsx
+++ b/frontend/src/views/Transactions/components/OrganizationList.jsx
@@ -15,7 +15,7 @@ const OrganizationList = ({ onOrgChange }) => {
     if (!isLoading) {
       const formattedData = data.map(org => ({
         ...org,
-        label: `${org.name} ${t('txn:complianceUnitsBalance')}: ${numberFormatter({ value: org.totalBalance })} (${numberFormatter({ value: org.reservedBalance })} ${t('txn:inReserve')})`
+        label: `${org.name} ${t('txn:complianceUnitsBalance')}: ${numberFormatter({ value: org.totalBalance })} (${numberFormatter({ value: Math.abs(org.reservedBalance) })} ${t('txn:inReserve')})`
       }));
 
       setOptionsList([

--- a/frontend/src/views/Transactions/components/TransactionDetails.jsx
+++ b/frontend/src/views/Transactions/components/TransactionDetails.jsx
@@ -46,7 +46,7 @@ export const TransactionDetails = ({ transactionId, isEditable }) => {
   // Fetching organization balance
   const displayBalance = () => {
     if (!orgBalanceInfo) return t('txn:loadingBalance')
-    return `${orgBalanceInfo.totalBalance.toLocaleString()} (${orgBalanceInfo.reservedBalance.toLocaleString()} ${t('txn:inReserve')})`
+    return `${orgBalanceInfo.totalBalance.toLocaleString()} (${Math.abs(orgBalanceInfo.reservedBalance).toLocaleString()} ${t('txn:inReserve')})`
   }
 
   // Render form error messages

--- a/frontend/src/views/Transfers/components/OrganizationBadge.jsx
+++ b/frontend/src/views/Transfers/components/OrganizationBadge.jsx
@@ -28,7 +28,7 @@ export const OrganizationBadge = ({
               <Role roles={[roles.government]}>
                 <Typography variant="body4">
                   Balance: {orgInfo?.totalBalance.toLocaleString()} (
-                  {orgInfo?.reservedBalance.toLocaleString()})
+                  {Math.abs(orgInfo?.reservedBalance).toLocaleString()})
                 </Typography>
                 <Typography variant="body4">
                   Registered: {orgInfo?.registered ? 'Yes' : 'No'}


### PR DESCRIPTION
This PR ensures that in reserve units do not display as negative values across various IDIR pages.
Closes #645