### PR TITLE
LCFS-968: Bug fix in Allocation agreements for Fuel code and CI of fuel

### DIFF
--- a/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
@@ -101,6 +101,9 @@ export const AddEditAllocationAgreements = () => {
 
   const onCellValueChanged = useCallback(
     async (params) => {
+      if (params.colDef.field === 'provisionOfTheAct') {
+        params.node.setDataValue('fuelCode', '')
+      }
       if (
         ['fuelType', 'fuelCode', 'provisionOfTheAct'].includes(
           params.colDef.field

--- a/frontend/src/views/AllocationAgreements/_schema.jsx
+++ b/frontend/src/views/AllocationAgreements/_schema.jsx
@@ -287,6 +287,9 @@ export const allocationAgreementColDefs = (optionsData, errors) => [
     headerName: i18n.t(
       'allocationAgreement:allocationAgreementColLabels.ciOfFuel'
     ),
+    valueFormatter: params => {
+      return parseFloat(params.value).toFixed(2);
+    },
     cellStyle: (params) => StandardCellErrors(params, errors),
     editable: false,
     valueGetter: (params) => {


### PR DESCRIPTION
Fix bug in allocation agreements in the following scenarios:
- When changing the value of `Determining Carbon Intensity` field, `Fuel code` field value should be reset:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/00637ef5-76f5-496d-b876-6763176001de">

- Formatting `CI of fuel` field to show 2 decimal places in the UI. We keep storing the original value to avoid losing precision.
<img width="678" alt="image" src="https://github.com/user-attachments/assets/14543c7f-1f28-4c07-967c-4beb5c2d6d71">

