### PR TITLE
feat: Enable saving of Line 6 without overwriting

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -1,17 +1,19 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
-from lcfs.web.api.compliance_report.services import ComplianceReportUpdateService
+
+import pytest
+
 from lcfs.db.models.compliance.ComplianceReport import ComplianceReport
+from lcfs.db.models.compliance.ComplianceReportStatus import (
+    ComplianceReportStatus,
+    ComplianceReportStatusEnum,
+)
 from lcfs.db.models.compliance.ComplianceReportSummary import ComplianceReportSummary
 from lcfs.web.api.compliance_report.schema import (
     ComplianceReportUpdateSchema,
     ComplianceReportSummaryRowSchema,
     ComplianceReportSummarySchema,
 )
-from lcfs.db.models.compliance.ComplianceReportStatus import (
-    ComplianceReportStatus,
-    ComplianceReportStatusEnum,
-)
+from lcfs.web.api.compliance_report.update_service import ComplianceReportUpdateService
 from lcfs.web.exception.exceptions import DataNotFoundException
 
 

--- a/backend/lcfs/tests/other_uses/test_other_uses.py
+++ b/backend/lcfs/tests/other_uses/test_other_uses.py
@@ -29,7 +29,7 @@ async def test_create_other_use(
         "fuel_type": "Diesel",
         "fuel_category": "Biofuel",
         "expected_use": "Transport",
-        "units": "liters",
+        "units": "litres",
         "rationale": "Initial setup of the other use.",
     }
     response = await client.post(url, json=other_use_payload)

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -151,12 +151,14 @@ class ComplianceReportRepository:
                 joinedload(ComplianceReport.compliance_period),
                 joinedload(ComplianceReport.current_status),
                 joinedload(ComplianceReport.summary),
-                joinedload(
-                    ComplianceReport.fuel_supplies
-                ),
+                joinedload(ComplianceReport.fuel_supplies),
                 joinedload(ComplianceReport.other_uses),
-                joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.status),
-                joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.user_profile),
+                joinedload(ComplianceReport.history).joinedload(
+                    ComplianceReportHistory.status
+                ),
+                joinedload(ComplianceReport.history).joinedload(
+                    ComplianceReportHistory.user_profile
+                ),
             )
             .where(ComplianceReport.compliance_report_id == compliance_report_id)
         )
@@ -336,8 +338,12 @@ class ComplianceReportRepository:
                 joinedload(ComplianceReport.compliance_period),
                 joinedload(ComplianceReport.current_status),
                 joinedload(ComplianceReport.summary),
-                joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.status),
-                joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.user_profile),
+                joinedload(ComplianceReport.history).joinedload(
+                    ComplianceReportHistory.status
+                ),
+                joinedload(ComplianceReport.history).joinedload(
+                    ComplianceReportHistory.user_profile
+                ),
             )
             .join(
                 ComplianceReportStatus,
@@ -402,8 +408,12 @@ class ComplianceReportRepository:
                         joinedload(ComplianceReport.compliance_period),
                         joinedload(ComplianceReport.current_status),
                         joinedload(ComplianceReport.summary),
-                        joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.status),
-                        joinedload(ComplianceReport.history).joinedload(ComplianceReportHistory.user_profile),
+                        joinedload(ComplianceReport.history).joinedload(
+                            ComplianceReportHistory.status
+                        ),
+                        joinedload(ComplianceReport.history).joinedload(
+                            ComplianceReportHistory.user_profile
+                        ),
                     )
                     .where(ComplianceReport.compliance_report_id == report_id)
                 )
@@ -522,7 +532,7 @@ class ComplianceReportRepository:
                 "current_status",
                 "summary",
                 "history",
-                "update_date"
+                "update_date",
             ],
         )
         return ComplianceReportBaseSchema.model_validate(report)
@@ -541,32 +551,40 @@ class ComplianceReportRepository:
 
     @repo_handler
     async def save_compliance_report_summary(
-        self, summary_id: int, summary: ComplianceReportSummarySchema
+        self, report_id: int, summary: ComplianceReportSummarySchema
     ):
         """
         Save the compliance report summary to the database.
 
-        :param summary_id: The ID of the compliance report summary
+        :param report_id: The ID of the compliance report
         :param summary: The generated summary data
         """
-        existing_summary = await self.get_summary_by_id(summary_id)
+        existing_summary = await self.get_summary_by_report_id(report_id)
 
         if existing_summary:
             summary_obj = existing_summary
         else:
-            raise ValueError(f"No summary found with ID {summary_id}")
+            raise ValueError(f"No summary found with report ID {report_id}")
 
         # Update renewable fuel target summary
         for row in summary.renewable_fuel_target_summary:
             line_number = row.line
             for fuel_type in ["gasoline", "diesel", "jet_fuel"]:
                 column_name = f"line_{line_number}_{row.field.lower()}_{fuel_type}"
-                setattr(summary_obj, column_name, int(getattr(row, fuel_type) or 0))
+                setattr(
+                    summary_obj,
+                    column_name,
+                    int(getattr(row, fuel_type) or getattr(summary_obj, column_name)),
+                )
 
         # Update low carbon fuel target summary
         for row in summary.low_carbon_fuel_target_summary:
             column_name = f"line_{row.line}_{row.field}"
-            setattr(summary_obj, column_name, int(row.value or 0))
+            setattr(
+                summary_obj,
+                column_name,
+                int(row.value or getattr(summary_obj, column_name)),
+            )
 
         # Update non-compliance penalty summary
         non_compliance_summary = summary.non_compliance_penalty_summary
@@ -584,14 +602,6 @@ class ComplianceReportRepository:
         await self.db.flush()
         await self.db.refresh(summary_obj)
         return summary_obj
-
-    @repo_handler
-    async def get_summary_by_id(self, summary_id: int) -> ComplianceReportSummary:
-        query = select(ComplianceReportSummary).where(
-            ComplianceReportSummary.summary_id == summary_id
-        )
-        result = await self.db.execute(query)
-        return result.scalars().first()
 
     @repo_handler
     async def get_summary_by_report_id(
@@ -686,21 +696,6 @@ class ComplianceReportRepository:
 
     @repo_handler
     async def calculate_fuel_quantities(
-        self, compliance_report_id: int
-    ) -> Dict[str, Dict[str, float]]:
-        fossil_fuel_quantities = await self._calculate_fuel_quantities(
-            compliance_report_id, fossil_derived=True
-        )
-        renewable_fuel_quantities = await self._calculate_fuel_quantities(
-            compliance_report_id, fossil_derived=False
-        )
-
-        return {
-            "fossil_fuel_quantities": fossil_fuel_quantities,
-            "renewable_fuel_quantities": renewable_fuel_quantities,
-        }
-
-    async def _calculate_fuel_quantities(
         self, compliance_report_id: int, fossil_derived: bool
     ) -> Dict[str, float]:
         fuel_quantities = defaultdict(float)
@@ -725,9 +720,11 @@ class ComplianceReportRepository:
             .where(
                 FuelSupply.compliance_report_id == compliance_report_id,
                 FuelType.fossil_derived.is_(fossil_derived),
+                FuelType.other_uses_fossil_derived.is_(fossil_derived),
             )
             .group_by(FuelCategory.category)
         )
+
         aggregate_fuel_quantities(await self.db.execute(fuel_supply_query))
 
         # Aggregate other uses quantities
@@ -746,10 +743,12 @@ class ComplianceReportRepository:
             )
             .where(
                 OtherUses.compliance_report_id == compliance_report_id,
+                FuelType.fossil_derived.is_(fossil_derived),
                 FuelType.other_uses_fossil_derived.is_(fossil_derived),
             )
             .group_by(FuelCategory.category)
         )
+
         aggregate_fuel_quantities(await self.db.execute(other_uses_query))
 
         # Aggregate allocation agreement quantities for renewable fuels
@@ -773,6 +772,7 @@ class ComplianceReportRepository:
                 .where(
                     AllocationAgreement.compliance_report_id == compliance_report_id,
                     FuelType.fossil_derived.is_(False),
+                    FuelType.other_uses_fossil_derived.is_(False),
                 )
                 .group_by(FuelCategory.category)
             )

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -1,12 +1,13 @@
 from fastapi import Depends, Request
+
 from lcfs.db.models.compliance.ComplianceReport import ComplianceReport
 from lcfs.db.models.compliance.ComplianceReportStatus import ComplianceReportStatusEnum
 from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 from lcfs.web.api.compliance_report.schema import ComplianceReportUpdateSchema
-from lcfs.web.exception.exceptions import DataNotFoundException, ServiceException
 from lcfs.web.api.compliance_report.summary_service import (
     ComplianceReportSummaryService,
 )
+from lcfs.web.exception.exceptions import DataNotFoundException, ServiceException
 
 
 class ComplianceReportUpdateService:
@@ -138,7 +139,7 @@ class ComplianceReportUpdateService:
         if report.summary:
             # Update existing summary
             await self.repo.save_compliance_report_summary(
-                report.summary.summary_id, calculated_summary
+                report.compliance_report_id, calculated_summary
             )
         else:
             # Create new summary if it doesn't exist

--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -66,7 +66,9 @@ async def get_compliance_reports(
     service: ComplianceReportServices = Depends(),
 ) -> ComplianceReportListSchema:
     # Add filter on statuses so that IDIR users won't be able to see draft reports
-    pagination.filters.append(FilterModel(field="status", filter="Draft", filter_type="text", type="notEqual"))
+    pagination.filters.append(
+        FilterModel(field="status", filter="Draft", filter_type="text", type="notEqual")
+    )
     return await service.get_compliance_reports_paginated(pagination)
 
 
@@ -98,13 +100,11 @@ async def get_compliance_report_summary(
     """
     Retrieve the comprehensive compliance report summary for a specific report by ID.
     """
-    return await summary_service.calculate_compliance_report_summary(
-        report_id, is_edit=False
-    )
+    return await summary_service.calculate_compliance_report_summary(report_id)
 
 
 @router.put(
-    "/{report_id}/summary/{summary_id}",
+    "/{report_id}/summary",
     response_model=ComplianceReportSummarySchema,
     status_code=status.HTTP_200_OK,
 )
@@ -112,15 +112,14 @@ async def get_compliance_report_summary(
 async def update_compliance_report_summary(
     request: Request,
     report_id: int,
-    summary_id: int,
     summary_data: ComplianceReportSummarySchema,
     summary_service: ComplianceReportSummaryService = Depends(),
 ) -> ComplianceReportSummarySchema:
     """
     Autosave compliance report summary details for a specific summary by ID.
     """
-    return await summary_service.auto_save_compliance_report_summary(
-        report_id, summary_id, summary_data
+    return await summary_service.update_compliance_report_summary(
+        report_id, summary_data
     )
 
 

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -37,7 +37,7 @@ export const apiRoutes = {
   otherUsesOptions: '/other-uses/table-options',
   getComplianceReport: '/reports/:reportID',
   getComplianceReportSummary: '/reports/:reportID/summary',
-  updateComplianceReportSummary: '/reports/:reportID/summary/:summaryID',
+  updateComplianceReportSummary: '/reports/:reportID/summary',
   getOrgComplianceReport: '/organization/:orgID/reports/:reportID',
   getOrgComplianceReports: '/organization/:orgID/reports/list',
   getOrgComplianceReportReportedYears:

--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -57,25 +57,23 @@ export const useGetComplianceReportSummary = (reportID, options) => {
 }
 
 export const useUpdateComplianceReportSummary = (
-  complianceReportId,
-  summaryId,
+  reportId,
   options
 ) => {
   const client = useApiService()
   const queryClient = useQueryClient()
   const path = apiRoutes.updateComplianceReportSummary
-    .replace(':reportID', complianceReportId)
-    .replace(':summaryID', summaryId)
+    .replace(':reportID', reportId)
   return useMutation({
     ...options,
     mutationFn: async (data) => {
       return await client.put(path, data)
     },
-    onSettled: () => {
-      queryClient.invalidateQueries([
-        'compliance-report-summary',
-        complianceReportId
-      ])
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        ['compliance-report-summary', reportId],
+        data.data
+      )
     }
   })
 }

--- a/frontend/src/layouts/MainLayout/components/Navbar.jsx
+++ b/frontend/src/layouts/MainLayout/components/Navbar.jsx
@@ -16,7 +16,7 @@ export const Navbar = () => {
 
   // Nav Links
   const navMenuItems = useMemo(() => {
-    const isAnalyst = currentUser.roles.find(
+    const isAnalyst = currentUser && currentUser.roles.find(
       (role) => role.name === roles.analyst
     )
     const idirRoutes = [

--- a/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
+++ b/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
@@ -35,20 +35,16 @@ const ComplianceReportSummary = ({ reportID, currentStatus, compliancePeriodYear
   const { data, isLoading, isError, error } =
     useGetComplianceReportSummary(reportID)
   const { mutate: updateComplianceReportSummary } =
-    useUpdateComplianceReportSummary(
-      data?.complianceReportId,
-      data?.summaryId,
-      {
-        onSuccess: (response) => {
-          setSummaryData(response.data)
-        },
-        onError: (error) => {
-          setAlertMessage(error.message)
-          setAlertSeverity('error')
-          alertRef.current.triggerAlert()
-        }
+    useUpdateComplianceReportSummary(data?.complianceReportId, {
+      onSuccess: (response) => {
+        setSummaryData(response.data)
+      },
+      onError: (error) => {
+        setAlertMessage(error.message)
+        setAlertSeverity('error')
+        alertRef.current.triggerAlert()
       }
-    )
+    })
   useEffect(() => {
     if (data) {
       setSummaryData(data)


### PR DESCRIPTION
 Previously any changes to fuel supply or other fields would cause line 6 to be overwritten. The endpoint was also being called twice.

This change aims to start fixing the issue, by updating the get endpoint to IDEALLY only re-calculate if something has changed however this is not currently working.

Changes:
* Unify get and put to have the same structure, Report -> Summary is 1:1 so there is no need to pass in ID
* Remove  need to pass in summary_id for get as there can only ever be one per report
* Begin to clean up line calculation code to use less / clear checks
* Update useComplianceReport to not invalidate its own data and instead set it
* Fix typos

closes: #895 #896 