### PR TITLE
feat: Add slow query tracker and function profiler

### DIFF
--- a/backend/lcfs/db/dependencies.py
+++ b/backend/lcfs/db/dependencies.py
@@ -9,6 +9,9 @@ from redis import asyncio as aioredis
 
 from lcfs.settings import settings
 
+if settings.environment == "dev":
+    import lcfs.utils.query_analyzer
+
 db_url = make_url(str(settings.db_url.with_path(f"/{settings.db_base}")))
 async_engine = create_async_engine(db_url, future=True)
 logging.getLogger("sqlalchemy.engine").setLevel(logging.WARN)

--- a/backend/lcfs/utils/performance_profiler.py
+++ b/backend/lcfs/utils/performance_profiler.py
@@ -1,0 +1,18 @@
+import cProfile
+import contextlib
+
+import pstats
+
+
+### with profile_performance():
+###     result = await self.db.execute(query)
+###     transactions = result.scalars().all()
+@contextlib.contextmanager
+def profile_performance():
+    """Developer Util for Profiling functions"""
+    pr = cProfile.Profile()
+    pr.enable()
+    yield
+    pr.disable()
+    ps = pstats.Stats(pr).sort_stats("cumulative")
+    ps.print_stats()

--- a/backend/lcfs/utils/query_analyzer.py
+++ b/backend/lcfs/utils/query_analyzer.py
@@ -1,0 +1,27 @@
+import logging
+import time
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+SLOW_QUERY_TIME = 1.3  # Seconds
+
+
+@event.listens_for(Engine, "before_cursor_execute")
+def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    conn.info.setdefault("query_start_time", []).append(time.time())
+
+
+@event.listens_for(Engine, "after_cursor_execute")
+def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    total = time.time() - conn.info["query_start_time"].pop(-1)
+    if total > SLOW_QUERY_TIME:
+        logger.warning(
+            f"Slow Query Detected:\n"
+            f"Query: {statement}\n"
+            f"Execution Time: {total:.2f} seconds\n"
+            f"Parameters: {parameters}\n"
+            f"Transaction ID: {id(conn)}\n"
+        )


### PR DESCRIPTION
* Log all queries with a warning slower than 1.3 seconds so we can start looking into performance
* Auto enable query profile for dev environments
* Add a performance profile so developers can quickly profile code to find bottlenecks