### PR TITLE
Fix: Error messages for permission access

### DIFF
--- a/backend/lcfs/web/core/decorators.py
+++ b/backend/lcfs/web/core/decorators.py
@@ -78,6 +78,8 @@ def view_handler(required_roles: List[Union[RoleEnum, Literal["*"]]]):
                 logger.error(str(e))
                 raise HTTPException(status_code=500, detail="Internal Server Error")
             except HTTPException as e:
+                if e.status_code == 403:
+                    raise HTTPException(status_code=404, detail="Not Found")
                 logger.error(str(e))
                 raise
             except DataNotFoundException:

--- a/backend/lcfs/web/core/decorators.py
+++ b/backend/lcfs/web/core/decorators.py
@@ -78,9 +78,9 @@ def view_handler(required_roles: List[Union[RoleEnum, Literal["*"]]]):
                 logger.error(str(e))
                 raise HTTPException(status_code=500, detail="Internal Server Error")
             except HTTPException as e:
+                logger.error(str(e))
                 if e.status_code == 403:
                     raise HTTPException(status_code=404, detail="Not Found")
-                logger.error(str(e))
                 raise
             except DataNotFoundException:
                 raise HTTPException(status_code=404, detail="Not Found")


### PR DESCRIPTION
#1014
> @prv-proton @Grulin yes I think it would be better to just be blank, so give no error at all. An error message like this may provide information that we don't want to be giving out.

Fix for above, currently the error message is changed to Not found for all 403 error messages.

Need to confirm with Al, before the changes are approved.