### PR TITLE
Feat: Add prefixes to transaction IDs and compliance reports - 677

### DIFF
--- a/frontend/src/views/Transactions/AddEditViewTransaction.jsx
+++ b/frontend/src/views/Transactions/AddEditViewTransaction.jsx
@@ -170,14 +170,24 @@ export const AddEditViewTransaction = () => {
     }
   }, [isFetched, transactionId, transactionData, isLoadingError, queryState, txnType, methods, t, queryClient])
 
+  const formatTransactionId = (transactionId, txnType) => {
+    const prefixMap = {
+      'administrativeAdjustment': "AA",
+      'initiativeAgreement': "IA"
+    }
+  
+    const prefix = prefixMap[txnType] || ""
+    return `${prefix}${transactionId}`
+  }
+
   const title = useMemo(() => {
     switch (mode) {
       case 'add':
         return t('txn:newTransaction')
       case 'edit':
-        return `Edit ${t(`${txnType}:${txnType}`)} ${transactionId}`
+        return `Edit ${t(`${txnType}:${txnType}`)} ${formatTransactionId(transactionId, txnType)}`
       default:
-        return `${t(`${txnType}:${txnType}`)} ${transactionId}`
+        return `${t(`${txnType}:${txnType}`)} ${formatTransactionId(transactionId, txnType)}`
     }
   }, [mode, t, transactionId, txnType])
 

--- a/frontend/src/views/Transactions/__tests__/AddEditViewTransaction.test.jsx
+++ b/frontend/src/views/Transactions/__tests__/AddEditViewTransaction.test.jsx
@@ -329,7 +329,7 @@ describe('AddEditViewTransaction Component Tests', () => {
     renderComponent('edit', INITIATIVE_AGREEMENT)
 
     await waitFor(() => {
-      expect(screen.getByText('Edit initiativeAgreement:initiativeAgreement 1')).toBeInTheDocument()
+      expect(screen.getByText('Edit initiativeAgreement:initiativeAgreement IA1')).toBeInTheDocument()
     })
   })
 
@@ -357,7 +357,7 @@ describe('AddEditViewTransaction Component Tests', () => {
     })
     renderComponent('view', INITIATIVE_AGREEMENT)
     await waitFor(() => {
-      expect(screen.getByText('initiativeAgreement:initiativeAgreement 1')).toBeInTheDocument()
+      expect(screen.getByText('initiativeAgreement:initiativeAgreement IA1')).toBeInTheDocument()
     })
   })
 
@@ -460,7 +460,7 @@ describe('AddEditViewTransaction Component Tests', () => {
     renderComponent('edit', ADMIN_ADJUSTMENT)
     
     await waitFor(() => {
-      expect(screen.getByText('Edit administrativeAdjustment:administrativeAdjustment 1')).toBeInTheDocument()
+      expect(screen.getByText('Edit administrativeAdjustment:administrativeAdjustment AA1')).toBeInTheDocument()
     })
   })
 
@@ -502,7 +502,7 @@ describe('AddEditViewTransaction Component Tests', () => {
     renderComponent('view', ADMIN_ADJUSTMENT)
 
     await waitFor(() => {
-      expect(screen.getByText('administrativeAdjustment:administrativeAdjustment 1')).toBeInTheDocument()
+      expect(screen.getByText('administrativeAdjustment:administrativeAdjustment AA1')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/views/Transactions/_schema.js
+++ b/frontend/src/views/Transactions/_schema.js
@@ -8,8 +8,24 @@ import { TransactionStatusRenderer } from '@/utils/cellRenderers'
 import { BCColumnSetFilter } from '@/components/BCDataGrid/components'
 import { useTransactionStatuses } from '@/hooks/useTransactions'
 
+const prefixMap = {
+  "Transfer": "CUT",
+  "AdminAdjustment": "AA",
+  "InitiativeAgreement": "IA"
+};
+
 export const transactionsColDefs = (t) => [
-  { colId: 'transactionId', field: 'transactionId', headerName: t('txn:txnColLabels.txnId'), width: 120 },
+  { 
+    colId: 'transactionId', 
+    field: 'transactionId', 
+    headerName: t('txn:txnColLabels.txnId'), 
+    width: 175,
+    valueGetter: (params) => {
+      const transactionType = params.data.transactionType;
+      const prefix = prefixMap[transactionType] || '';
+      return `${prefix}${params.data.transactionId}`;
+    }
+  },
   { 
     colId: 'transactionType', 
     field: 'transactionType', 

--- a/frontend/src/views/Transactions/components/OrgTransactionDetails.jsx
+++ b/frontend/src/views/Transactions/components/OrgTransactionDetails.jsx
@@ -53,8 +53,8 @@ export const OrgTransactionDetails = ({ transactionType, transactionData }) => {
 
   // Determine the title based on the transaction type
   const title = transactionType === ADMIN_ADJUSTMENT
-    ? `${t('txn:adminAdjustmentId')} ${transactionData.adminAdjustmentId}`
-    : `${t('txn:initiativeAgreementId')} ${transactionData.initiativeAgreementId}`
+    ? `${t('txn:adminAdjustmentId')} AA${transactionData.adminAdjustmentId}`
+    : `${t('txn:initiativeAgreementId')} IA${transactionData.initiativeAgreementId}`
 
   return (
     <Grid container spacing={2}>

--- a/frontend/src/views/Transactions/components/__tests__/OrgTransactionDetails.test.jsx
+++ b/frontend/src/views/Transactions/components/__tests__/OrgTransactionDetails.test.jsx
@@ -111,7 +111,7 @@ describe('OrgTransactionDetails Component', () => {
     render(<OrgTransactionDetails transactionType={INITIATIVE_AGREEMENT} transactionData={mockInitiativeAgreementData} />);
 
     // Validate the presence of key elements
-    expect(screen.getByText(/Initiative agreement — ID: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Initiative agreement — ID: IA1/)).toBeInTheDocument();
     expect(screen.getByText((content, element) => element.tagName.toLowerCase() === 'strong' && content.includes('Initiative agreement for LCFS Org 1'))).toBeInTheDocument();
     expect(screen.getByText(/Compliance units/)).toBeInTheDocument();
     expect(screen.getAllByText(/1/)).toHaveLength(3);
@@ -126,7 +126,7 @@ describe('OrgTransactionDetails Component', () => {
     render(<OrgTransactionDetails transactionType={ADMIN_ADJUSTMENT} transactionData={mockAdminAdjustmentData} />);
 
     // Validate the presence of key elements
-    expect(screen.getByText(/Administrative adjustment — ID: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Administrative adjustment — ID: AA1/)).toBeInTheDocument();
     expect(screen.getByText((content, element) => element.tagName.toLowerCase() === 'strong' && content.includes('Administrative adjustment for LCFS Org 1'))).toBeInTheDocument();
     expect(screen.getByText(/Compliance units/)).toBeInTheDocument();
     expect(screen.getByText(/50,000/)).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('OrgTransactionDetails Component', () => {
     render(<OrgTransactionDetails transactionType={INITIATIVE_AGREEMENT} transactionData={transactionDataWithoutHistory} />);
 
     // Validate the presence of key elements
-    expect(screen.getByText(/Initiative agreement — ID: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Initiative agreement — ID: IA1/)).toBeInTheDocument();
     expect(screen.getByText((content, element) => element.tagName.toLowerCase() === 'strong' && content.includes('Initiative agreement for LCFS Org 1'))).toBeInTheDocument();
     expect(screen.getByText(/Compliance units/)).toBeInTheDocument();
     expect(screen.getAllByText(/1/)).toHaveLength(3);

--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -302,16 +302,18 @@ export const AddEditViewTransfer = () => {
   )
 
   const title = useMemo(() => {
+    const formattedTransferId = `CUT${transferId}`
+    
     if (!editorMode) {
-      return t('transfer:transferID') + transferId
+      return `${t('transfer:transferID')} ${formattedTransferId}`
     }
     switch (mode) {
       case 'add':
         return t('transfer:newTransfer')
       case 'edit':
-        return t('transfer:editTransferID') + transferId
+        return `${t('transfer:editTransferID')} ${formattedTransferId}`
       default:
-        return t('transfer:transferID') + transferId
+        return `${t('transfer:transferID')} ${formattedTransferId}`
     }
   }, [editorMode, mode, t, transferId])
 


### PR DESCRIPTION
This PR adds prefixes to transaction IDs and compliance report IDs for better distinction and clarity.

Closes #677