### PR TITLE
Refactor: Relocate Validation Alert and Fix Missing Report Type - 973, 975

### DIFF
--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -84,5 +84,15 @@
     "Assessed": "Assessed",
     "ReAssessed": "Re-assessed"
   },
-  "internalComments": "Internal comments"
+  "internalComments": "Internal comments",
+  "fuelLabels": {
+    "gasoline": "Gasoline",
+    "diesel": "Diesel",
+    "jetFuel": "Jet fuel"
+  },
+  "summaryLabels": {
+    "line": "Line",
+    "value": "Value",
+    "totalValue": "Total Value"
+  }
 }

--- a/frontend/src/components/BCDataGrid/BCGridEditor.jsx
+++ b/frontend/src/components/BCDataGrid/BCGridEditor.jsx
@@ -14,6 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus, faCaretDown } from '@fortawesome/free-solid-svg-icons'
 import BCModal from '@/components/BCModal'
 import { useTranslation } from 'react-i18next'
+import { BCAlert2 } from '@/components/BCAlert'
 
 /**
  * @typedef {import('ag-grid-community').GridOptions} GridOptions
@@ -29,6 +30,7 @@ import { useTranslation } from 'react-i18next'
  */
 export const BCGridEditor = ({
   gridRef,
+  alertRef,
   handlePaste,
   onCellEditingStopped,
   onCellValueChanged,
@@ -170,6 +172,11 @@ export const BCGridEditor = ({
         onCellEditingStopped={handleOnCellEditingStopped}
         {...props}
       />
+      <BCBox 
+        sx={{ height: '40px', marginTop: '15px', width: '100%' }}
+      >
+        <BCAlert2 ref={alertRef} data-test="alert-box" />
+      </BCBox>
       {showAddRowsButton && (
         <BCBox mt={2}>
           <BCButton

--- a/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
@@ -255,7 +255,6 @@ export const AddEditAllocationAgreements = () => {
     isFetched &&
     !allocationAgreementsLoading && (
       <Grid2 className="add-edit-allocation-agreement-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('allocationAgreement:addAllocationAgreementRowsTitle')}
@@ -272,6 +271,7 @@ export const AddEditAllocationAgreements = () => {
         <BCBox my={2} component="div" style={{ height: '100%', width: '100%' }}>
           <BCGridEditor
             gridRef={gridRef}
+            alertRef={alertRef}
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             onGridReady={onGridReady}

--- a/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
+++ b/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
@@ -104,6 +104,7 @@ const ComplianceReportSummary = ({ reportID, currentStatus, compliancePeriodYear
             columns={
               summaryData
                 ? renewableFuelColumns(
+                  t,
                   summaryData?.renewableFuelTargetSummary,
                   currentStatus === 'Draft',
                   compliancePeriodYear
@@ -115,13 +116,13 @@ const ComplianceReportSummary = ({ reportID, currentStatus, compliancePeriodYear
           />
           <SummaryTable
             title={t('report:lowCarbonFuelTargetSummary')}
-            columns={lowCarbonColumns}
+            columns={lowCarbonColumns(t)}
             data={summaryData?.lowCarbonFuelTargetSummary}
             width={'81%'}
           />
           <SummaryTable
             title={t('report:nonCompliancePenaltySummary')}
-            columns={nonComplianceColumns}
+            columns={nonComplianceColumns(t)}
             data={summaryData?.nonCompliancePenaltySummary}
             width={'81%'}
           />

--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -22,7 +22,7 @@ export const reportsColDefs = (t, bceidRole) => [
     field: 'type',
     headerName: t('report:reportColLabels.type'),
     flex: 2,
-    valueGetter: () => 'Compliance report'
+    valueGetter: () => t('report:complianceReport')
   },
   {
     field: 'status',
@@ -67,7 +67,7 @@ export const reportsColDefs = (t, bceidRole) => [
   }
 ]
 
-export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
+export const renewableFuelColumns = (t, data, editable, compliancePeriodYear) => {
   /**
    * Editable Lines Logic:
    *
@@ -114,7 +114,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
       (line) => line !== SUMMARY.LINE_8
     )
   }
-  
+
   // ============ Diesel Logic ============
   if (
     data[SUMMARY.LINE_2].diesel > 0 &&
@@ -126,7 +126,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
     data[SUMMARY.LINE_2].diesel - data[SUMMARY.LINE_4].diesel > 0
   )
     dieselEditableCells = [SUMMARY.LINE_8, SUMMARY.LINE_9]
-  
+
   // Line 8
   if (data[SUMMARY.LINE_2].diesel < data[SUMMARY.LINE_4].diesel) {
     // If Line 2 is less than Line 4, ensure Line 8 is available
@@ -139,7 +139,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
       (line) => line !== SUMMARY.LINE_8
     )
   }
-  
+
   // ============ Jet Fuel Logic ============
   if (
     data[SUMMARY.LINE_2].jetFuel > 0 &&
@@ -151,7 +151,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
     data[SUMMARY.LINE_2].jetFuel - data[SUMMARY.LINE_4].jetFuel > 0
   )
     jetFuelEditableCells = [SUMMARY.LINE_8, SUMMARY.LINE_9]
-  
+
 
   // Line 8
   if (parseInt(compliancePeriodYear) >= 2028) {
@@ -184,15 +184,15 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
   }
 
   return [
-    { id: 'line', label: 'Line', align: 'center', width: '100px', bold: true },
+    { id: 'line', label: t('report:summaryLabels.line'), align: 'center', width: '100px', bold: true },
     {
       id: 'description',
-      label: 'Renewable fuel target summary',
+      label: t('report:renewableFuelTargetSummary'),
       maxWidth: '300px'
     },
     {
       id: 'gasoline',
-      label: 'Gasoline',
+      label: t('report:fuelLabels.gasoline'),
       align: 'right',
       width: '150px',
       editable,
@@ -204,7 +204,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
     },
     {
       id: 'diesel',
-      label: 'Diesel',
+      label: t('report:fuelLabels.diesel'),
       align: 'right',
       width: '150px',
       editable,
@@ -216,7 +216,7 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
     },
     {
       id: 'jetFuel',
-      label: 'Jet fuel',
+      label: t('report:fuelLabels.jetFuel'),
       align: 'right',
       width: '150px',
       editable,
@@ -229,23 +229,23 @@ export const renewableFuelColumns = (data, editable, compliancePeriodYear) => {
   ]
 }
 
-export const lowCarbonColumns = [
-  { id: 'line', label: 'Line', align: 'center', width: '100px', bold: true },
+export const lowCarbonColumns = (t) => [
+  { id: 'line', label: t('report:summaryLabels.line'), align: 'center', width: '100px', bold: true },
   {
     id: 'description',
-    label: 'Low carbon fuel target summary',
+    label: t('report:lowCarbonFuelTargetSummary'),
     maxWidth: '300px'
   },
-  { id: 'value', label: 'Value', align: 'center', width: '150px' }
+  { id: 'value', label: t('report:summaryLabels.value'), align: 'center', width: '150px' }
 ]
 
-export const nonComplianceColumns = [
+export const nonComplianceColumns = (t) => [
   {
     id: 'description',
-    label: 'Non-compliance penalty payable summary',
+    label: t('report:nonCompliancePenaltySummary'),
     maxWidth: '300px'
   },
-  { id: 'totalValue', label: 'Total Value', align: 'center', width: '150px' }
+  { id: 'totalValue', label: t('report:summaryLabels.totalValue'), align: 'center', width: '150px' }
 ]
 
 export const defaultSortModel = [

--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -22,7 +22,7 @@ export const reportsColDefs = (t, bceidRole) => [
     field: 'type',
     headerName: t('report:reportColLabels.type'),
     flex: 2,
-    valueGetter: ({ data }) => data.type?.description || ''
+    valueGetter: () => 'Compliance report'
   },
   {
     field: 'status',

--- a/frontend/src/views/FinalSupplyEquipments/AddEditFinalSupplyEquipments.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/AddEditFinalSupplyEquipments.jsx
@@ -254,7 +254,6 @@ export const AddEditFinalSupplyEquipments = () => {
     isFetched &&
     !equipmentsLoading && (
       <Grid2 className="add-edit-final-supply-equipment-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('finalSupplyEquipment:addFSErowsTitle')}
@@ -271,6 +270,7 @@ export const AddEditFinalSupplyEquipments = () => {
         <BCBox my={2} component="div" style={{ height: '100%', width: '100%' }}>
           <BCGridEditor
             gridRef={gridRef}
+            alertRef={alertRef}
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             onGridReady={onGridReady}

--- a/frontend/src/views/FuelExports/AddEditFuelExports.jsx
+++ b/frontend/src/views/FuelExports/AddEditFuelExports.jsx
@@ -252,7 +252,6 @@ export const AddEditFuelExports = () => {
     isFetched &&
     !fuelExportsLoading && (
       <Grid2 className="add-edit-fuel-export-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('fuelExport:addFuelExportRowsTitle')}
@@ -269,6 +268,7 @@ export const AddEditFuelExports = () => {
         <BCBox my={2} component="div" style={{ height: '100%', width: '100%' }}>
           <BCGridEditor
             gridRef={gridRef}
+            alertRef={alertRef}
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             onGridReady={onGridReady}

--- a/frontend/src/views/FuelSupplies/AddEditFuelSupplies.jsx
+++ b/frontend/src/views/FuelSupplies/AddEditFuelSupplies.jsx
@@ -346,7 +346,6 @@ export const AddEditFuelSupplies = () => {
     isFetched &&
     !fuelSuppliesLoading && (
       <Grid2 className="add-edit-fuel-supply-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('fuelSupply:addFuelSupplyRowsTitle')}
@@ -363,6 +362,7 @@ export const AddEditFuelSupplies = () => {
         <BCBox my={2} component="div" style={{ height: '100%', width: '100%' }}>
           <BCGridEditor
             gridRef={gridRef}
+            alertRef={alertRef}
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             onGridReady={onGridReady}

--- a/frontend/src/views/NotionalTransfers/AddEditNotionalTransfers.jsx
+++ b/frontend/src/views/NotionalTransfers/AddEditNotionalTransfers.jsx
@@ -235,7 +235,6 @@ export const AddEditNotionalTransfers = () => {
     isFetched &&
     !transfersLoading && (
       <Grid2 className="add-edit-notional-transfer-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('notionalTransfer:newNotionalTransferTitle')}
@@ -244,6 +243,7 @@ export const AddEditNotionalTransfers = () => {
         <BCBox my={2} component="div" style={{ height: '100%', width: '100%' }}>
           <BCGridEditor
             gridRef={gridRef}
+            alertRef={alertRef}
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             onGridReady={onGridReady}

--- a/frontend/src/views/OtherUses/AddEditOtherUses.jsx
+++ b/frontend/src/views/OtherUses/AddEditOtherUses.jsx
@@ -254,7 +254,6 @@ export const AddEditOtherUses = () => {
   return (
     isFetched && (
       <Grid2 className="add-edit-other-uses-container" mx={-1}>
-        <BCAlert2 ref={alertRef} data-test="alert-box" />
         <div className="header">
           <Typography variant="h5" color="primary">
             {t('otherUses:newOtherUsesTitle')}
@@ -263,6 +262,7 @@ export const AddEditOtherUses = () => {
 
         <BCGridEditor
           gridRef={gridRef}
+          alertRef={alertRef}
           getRowId={(params) => params.data.id}
           columnDefs={otherUsesColDefs(optionsData, errors)}
           defaultColDef={defaultColDef}


### PR DESCRIPTION
This PR relocates the validation alert directly under the table to prevent UI shifting and fixes the missing compliance report type text in the index page.

Closes #973, #975