### PR TITLE
LCFS-1055: Allocation agreement schedule is allowing all fuel types to chose any of the 3 determining carbon intensity options

### DIFF
--- a/backend/lcfs/web/api/allocation_agreement/schema.py
+++ b/backend/lcfs/web/api/allocation_agreement/schema.py
@@ -26,6 +26,10 @@ class FuelCodeSchema(BaseSchema):
     carbon_intensity: float
 
 
+class ProvisionOfTheActSchema(BaseSchema):
+    provision_of_the_act_id: int
+    name: str
+
 class FuelTypeSchema(BaseSchema):
     fuel_type_id: int
     fuel_type: str
@@ -34,6 +38,7 @@ class FuelTypeSchema(BaseSchema):
     unrecognized: bool
     fuel_categories: List[FuelCategorySchema]
     fuel_codes: Optional[List[FuelCodeSchema]] = []
+    provision_of_the_act: Optional[List[ProvisionOfTheActSchema]] = []
 
 
 class ProvisionOfTheActSchema(BaseSchema):

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -107,7 +107,24 @@ class FuelCodeRepository:
                     }
                     for fc in fuel_type.fuel_codes
                 ],
+                "provision_of_the_act": [],
             }
+
+            if fuel_type.provision_1:
+                formatted_fuel_type["provision_of_the_act"].append(
+                    {
+                        "provision_of_the_act_id": fuel_type.provision_1_id,
+                        "name": fuel_type.provision_1.name,
+                    }
+                )
+
+            if fuel_type.provision_2:
+                formatted_fuel_type["provision_of_the_act"].append(
+                    {
+                        "provision_of_the_act_id": fuel_type.provision_2_id,
+                        "name": fuel_type.provision_2.name,
+                    }
+                )
             formatted_fuel_types.append(formatted_fuel_type)
 
         return formatted_fuel_types

--- a/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddAllocationAgreements.jsx
@@ -135,6 +135,14 @@ export const AddEditAllocationAgreements = () => {
     async (params) => {
       if (params.oldValue === params.newValue) return
 
+      if (!params.data.provisionOfTheAct) {
+        alertRef.current?.triggerAlert({
+          message: 'Determining Carbon Intensity field is required.',
+          severity: 'error'
+        })
+        return
+      }
+
       params.node.updateData({
         ...params.node.data,
         validationStatus: 'pending'

--- a/frontend/src/views/AllocationAgreements/_schema.jsx
+++ b/frontend/src/views/AllocationAgreements/_schema.jsx
@@ -188,6 +188,7 @@ export const allocationAgreementColDefs = (optionsData, errors) => [
           fuelType.fuelCategories?.[0]?.category ?? null
         params.data.units = fuelType?.units
         params.data.unrecognized = fuelType?.unrecognized
+        params.data.provisionOfTheAct = null;
       }
       return true
     },
@@ -239,8 +240,18 @@ export const allocationAgreementColDefs = (optionsData, errors) => [
       'allocationAgreement:allocationAgreementColLabels.provisionOfTheAct'
     ),
     cellEditor: 'agSelectCellEditor',
-    cellEditorParams: {
-      values: optionsData?.provisionsOfTheAct?.map((obj) => obj.name).sort()
+    cellEditorParams: (params) => {
+      const fuelType = optionsData?.fuelTypes?.find(
+        (type) => type.fuelType === params.data.fuelType
+      )
+
+      const provisionsOfTheAct = fuelType
+        ? fuelType.provisionOfTheAct.map((provision) => provision.name)
+        : []
+
+      return {
+        values: provisionsOfTheAct.sort()
+      }
     },
     cellRenderer: (params) =>
       params.value ||


### PR DESCRIPTION
**Issue**

The `provisionOfTheAct field` (labeled as "_Determining Carbon Intensity_") was displaying all available options, regardless of the selected fuel type. This caused confusion since not all provisions are applicable to every fuel type.


**Fix**

The `provisionOfTheAct` field is now dynamically filtered based on the selected `Fuel Type` field, following the existing relationship in the database. The field will only display the provisions that are relevant to the chosen fuel type.

The provisions displayed are based on the following mappings:

```
fuel_type_id|fuel_type              |provision_1_name                            |provision_2_name                              |
------------+-----------------------+--------------------------------------------+----------------------------------------------+
           1|Biodiesel              |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           2|CNG                    |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           3|Electricity            |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           4|Ethanol                |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           5|HDRD                   |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           6|Hydrogen               |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           7|LNG                    |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
           9|Other diesel fuel      |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
          11|Alternative jet fuel   |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
          13|Propane                |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
          14|Renewable gasoline     |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
          15|Renewable naphtha      |Fuel code - section 19 (b) (i)              |Default carbon intensity - section 19 (b) (ii)|
          16|Fossil-derived diesel  |Prescribed carbon intensity - section 19 (a)|NULL                                          |
          17|Fossil-derived gasoline|Prescribed carbon intensity - section 19 (a)|NULL                                          |
          18|Fossil-derived jet fuel|Prescribed carbon intensity - section 19 (a)|NULL                                          |
```

**Examples:**

**Fuel Type: Electricity**
Fuel Type `Electricity` has two possible _Determining Carbon Intensity_ options: `Default carbon intensity - section 19 (b) (ii)`, `Fuel code - section 19 (b) (i)`
![image](https://github.com/user-attachments/assets/dc2b517e-2ed5-4747-afb2-cde435cdddcf)



**Fuel Type: Fossil-derived gasoline**
Fuel Type `Fossil-derived gasoline` has one possible _Determining Carbon Intensity_ option: `Prescribed carbon intensity - section 19 (a)`
![image](https://github.com/user-attachments/assets/ffc65c24-9c71-445b-968b-92ca65e504bc)


**Prompt for Provision of the Act selection**
_Determining Carbon Intensity field_ needs to be selected when changing fuel type.
![image](https://github.com/user-attachments/assets/c6eaf779-71ad-4d4d-9aa3-55726d76ade7)


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=83531970&issue=bcgov%7Clcfs%7C1055)
