### PR TITLE
LCFS-1033: Allocation agreement schedule edits not persisting when save is selected

### DIFF
--- a/backend/lcfs/web/api/allocation_agreement/services.py
+++ b/backend/lcfs/web/api/allocation_agreement/services.py
@@ -233,9 +233,12 @@ class AllocationAgreementServices:
             )
 
         if (
-            existing_allocation_agreement.fuel_code.fuel_code
+            existing_allocation_agreement.fuel_code is None
+            or allocation_agreement_data.fuel_code is None
+            or existing_allocation_agreement.fuel_code.fuel_code
             != allocation_agreement_data.fuel_code
         ):
+
             existing_allocation_agreement.fuel_code = (
                 await self.fuel_repo.get_fuel_code_by_name(
                     allocation_agreement_data.fuel_code
@@ -276,7 +279,11 @@ class AllocationAgreementServices:
             fuel_type=updated_allocation_agreement.fuel_type.fuel_type,
             fuel_category=updated_allocation_agreement.fuel_category.category,
             provision_of_the_act=updated_allocation_agreement.provision_of_the_act.name,
-            fuel_code=updated_allocation_agreement.fuel_code.fuel_code,
+            fuel_code=(
+                updated_allocation_agreement.fuel_code.fuel_code
+                if updated_allocation_agreement.fuel_code
+                else None
+            ),
         )
 
     @service_handler


### PR DESCRIPTION
**Issue**
- Fix issue when saving changes in Allocation agreements throwing this error in backend:
  AttributeError: 'NoneType' object has no attribute 'fuel_code'
- The issue is that null values are possible in `fuel_code` field for `existing_allocation_agreement` (data from `allocation_agreement` table queried in database) or `allocation_agreement_data` (data from payload sent with the POST request).
 


**Valid scenarios when saving fuel_code**
- When selecting the different values from Determining Carbon Intensity, fuel_code is behaving as follows:
   - Default carbon intensity -section 19 (b): fuel_code is empty and not editable.
   - Fuel code - section 19 (b) (i): User can select any `active` fuel_code
   - Prescribed carbon intensity - section 19 (a): fuel_code is empty and not editable.

[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=82975566&issue=bcgov%7Clcfs%7C1033)