### PR TITLE
hotfix: Fixing two heads in alembic.

### DIFF
--- a/backend/lcfs/db/migrations/versions/2024-10-18-19-48_bb5504e743a0.py
+++ b/backend/lcfs/db/migrations/versions/2024-10-18-19-48_bb5504e743a0.py
@@ -1,7 +1,7 @@
 """Update 'price_per_unit' column from Integer to Numeric(10, 2).
 
 Revision ID: bb5504e743a0
-Revises: 4f25f8811872
+Revises: a731a32947dc
 Create Date: 2024-10-18 19:48:34.877657
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "bb5504e743a0"
-down_revision = "4f25f8811872"
+down_revision = "a731a32947dc"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
**Issue**

Last migration 2024-10-18-19-48_bb5504e743a0.py should have included revises `a731a32947dc`:

2024-10-18-19-48_bb5504e743a0.py:
"""Update 'price_per_unit' column from Integer to Numeric(10, 2).

Revision ID: bb5504e743a0
Revises: 4f25f8811872 --> This should be the previous migrationa731a32947dc
Create Date: 2024-10-18 19:48:34.877657

"""

The previous migration is `2024-10-18-19-46_a731a32947dc.py`:
"""Use Numeric for 2 Decimal Columns

Revision ID: a731a32947dc
Revises: 4f25f8811872
Create Date: 2024-10-18 19:46:48.189455

"""

The above is creating two heads in alembic:
alembic heads
a731a32947dc (head)
bb5504e743a0 (head)

**Fix:**
Merge the two migrations to have one head.

