### PR TITLE
Fix: Bug fix for compliance report director assessment

### DIFF
--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -428,6 +428,7 @@ class ComplianceReportRepository:
                         joinedload(ComplianceReport.history).joinedload(
                             ComplianceReportHistory.user_profile
                         ),
+                        joinedload(ComplianceReport.transaction)
                     )
                     .where(ComplianceReport.compliance_report_id == report_id)
                 )

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -219,6 +219,7 @@ class ComplianceReportUpdateService:
             raise HTTPException(status_code=403, detail="Forbidden.")
         # Update the transaction to assessed
         report.transaction.transaction_action = TransactionActionEnum.Adjustment
+        report.transaction.update_user = str(user.user_profile_id)
         await self.repo.update_compliance_report(report)
 
     async def handle_reassessed_status(self, report: ComplianceReport):

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -218,17 +218,7 @@ class ComplianceReportUpdateService:
         if not has_director_role:
             raise HTTPException(status_code=403, detail="Forbidden.")
         # Update the transaction to assessed
-        if report.transaction == None:
-            # TODO: this is a temporary fix for existing records in dev. this code wont' be executed in prod, 
-            # as the transaction would have already been created during report submission.
-            report.transaction = await self.org_service.adjust_balance(
-                transaction_action=TransactionActionEnum.Adjustment,
-                compliance_units=report.summary.line_20_surplus_deficit_units,
-                organization_id=report.organization_id,
-            )
-        else:
-            # Confirm the transaction.
-            report.transaction.transaction_action = TransactionActionEnum.Adjustment
+        report.transaction.transaction_action = TransactionActionEnum.Adjustment
         await self.repo.update_compliance_report(report)
 
     async def handle_reassessed_status(self, report: ComplianceReport):

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -219,7 +219,7 @@ class ComplianceReportUpdateService:
             raise HTTPException(status_code=403, detail="Forbidden.")
         # Update the transaction to assessed
         report.transaction.transaction_action = TransactionActionEnum.Adjustment
-        report.transaction.update_user = str(user.user_profile_id)
+        report.transaction.update_user = user.keycloak_username
         await self.repo.update_compliance_report(report)
 
     async def handle_reassessed_status(self, report: ComplianceReport):

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -218,7 +218,17 @@ class ComplianceReportUpdateService:
         if not has_director_role:
             raise HTTPException(status_code=403, detail="Forbidden.")
         # Update the transaction to assessed
-        report.transaction.transaction_action = TransactionActionEnum.Adjustment
+        if report.transaction == None:
+            # TODO: this is a temporary fix for existing records in dev. this code wont' be executed in prod, 
+            # as the transaction would have already been created during report submission.
+            report.transaction = await self.org_service.adjust_balance(
+                transaction_action=TransactionActionEnum.Adjustment,
+                compliance_units=report.summary.line_20_surplus_deficit_units,
+                organization_id=report.organization_id,
+            )
+        else:
+            # Confirm the transaction.
+            report.transaction.transaction_action = TransactionActionEnum.Adjustment
         await self.repo.update_compliance_report(report)
 
     async def handle_reassessed_status(self, report: ComplianceReport):


### PR DESCRIPTION
#1005
> Everything works great but the Issue assessment button gives a 500 error

Since the reports were already created in dev environment, without creating a transaction record in RESERVED status, existing reports were failing. Hence have made changes to create a new transaction as ADJUSTMENT for the final report assessment in case there is no existing transaction.