### PR TITLE
fix: compliance report schedules row ordering

### DIFF
--- a/backend/lcfs/web/api/allocation_agreement/repo.py
+++ b/backend/lcfs/web/api/allocation_agreement/repo.py
@@ -75,6 +75,7 @@ class AllocationAgreementRepository:
                 joinedload(AllocationAgreement.compliance_report),
             )
             .where(AllocationAgreement.compliance_report_id == compliance_report_id)
+            .order_by(AllocationAgreement.allocation_agreement_id)
         )
         result = await self.db.execute(query)
         allocation_agreements = result.unique().scalars().all()

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -127,6 +127,7 @@ class FinalSupplyEquipmentRepository:
                 joinedload(FinalSupplyEquipment.level_of_equipment),
             )
             .where(FinalSupplyEquipment.compliance_report_id == report_id)
+            .order_by(FinalSupplyEquipment.final_supply_equipment_id)
         )
         return result.unique().scalars().all()
 

--- a/backend/lcfs/web/api/fuel_export/repo.py
+++ b/backend/lcfs/web/api/fuel_export/repo.py
@@ -173,7 +173,8 @@ class FuelExportRepository:
         """
         query = self.query.where(
             FuelExport.compliance_report_id == compliance_report_id
-        )
+        ).order_by(FuelExport.fuel_export_id)
+
         results = (await self.db.execute(query)).unique().scalars().all()
         return results
 

--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -175,7 +175,7 @@ class FuelSupplyRepository:
         """
         query = self.query.where(
             FuelSupply.compliance_report_id == compliance_report_id
-        )
+        ).order_by(FuelSupply.fuel_supply_id)
         results = (await self.db.execute(query)).unique().scalars().all()
         return results
 

--- a/backend/lcfs/web/api/notional_transfer/repo.py
+++ b/backend/lcfs/web/api/notional_transfer/repo.py
@@ -50,6 +50,7 @@ class NotionalTransferRepository:
             select(NotionalTransfer)
             .options(joinedload(NotionalTransfer.fuel_category))
             .where(NotionalTransfer.compliance_report_id == compliance_report_id)
+            .order_by(NotionalTransfer.notional_transfer_id)
         )
         result = await self.db.execute(query)
         notional_transfers = result.unique().scalars().all()

--- a/backend/lcfs/web/api/other_uses/repo.py
+++ b/backend/lcfs/web/api/other_uses/repo.py
@@ -56,7 +56,9 @@ class OtherUsesRepository:
                 joinedload(OtherUses.expected_use),
             )
             .where(OtherUses.compliance_report_id == compliance_report_id)
+            .order_by(OtherUses.other_uses_id)
         )
+
         result = await self.db.execute(query)
         other_uses = result.unique().scalars().all()
 


### PR DESCRIPTION
- fix: compliance report schedules row sorting to sot by ID, closes #912 


Sort comparator function for ag grid does not seem to affect the sorting of the rows. resorted to sorting the returned backend data as the order for that was what was affecting the sort order.