### PR TITLE
fix: Filter Report Status on Get Report Endpoint

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_compliance_report_services.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_services.py
@@ -1,13 +1,8 @@
 import pytest
-
 from unittest.mock import MagicMock, AsyncMock
-
 from lcfs.db.models.compliance.CompliancePeriod import CompliancePeriod
 from lcfs.db.models.compliance.ComplianceReportStatus import ComplianceReportStatus
-
-from lcfs.web.exception.exceptions import ServiceException
-from lcfs.web.exception.exceptions import DataNotFoundException
-
+from lcfs.web.exception.exceptions import ServiceException, DataNotFoundException
 
 # get_all_compliance_periods
 @pytest.mark.anyio
@@ -145,12 +140,19 @@ async def test_get_compliance_report_by_id_success(
 ):
     mock_compliance_report = compliance_report_base_schema()
 
+    compliance_report_service._mask_report_status_for_history = MagicMock(
+        return_value=mock_compliance_report
+    )
+
     mock_repo.get_compliance_report_by_id.return_value = mock_compliance_report
 
     result = await compliance_report_service.get_compliance_report_by_id(1)
 
     assert result == mock_compliance_report
     mock_repo.get_compliance_report_by_id.assert_called_once_with(1)
+    compliance_report_service._mask_report_status_for_history.assert_called_once_with(
+        mock_compliance_report, False
+    )
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
@@ -239,7 +239,7 @@ async def test_get_compliance_report_by_id_success(
         expected_response = json.loads(mock_compliance_report.json(by_alias=True))
 
         assert response.json() == expected_response
-        mock_get_compliance_report_by_id.assert_called_once_with(1)
+        mock_get_compliance_report_by_id.assert_called_once_with(1, False)
         mock_validate_organization_access.assert_called_once_with(1)
 
 

--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -33,6 +33,7 @@ from lcfs.web.api.compliance_report.summary_service import (
 )
 from lcfs.web.api.compliance_report.update_service import ComplianceReportUpdateService
 from lcfs.web.api.compliance_report.validation import ComplianceReportValidation
+from lcfs.web.api.role.schema import user_has_roles
 from lcfs.web.core.decorators import view_handler
 
 router = APIRouter()
@@ -85,7 +86,10 @@ async def get_compliance_report_by_id(
     validate: ComplianceReportValidation = Depends(),
 ) -> ComplianceReportBaseSchema:
     await validate.validate_organization_access(report_id)
-    return await service.get_compliance_report_by_id(report_id)
+
+    mask_statuses = not user_has_roles(request.user, [RoleEnum.GOVERNMENT])
+
+    return await service.get_compliance_report_by_id(report_id, mask_statuses)
 
 
 @router.get(

--- a/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
+++ b/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
@@ -91,7 +91,7 @@ export const AssessmentCard = ({
         <>
           <Stack direction="column" spacing={0.5}>
             <Typography variant="h6" color="primary">
-              {orgData.name}
+              {orgData?.name}
             </Typography>
             <List sx={{ padding: 0 }}>
               <StyledListItem>


### PR DESCRIPTION
* Re-use existing status mask from list reports on get compliance report
* This correctly masks the status for organizations