### PR TITLE
Fix: Compliance report loading issue in dev

### DIFF
--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -53,9 +53,10 @@ export const useGetComplianceReport = (orgID, reportID, options) => {
         .replace(':reportID', reportID)
     : apiRoutes.getComplianceReport.replace(':reportID', reportID)
   return useQuery({
-    enabled: !!orgID,
     queryKey: ['compliance-report', reportID],
-    queryFn: () => client.get(path),
+    queryFn: async () => {
+      return (await client.get(path))
+    },
     ...options
   })
 }


### PR DESCRIPTION
Quick fix for the issue in dev.
getComplianceReport call is disabled if orgID is not provided, added fix to bypass this for IDIR users and async call introduced.