### PR TITLE
fix: Don't unload components when RequireAuth is loading

### DIFF
--- a/frontend/src/components/RequireAuth.jsx
+++ b/frontend/src/components/RequireAuth.jsx
@@ -7,10 +7,6 @@ export const RequireAuth = ({ children, redirectTo }) => {
   const { keycloak, initialized } = useKeycloak()
   const { isLoading, isError, error } = useCurrentUser()
 
-  if (!initialized || isLoading) {
-    return <Loading />
-  }
-
   if (isError) {
     const state = {
       message: error?.response?.data?.detail,

--- a/frontend/src/layouts/MainLayout/components/Navbar.jsx
+++ b/frontend/src/layouts/MainLayout/components/Navbar.jsx
@@ -39,7 +39,7 @@ export const Navbar = () => {
     ]
     const mobileRoutes = [{ name: t('logout'), route: ROUTES.LOG_OUT }]
 
-    const activeRoutes = currentUser.isGovernmentUser ? idirRoutes : bceidRoutes
+    const activeRoutes = currentUser?.isGovernmentUser ? idirRoutes : bceidRoutes
 
     if (isMobileView) {
       activeRoutes.push(...mobileRoutes)


### PR DESCRIPTION
* Token refresh causes loading to go true, this clears all components from the page and resets their status
* By not loading, components on the page keep their state