### PR TITLE
Fix: Removed trailing slash in director review counts URL - 992

### DIFF
--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -56,7 +56,7 @@ export const apiRoutes = {
   fuelExportOptions: '/fuel-exports/table-options?',
   getAllFuelExports: '/fuel-exports/list-all',
   saveFuelExports: '/fuel-exports/save',
-  directorReviewCounts: '/dashboard/director-review-counts/',
+  directorReviewCounts: '/dashboard/director-review-counts',
   TransactionCounts: '/dashboard/transaction-counts',
   OrgTransactionCounts: '/dashboard/org-transaction-counts',
   getAllAllocationAgreements: '/allocation-agreement/list-all',


### PR DESCRIPTION
This PR fixes the issue where the dashboard widget counter for directors was always showing 0 due to an incorrect URL. 

Closes #992