### PR TITLE
Fix: Resolve Fuel Code Form Display Issues - 861

### DIFF
--- a/backend/lcfs/web/api/fuel_code/schema.py
+++ b/backend/lcfs/web/api/fuel_code/schema.py
@@ -214,9 +214,9 @@ class FieldOptions(BaseSchema):
 
 
 class FPLocationsSchema(BaseSchema):
-    fuel_production_facility_city: str
-    fuel_production_facility_province_state: str
-    fuel_production_facility_country: str
+    fuel_production_facility_city: Optional[str] = None
+    fuel_production_facility_province_state: Optional[str] = None
+    fuel_production_facility_country: Optional[str] = None
 
 
 class TableOptionsSchema(BaseSchema):


### PR DESCRIPTION
This PR fixes the issue where existing fuel codes were not displayed and the input form was missing when adding a new code.

Closes #861