### PR TITLE
LCFS-1149: Notification System for LCFS

### DIFF
--- a/backend/lcfs/db/migrations/versions/2024-11-12-13-14_2d98674000f3.py
+++ b/backend/lcfs/db/migrations/versions/2024-11-12-13-14_2d98674000f3.py
@@ -1,0 +1,168 @@
+"""Prepare Notification endpoints
+
+Revision ID: 2d98674000f3
+Revises: b659816d0a86
+Create Date: 2024-11-01 17:28:20.854410
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+# Revision identifiers, used by Alembic.
+revision = "2d98674000f3"
+down_revision = "b659816d0a86"
+branch_labels = None
+depends_on = None
+
+# Define the new ENUM type with a different name
+notification_type_enum_v2 = ENUM(
+    "TRANSFER_PARTNER_UPDATE",
+    "TRANSFER_DIRECTOR_REVIEW",
+    "INITIATIVE_APPROVED",
+    "INITIATIVE_DA_REQUEST",
+    "SUPPLEMENTAL_REQUESTED",
+    "DIRECTOR_ASSESSMENT",
+    name="notification_type_enum_v2",
+)
+
+# Define enums if they haven’t been created earlier in the migration
+channel_enum = ENUM("EMAIL", "IN_APP", name="channel_enum")
+
+
+def upgrade():
+    op.add_column("notification_message", sa.Column("message", sa.Text, nullable=False))
+
+    op.create_unique_constraint(
+        "uq_user_channel_type",
+        "notification_channel_subscription",
+        ["user_profile_id", "notification_channel_id", "notification_type_id"],
+    )
+
+    # Step 1: Create the new enum type with a different name
+    notification_type_enum_v2.create(op.get_bind(), checkfirst=False)
+
+    # Step 2: Alter the `name` column in `notification_type` to use the new enum
+    with op.batch_alter_table("notification_type") as batch_op:
+        batch_op.alter_column(
+            "name",
+            type_=notification_type_enum_v2,
+            postgresql_using="name::text::notification_type_enum_v2",
+        )
+
+    # Insert rows into the `notification_type` table
+    op.execute(
+        """
+        INSERT INTO notification_type (name, description, email_content, create_user, update_user)
+        VALUES 
+            ('TRANSFER_PARTNER_UPDATE', 'Transfer partner update notification', 'Email content for transfer partner update', 'system', 'system'),
+            ('TRANSFER_DIRECTOR_REVIEW', 'Director review notification', 'Email content for director review', 'system', 'system'),
+            ('INITIATIVE_APPROVED', 'Initiative approved notification', 'Email content for initiative approval', 'system', 'system'),
+            ('INITIATIVE_DA_REQUEST', 'DA request notification', 'Email content for DA request', 'system', 'system'),
+            ('SUPPLEMENTAL_REQUESTED', 'Supplemental requested notification', 'Email content for supplemental request', 'system', 'system'),
+            ('DIRECTOR_ASSESSMENT', 'Director assessment notification', 'Email content for director assessment', 'system', 'system');
+    """
+    )
+
+    # Create the enum if needed
+    channel_enum.create(op.get_bind(), checkfirst=True)
+
+    # Create necessary records in the notification_channel table
+    op.execute(
+        """
+        INSERT INTO notification_channel (channel_name, enabled, subscribe_by_default)
+        VALUES
+            ('EMAIL', TRUE, TRUE),
+            ('IN_APP', TRUE, FALSE)
+        ON CONFLICT DO NOTHING;
+    """
+    )
+
+
+def downgrade():
+    # Remove the unique constraint from `notification_channel_subscription` table
+    op.drop_constraint(
+        "uq_user_channel_type", "notification_channel_subscription", type_="unique"
+    )
+
+    # Drop the `message` column from `notification_message` table
+    op.drop_column("notification_message", "message")
+
+    # Step 1: Revert the `name` column to the original enum type
+    with op.batch_alter_table("notification_type") as batch_op:
+        batch_op.alter_column(
+            "name",
+            type_=sa.Enum(
+                "CREDIT_TRANSFER_CREATED",  # include all original values here
+                "CREDIT_TRANSFER_SIGNED_1OF2",
+                "CREDIT_TRANSFER_SIGNED_2OF2",
+                "CREDIT_TRANSFER_PROPOSAL_REFUSED",
+                "CREDIT_TRANSFER_PROPOSAL_ACCEPTED",
+                "CREDIT_TRANSFER_RECOMMENDED_FOR_APPROVAL",
+                "CREDIT_TRANSFER_RECOMMENDED_FOR_DECLINATION",
+                "CREDIT_TRANSFER_DECLINED",
+                "CREDIT_TRANSFER_APPROVED",
+                "CREDIT_TRANSFER_RESCINDED",
+                "CREDIT_TRANSFER_COMMENT",
+                "CREDIT_TRANSFER_INTERNAL_COMMENT",
+                "PVR_CREATED",
+                "PVR_RECOMMENDED_FOR_APPROVAL",
+                "PVR_RESCINDED",
+                "PVR_PULLED_BACK",
+                "PVR_DECLINED",
+                "PVR_APPROVED",
+                "PVR_COMMENT",
+                "PVR_INTERNAL_COMMENT",
+                "PVR_RETURNED_TO_ANALYST",
+                "DOCUMENT_PENDING_SUBMISSION",
+                "DOCUMENT_SUBMITTED",
+                "DOCUMENT_SCAN_FAILED",
+                "DOCUMENT_RECEIVED",
+                "DOCUMENT_ARCHIVED",
+                "COMPLIANCE_REPORT_DRAFT",
+                "COMPLIANCE_REPORT_SUBMITTED",
+                "COMPLIANCE_REPORT_RECOMMENDED_FOR_ACCEPTANCE_ANALYST",
+                "COMPLIANCE_REPORT_RECOMMENDED_FOR_REJECTION_ANALYST",
+                "COMPLIANCE_REPORT_RECOMMENDED_FOR_ACCEPTANCE_MANAGER",
+                "COMPLIANCE_REPORT_RECOMMENDED_FOR_REJECTION_MANAGER",
+                "COMPLIANCE_REPORT_ACCEPTED",
+                "COMPLIANCE_REPORT_REJECTED",
+                "COMPLIANCE_REPORT_REQUESTED_SUPPLEMENTAL",
+                "EXCLUSION_REPORT_DRAFT",
+                "EXCLUSION_REPORT_SUBMITTED",
+                "EXCLUSION_REPORT_RECOMMENDED_FOR_ACCEPTANCE_ANALYST",
+                "EXCLUSION_REPORT_RECOMMENDED_FOR_REJECTION_ANALYST",
+                "EXCLUSION_REPORT_RECOMMENDED_FOR_ACCEPTANCE_MANAGER",
+                "EXCLUSION_REPORT_RECOMMENDED_FOR_REJECTION_MANAGER",
+                "EXCLUSION_REPORT_ACCEPTED",
+                "EXCLUSION_REPORT_REJECTED",
+                "EXCLUSION_REPORT_REQUESTED_SUPPLEMENTAL",
+                name="notification_type_enum",
+            ),
+            postgresql_using="name::text::notification_type_enum",
+        )
+
+    # Step 2: Drop the new enum type created in the upgrade
+    op.execute("DROP TYPE IF EXISTS notification_type_enum_v2")
+
+    # Delete rows from the `notification_type` table based on the inserted names
+    op.execute(
+        """
+        DELETE FROM notification_type
+        WHERE name IN (
+            'TRANSFER_PARTNER_UPDATE', 
+            'TRANSFER_DIRECTOR_REVIEW', 
+            'INITIATIVE_APPROVED', 
+            'INITIATIVE_DA_REQUEST', 
+            'SUPPLEMENTAL_REQUESTED', 
+            'DIRECTOR_ASSESSMENT'
+        );
+    """
+    )
+    # Remove inserted records if downgrading
+    op.execute(
+        "DELETE FROM notification_channel WHERE channel_name IN ('EMAIL', 'IN_APP')"
+    )
+
+    # Drop the enum if needed
+    channel_enum.drop(op.get_bind(), checkfirst=True)

--- a/backend/lcfs/db/models/notification/NotificationChannelSubscription.py
+++ b/backend/lcfs/db/models/notification/NotificationChannelSubscription.py
@@ -1,13 +1,17 @@
 from lcfs.db.base import BaseModel, Auditable
-from sqlalchemy import Column, Integer, ForeignKey, Boolean
+from sqlalchemy import Column, Integer, ForeignKey, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 
 class NotificationChannelSubscription(BaseModel, Auditable):
     __tablename__ = "notification_channel_subscription"
-    __table_args__ = {
-        "comment": "Represents a user's subscription to notification events"
-    }
+    __table_args__ = (
+        UniqueConstraint(
+            "user_profile_id", "notification_channel_id", "notification_type_id",
+            name="uq_user_channel_type"
+        ),
+        {"comment": "Represents a user's subscription to notification events"},
+    )
 
     notification_channel_subscription_id = Column(
         Integer, primary_key=True, autoincrement=True
@@ -23,10 +27,6 @@ class NotificationChannelSubscription(BaseModel, Auditable):
         Integer, ForeignKey("notification_channel.notification_channel_id")
     )
 
-    user_profile = relationship(
-        "UserProfile", back_populates="notification_channel_subscriptions"
-    )
-    notification_type = relationship("NotificationType")
-    notification_channel = relationship(
-        "NotificationChannel", back_populates="notification_channel_subscriptions"
-    )
+    notification_type = relationship("NotificationType", back_populates="subscriptions")
+    user_profile = relationship("UserProfile", back_populates="notification_channel_subscriptions")
+    notification_channel = relationship("NotificationChannel", back_populates="notification_channel_subscriptions")

--- a/backend/lcfs/db/models/notification/NotificationMessage.py
+++ b/backend/lcfs/db/models/notification/NotificationMessage.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, ForeignKey, Boolean
+from sqlalchemy import Column, Integer, ForeignKey, Boolean, Text
 from sqlalchemy.orm import relationship
 from lcfs.db.base import BaseModel, Auditable
 
@@ -20,6 +20,7 @@ class NotificationMessage(BaseModel, Auditable):
     is_warning = Column(Boolean, default=False)
     is_error = Column(Boolean, default=False)
     is_archived = Column(Boolean, default=False)
+    message = Column(Text, nullable=False)
 
     related_organization_id = Column(
         Integer, ForeignKey("organization.organization_id")
@@ -37,7 +38,9 @@ class NotificationMessage(BaseModel, Auditable):
     # related_document_id = Column(Integer, ForeignKey('document.id'))
     # related_report_id = Column(Integer, ForeignKey('compliance_report.id'))
 
-    related_organization = relationship("Organization")
+    related_organization = relationship(
+        "Organization", back_populates="notification_messages"
+    )
     notification_type = relationship("NotificationType")
     origin_user_profile = relationship(
         "UserProfile",

--- a/backend/lcfs/db/models/notification/NotificationType.py
+++ b/backend/lcfs/db/models/notification/NotificationType.py
@@ -1,81 +1,16 @@
 import enum
 from lcfs.db.base import BaseModel, Auditable
 from sqlalchemy import Column, Integer, Enum, Text
+from sqlalchemy.orm import relationship
 
 
 class NotificationTypeEnum(enum.Enum):
-    CREDIT_TRANSFER_CREATED = "Credit Transfer Proposal Created"
-    CREDIT_TRANSFER_SIGNED_1OF2 = "Credit Transfer Proposal Signed 1/2"
-    CREDIT_TRANSFER_SIGNED_2OF2 = "Credit Transfer Proposal Signed 2/2"
-    CREDIT_TRANSFER_PROPOSAL_REFUSED = "Credit Transfer Proposal Refused"
-    CREDIT_TRANSFER_PROPOSAL_ACCEPTED = "Credit Transfer Proposal Accepted"
-    CREDIT_TRANSFER_RECOMMENDED_FOR_APPROVAL = (
-        "Credit Transfer Proposal Recommended For Approval"
-    )
-    CREDIT_TRANSFER_RECOMMENDED_FOR_DECLINATION = (
-        "Credit Transfer Proposal Recommended For Declination"
-    )
-    CREDIT_TRANSFER_DECLINED = "Credit Transfer Proposal Declined"
-    CREDIT_TRANSFER_APPROVED = "Credit Transfer Proposal Approved"
-    CREDIT_TRANSFER_RESCINDED = "Credit Transfer Proposal Rescinded"
-    CREDIT_TRANSFER_COMMENT = "Credit Transfer Proposal Comment Created Or Updated"
-    CREDIT_TRANSFER_INTERNAL_COMMENT = (
-        "Credit Transfer Proposal Internal Comment Created Or Updated"
-    )
-
-    PVR_CREATED = "PVR Created"
-    PVR_RECOMMENDED_FOR_APPROVAL = "PVR Recommended For Approval"
-    PVR_RESCINDED = "PVR Rescinded"
-    PVR_PULLED_BACK = "PVR Pulled Back"
-    PVR_DECLINED = "PVR Declined"
-    PVR_APPROVED = "PVR Approved"
-    PVR_COMMENT = "PVR Comment Created Or Updated"
-    PVR_INTERNAL_COMMENT = "PVR Internal Comment Created Or Updated"
-    PVR_RETURNED_TO_ANALYST = "PVR Returned to Analyst"
-
-    DOCUMENT_PENDING_SUBMISSION = "Document Pending Submission"
-    DOCUMENT_SUBMITTED = "Document Submitted"
-    DOCUMENT_SCAN_FAILED = "Document Security Scan Failed"
-    DOCUMENT_RECEIVED = "Document Received"
-    DOCUMENT_ARCHIVED = "Document Archived"
-
-    COMPLIANCE_REPORT_DRAFT = "Compliance Report Draft Saved"
-    COMPLIANCE_REPORT_SUBMITTED = "Compliance Report Submitted"
-    COMPLIANCE_REPORT_RECOMMENDED_FOR_ACCEPTANCE_ANALYST = (
-        "Compliance Report Recommended for Acceptance - Analyst"
-    )
-    COMPLIANCE_REPORT_RECOMMENDED_FOR_REJECTION_ANALYST = (
-        "Compliance Report Recommended for Rejection - Analyst"
-    )
-    COMPLIANCE_REPORT_RECOMMENDED_FOR_ACCEPTANCE_MANAGER = (
-        "Compliance Report Recommended for Acceptance - Manager"
-    )
-    COMPLIANCE_REPORT_RECOMMENDED_FOR_REJECTION_MANAGER = (
-        "Compliance Report Recommended for Rejection - Manager"
-    )
-    COMPLIANCE_REPORT_ACCEPTED = "Compliance Report Accepted"
-    COMPLIANCE_REPORT_REJECTED = "Compliance Report Rejected"
-    COMPLIANCE_REPORT_REQUESTED_SUPPLEMENTAL = (
-        "Compliance Report Requested Supplemental"
-    )
-
-    EXCLUSION_REPORT_DRAFT = "Exclusion Report Draft Saved"
-    EXCLUSION_REPORT_SUBMITTED = "Exclusion Report Submitted"
-    EXCLUSION_REPORT_RECOMMENDED_FOR_ACCEPTANCE_ANALYST = (
-        "Exclusion Report Recommended for Acceptance - Analyst"
-    )
-    EXCLUSION_REPORT_RECOMMENDED_FOR_REJECTION_ANALYST = (
-        "Exclusion Report Recommended for Rejection - Analyst"
-    )
-    EXCLUSION_REPORT_RECOMMENDED_FOR_ACCEPTANCE_MANAGER = (
-        "Exclusion Report Recommended for Acceptance - Manager"
-    )
-    EXCLUSION_REPORT_RECOMMENDED_FOR_REJECTION_MANAGER = (
-        "Exclusion Report Recommended for Rejection - Manager"
-    )
-    EXCLUSION_REPORT_ACCEPTED = "Exclusion Report Accepted"
-    EXCLUSION_REPORT_REJECTED = "Exclusion Report Rejected"
-    EXCLUSION_REPORT_REQUESTED_SUPPLEMENTAL = "Exclusion Report Requested Supplemental"
+    TRANSFER_PARTNER_UPDATE = "Transfer partner proposed, declined, rescinded, or signed"
+    TRANSFER_DIRECTOR_REVIEW = "Director recorded/refused"
+    INITIATIVE_APPROVED = "Director approved"
+    INITIATIVE_DA_REQUEST = "DA request"
+    SUPPLEMENTAL_REQUESTED = "Supplemental requested"
+    DIRECTOR_ASSESSMENT = "Director assessment"
 
 
 class NotificationType(BaseModel, Auditable):
@@ -88,4 +23,6 @@ class NotificationType(BaseModel, Auditable):
         nullable=False,
     )
     description = Column(Text, nullable=True)
-    email_content = Column(Text)
+    email_content = Column(Text, nullable=True)
+
+    subscriptions = relationship("NotificationChannelSubscription", back_populates="notification_type")

--- a/backend/lcfs/db/models/organization/Organization.py
+++ b/backend/lcfs/db/models/organization/Organization.py
@@ -108,6 +108,9 @@ class Organization(BaseModel, Auditable, EffectiveDates):
         back_populates="to_organization",
     )
     compliance_reports = relationship("ComplianceReport", back_populates="organization")
+    notification_messages = relationship(
+        "NotificationMessage", back_populates="related_organization"
+    )
 
 
 @event.listens_for(Organization, "before_insert")

--- a/backend/lcfs/tests/notification/test_notification_repo.py
+++ b/backend/lcfs/tests/notification/test_notification_repo.py
@@ -1,0 +1,286 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete 
+from lcfs.web.api.notification.repo import NotificationRepository
+from lcfs.db.models.notification import NotificationMessage, NotificationChannelSubscription
+from lcfs.web.exception.exceptions import DataNotFoundException
+from unittest.mock import AsyncMock, MagicMock
+
+@pytest.fixture
+def mock_db_session():
+    session = AsyncMock(spec=AsyncSession)
+
+    async def mock_execute(*args, **kwargs):
+        mock_result = (
+            MagicMock()
+        )  # Changed to MagicMock since the chained methods are sync
+        mock_result.scalars = MagicMock(return_value=mock_result)
+        mock_result.unique = MagicMock(return_value=mock_result)
+        mock_result.all = MagicMock(return_value=[MagicMock(spec=NotificationMessage)])
+        mock_result.first = MagicMock(return_value=MagicMock(spec=NotificationMessage))
+        return mock_result
+
+    session.execute = mock_execute
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    return session
+
+
+@pytest.fixture
+def notification_repo(mock_db_session):
+    return NotificationRepository(db=mock_db_session)
+
+
+@pytest.mark.anyio
+async def test_create_notification_message(notification_repo, mock_db_session):
+    new_notification_message = MagicMock(spec=NotificationMessage)
+
+    result = await notification_repo.create_notification_message(new_notification_message)
+
+    assert result == new_notification_message
+    mock_db_session.add.assert_called_once_with(new_notification_message)
+    assert mock_db_session.flush.await_count == 1
+    assert mock_db_session.refresh.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_get_notification_message_by_id_found(notification_repo, mock_db_session):
+    notification_id = 1
+    mock_result = MagicMock(spec=NotificationMessage)
+
+    mock_result_chain = MagicMock()
+    mock_result_chain.scalars = MagicMock(return_value=mock_result_chain)
+    mock_result_chain.unique = MagicMock(return_value=mock_result_chain)
+    mock_result_chain.scalar_one  = MagicMock(return_value=mock_result)
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result_chain
+
+    mock_db_session.execute = mock_execute
+
+    result = await notification_repo.get_notification_message_by_id(notification_id)
+
+    assert result == mock_result
+
+@pytest.mark.anyio
+async def test_get_notification_message_by_id_not_found(notification_repo, mock_db_session):
+    mock_result_chain = MagicMock()
+    mock_result_chain.scalars = MagicMock(return_value=mock_result_chain)
+    mock_result_chain.unique = MagicMock(return_value=mock_result_chain)
+    mock_result_chain.scalar_one.side_effect = DataNotFoundException
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result_chain
+
+    mock_db_session.execute = mock_execute
+
+    with pytest.raises(DataNotFoundException):
+        await notification_repo.get_notification_message_by_id(999)
+
+
+@pytest.mark.anyio
+async def test_get_notification_messages_by_user(notification_repo, mock_db_session):
+    mock_notification1 = MagicMock(spec=NotificationMessage)
+    mock_notification1.related_user_id = 1
+    mock_notification1.origin_user_id = 2
+    mock_notification1.notification_message_id = 1
+    mock_notification1.message = "Test message 1"
+
+    mock_notification2 = MagicMock(spec=NotificationMessage)
+    mock_notification2.related_user_id = 1
+    mock_notification2.origin_user_id = 2
+    mock_notification2.notification_message_id = 2
+    mock_notification2.message = "Test message 2"
+
+    mock_result_chain = MagicMock()
+    mock_result_chain.scalars.return_value.all.return_value = [mock_notification1, mock_notification2]
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result_chain
+
+    # Inject the mocked execute method into the session
+    mock_db_session.execute = mock_execute
+
+    result = await notification_repo.get_notification_messages_by_user(1)
+
+    assert len(result) == 2
+    assert result[0].notification_message_id == 1
+    assert result[1].notification_message_id == 2
+
+
+@pytest.mark.anyio
+async def test_get_unread_notification_message_count_by_user_id(notification_repo, mock_db_session):
+    user_id = 1
+    expected_unread_count = 5
+
+    mock_result = MagicMock()
+    mock_result.scalar_one.return_value = expected_unread_count
+
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await notification_repo.get_unread_notification_message_count_by_user_id(user_id)
+
+    assert result == expected_unread_count
+    mock_db_session.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_notification_message(notification_repo, mock_db_session):
+    notification_id = 123
+
+    mock_db_session.execute = AsyncMock()
+    mock_db_session.flush = AsyncMock()
+
+    await notification_repo.delete_notification_message(notification_id)
+
+    assert mock_db_session.execute.call_count == 1
+    executed_query = mock_db_session.execute.call_args[0][0]
+
+    expected_query = delete(NotificationMessage).where(
+        NotificationMessage.notification_message_id == notification_id
+    )
+    assert str(executed_query) == str(expected_query)
+
+    mock_db_session.flush.assert_called_once()
+
+
+
+@pytest.mark.anyio
+async def test_update_notification_message(notification_repo, mock_db_session):
+    mock_notification = MagicMock(spec=NotificationMessage)
+    mock_notification.notification_message_id = 1
+    mock_notification.is_read = False
+    mock_notification.message = "Original message"
+
+    updated_notification = MagicMock(spec=NotificationMessage)
+    updated_notification.notification_message_id = 1
+    updated_notification.is_read = True
+    updated_notification.message = "Updated message"
+
+    mock_db_session.merge.return_value = updated_notification
+    mock_db_session.flush = AsyncMock()
+
+    notification_repo.db = mock_db_session
+
+    result = await notification_repo.update_notification_message(mock_notification)
+
+    mock_db_session.merge.assert_called_once_with(mock_notification)
+    mock_db_session.flush.assert_called_once()
+    assert result == updated_notification
+    assert result.is_read == True
+    assert result.message == "Updated message"
+
+
+@pytest.mark.anyio
+async def test_mark_notification_as_read(notification_repo, mock_db_session):
+    notification_id = 123
+
+    mock_notification = MagicMock(spec=NotificationMessage)
+    mock_notification.notification_message_id = notification_id
+    mock_notification.is_read = False  # Initially, the notification is unread
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_notification
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute = mock_execute
+    mock_db_session.commit = AsyncMock()
+    mock_db_session.refresh = AsyncMock()
+
+    result = await notification_repo.mark_notification_as_read(notification_id)
+
+    assert result.is_read is True  # Verify that is_read was set to True
+    mock_db_session.commit.assert_called_once()  # Ensure commit was called
+    mock_db_session.refresh.assert_called_once_with(mock_notification)  # Check refresh was called
+
+
+@pytest.mark.anyio
+async def test_create_notification_channel_subscription(notification_repo, mock_db_session):
+    new_subscription = MagicMock(spec=NotificationChannelSubscription)
+
+    result = await notification_repo.create_notification_channel_subscription(new_subscription)
+
+    assert result == new_subscription
+    mock_db_session.add.assert_called_once_with(new_subscription)
+    assert mock_db_session.flush.await_count == 1
+    assert mock_db_session.refresh.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_get_notification_channel_subscriptions_by_user(notification_repo, mock_db_session):
+    mock_subscription = MagicMock(spec=NotificationChannelSubscription)
+    mock_subscription.user_profile_id = 1
+    mock_subscription.notification_channel_subscription_id = 1
+    mock_subscription.notification_type_id = 1
+    mock_subscription.notification_channel_id = 1
+    
+    mock_result_chain = MagicMock()
+    mock_result_chain.scalars.return_value.all.return_value = [mock_subscription]
+    
+    async def mock_execute(*args, **kwargs):
+        return mock_result_chain
+
+    mock_db_session.execute = mock_execute
+
+    result = await notification_repo.get_notification_channel_subscriptions_by_user(1)
+
+    assert len(result) == 1
+    assert result[0].user_profile_id == 1
+
+
+@pytest.mark.anyio
+async def test_get_notification_channel_subscriptions_by_id(notification_repo, mock_db_session):
+    subscription_id = 1
+    mock_subscription = MagicMock(spec=NotificationChannelSubscription)
+    mock_subscription.notification_channel_subscription_id = subscription_id
+
+   
+    mock_result_chain = MagicMock()
+    mock_result_chain.scalar_one.return_value = mock_subscription 
+    
+    async def mock_execute(*args, **kwargs):
+        return mock_result_chain
+
+    mock_db_session.execute = mock_execute
+
+    result = await notification_repo.get_notification_channel_subscription_by_id(subscription_id)
+
+    assert result is not None
+    assert result.notification_channel_subscription_id == subscription_id
+
+
+@pytest.mark.anyio
+async def test_update_notification_channel_subscription(notification_repo, mock_db_session):
+    mock_subscription = MagicMock(spec=NotificationChannelSubscription)
+    mock_subscription.notification_channel_subscription_id = 1
+    mock_subscription.is_enabled = True
+    mock_subscription.user_profile_id = 1
+    mock_subscription.notification_type_id= 1
+    mock_subscription.notification_channel_id = 1
+
+    updated_subscription = NotificationChannelSubscription(
+        notification_channel_subscription_id=1,
+        is_enabled=False,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=1
+    )
+
+    mock_db_session.merge.return_value = updated_subscription
+    mock_db_session.flush = AsyncMock()
+
+    notification_repo.db = mock_db_session
+
+    result = await notification_repo.update_notification_channel_subscription(mock_subscription)
+
+    mock_db_session.merge.assert_called_once_with(mock_subscription)
+    mock_db_session.flush.assert_called_once()
+    assert result == updated_subscription
+    assert result.is_enabled is False
+    assert result.notification_type_id == 2
+
+

--- a/backend/lcfs/tests/notification/test_notification_repo.py
+++ b/backend/lcfs/tests/notification/test_notification_repo.py
@@ -52,29 +52,31 @@ async def test_get_notification_message_by_id_found(notification_repo, mock_db_s
 
     mock_result_chain = MagicMock()
     mock_result_chain.scalars = MagicMock(return_value=mock_result_chain)
-    mock_result_chain.unique = MagicMock(return_value=mock_result_chain)
-    mock_result_chain.scalar_one  = MagicMock(return_value=mock_result)
+    mock_result_chain.scalar_one_or_none = MagicMock(return_value=mock_result)
 
     async def mock_execute(*args, **kwargs):
         return mock_result_chain
 
-    mock_db_session.execute = mock_execute
+    mock_db_session.execute = MagicMock(side_effect=mock_execute)
 
     result = await notification_repo.get_notification_message_by_id(notification_id)
 
     assert result == mock_result
+    mock_db_session.execute.assert_called_once()
+    mock_result_chain.scalar_one_or_none.assert_called_once()
+
+
 
 @pytest.mark.anyio
 async def test_get_notification_message_by_id_not_found(notification_repo, mock_db_session):
     mock_result_chain = MagicMock()
     mock_result_chain.scalars = MagicMock(return_value=mock_result_chain)
-    mock_result_chain.unique = MagicMock(return_value=mock_result_chain)
-    mock_result_chain.scalar_one.side_effect = DataNotFoundException
+    mock_result_chain.scalar_one_or_none.side_effect = DataNotFoundException
 
     async def mock_execute(*args, **kwargs):
         return mock_result_chain
 
-    mock_db_session.execute = mock_execute
+    mock_db_session.execute = MagicMock(side_effect=mock_execute)
 
     with pytest.raises(DataNotFoundException):
         await notification_repo.get_notification_message_by_id(999)

--- a/backend/lcfs/tests/notification/test_notification_services.py
+++ b/backend/lcfs/tests/notification/test_notification_services.py
@@ -1,0 +1,443 @@
+from lcfs.web.api.notification.schema import (
+    SubscriptionSchema,
+    NotificationMessageSchema,
+)
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from lcfs.web.api.notification.services import NotificationService
+from lcfs.db.models.notification import (
+    NotificationChannelSubscription,
+    NotificationMessage,
+)
+from lcfs.web.api.notification.repo import NotificationRepository
+
+# Mock common data for reuse
+mock_notification_message = NotificationMessage(
+    notification_message_id=1,
+    message="Test message",
+    is_read=False,
+    origin_user_profile_id=1,
+    related_user_profile_id=2,
+    notification_type_id=1,
+)
+
+mock_notification_channel_subscription = NotificationChannelSubscription(
+    notification_channel_subscription_id=1,
+    is_enabled=True,
+    user_profile_id=1,
+    notification_type_id=1,
+    notification_channel_id=1,
+)
+
+
+@pytest.fixture
+def notification_service():
+    mock_repo = MagicMock(spec=NotificationRepository)
+    service = NotificationService(repo=mock_repo)
+    return service, mock_repo
+
+
+@pytest.mark.anyio
+async def test_get_notifications_by_user_id(notification_service):
+    service, mock_repo = notification_service
+    user_id = 1
+
+    mock_repo.get_notification_messages_by_user = AsyncMock(
+        return_value=[mock_notification_message]
+    )
+
+    result = await service.get_notification_messages_by_user_id(user_id)
+
+    # Assertions
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], NotificationMessageSchema)
+    assert (
+        result[0].notification_message_id
+        == mock_notification_message.notification_message_id
+    )
+
+    # Verify that the mock repository method was called with `user_profile_id` and `is_read=None`
+    mock_repo.get_notification_messages_by_user.assert_called_once_with(
+        user_profile_id=1, is_read=None
+    )
+
+
+@pytest.mark.anyio
+async def test_get_notification_by_id(notification_service):
+    service, mock_repo = notification_service
+    notification_id = 1
+
+    mock_notification = NotificationMessage(
+        notification_message_id=notification_id,
+        message="Test message",
+        is_read=False,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    mock_repo.get_notification_message_by_id = AsyncMock(return_value=mock_notification)
+
+    result = await service.get_notification_message_by_id(notification_id)
+
+    assert isinstance(result, NotificationMessageSchema)
+    assert result.notification_message_id == mock_notification.notification_message_id
+    assert result.message == mock_notification.message
+    assert result.is_read == mock_notification.is_read
+    assert result.origin_user_profile_id == mock_notification.origin_user_profile_id
+    assert result.related_user_profile_id == mock_notification.related_user_profile_id
+    assert result.notification_type_id == mock_notification.notification_type_id
+
+    mock_repo.get_notification_message_by_id.assert_called_once_with(notification_id)
+
+
+@pytest.mark.anyio
+async def test_count_unread_notifications_by_user_id(notification_service):
+    service, mock_repo = notification_service
+    user_id = 1
+    expected_unread_count = 5
+
+    mock_repo.get_unread_notification_message_count_by_user_id = AsyncMock(
+        return_value=expected_unread_count
+    )
+
+    result = await service.count_unread_notifications_by_user_id(user_id)
+
+    assert isinstance(result, int)  # Ensure the return type is an integer
+    assert result == expected_unread_count  # Check that the count is as expected
+
+    mock_repo.get_unread_notification_message_count_by_user_id.assert_awaited_once_with(
+        user_id=user_id
+    )
+
+
+@pytest.mark.anyio
+async def test_mark_notification_as_read(notification_service):
+    service, mock_repo = notification_service
+    notification_id = 1
+
+    mock_notification = NotificationMessage(
+        notification_message_id=notification_id,
+        message="Test message",
+        is_read=False,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    async def mock_mark_as_read(notification_id):
+        mock_notification.is_read = True
+        return mock_notification
+
+    mock_repo.mark_notification_as_read = AsyncMock(side_effect=mock_mark_as_read)
+
+    result = await service.mark_notification_as_read(notification_id)
+
+    assert result is mock_notification
+    assert result.is_read is True
+
+    mock_repo.mark_notification_as_read.assert_awaited_once_with(notification_id)
+
+
+@pytest.mark.anyio
+async def test_create_notification_message(notification_service):
+    service, mock_repo = notification_service
+
+    notification_data = NotificationMessageSchema(
+        message="Test notification",
+        is_read=False,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    created_notification = NotificationMessage(
+        notification_message_id=1,  # Simulate the auto-generated ID
+        message="Test notification",
+        is_read=False,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    mock_repo.create_notification_message = AsyncMock(return_value=created_notification)
+
+    result = await service.create_notification_message(notification_data)
+
+    assert result == created_notification  # Ensure the created notification is returned
+
+    # Extract the argument passed to `create_notification_message`
+    called_args, _ = mock_repo.create_notification_message.await_args
+    passed_notification = called_args[0]
+
+    assert passed_notification.message == created_notification.message
+    assert passed_notification.is_read == created_notification.is_read
+    assert (
+        passed_notification.origin_user_profile_id
+        == created_notification.origin_user_profile_id
+    )
+    assert (
+        passed_notification.related_user_profile_id
+        == created_notification.related_user_profile_id
+    )
+    assert (
+        passed_notification.notification_type_id
+        == created_notification.notification_type_id
+    )
+
+
+@pytest.mark.anyio
+async def test_update_notification_message(notification_service):
+    service, mock_repo = notification_service
+
+    updated_data = NotificationMessageSchema(
+        notification_message_id=1,
+        message="Updated message",
+        is_read=True,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    updated_notification = NotificationMessage(
+        notification_message_id=1,
+        message="Updated message",
+        is_read=True,
+        origin_user_profile_id=1,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    mock_repo.update_notification_message = AsyncMock(return_value=updated_notification)
+
+    result = await service.update_notification(updated_data)
+
+    assert result == updated_notification  # Ensure the updated notification is returned
+
+    # Extract the argument passed to `update_notification_message`
+    called_args, _ = mock_repo.update_notification_message.await_args
+    passed_notification = called_args[0]
+
+    assert (
+        passed_notification.notification_message_id
+        == updated_data.notification_message_id
+    )
+    assert passed_notification.message == updated_data.message
+    assert passed_notification.is_read == updated_data.is_read
+    assert (
+        passed_notification.origin_user_profile_id
+        == updated_data.origin_user_profile_id
+    )
+    assert (
+        passed_notification.related_user_profile_id
+        == updated_data.related_user_profile_id
+    )
+    assert passed_notification.notification_type_id == updated_data.notification_type_id
+
+    mock_repo.update_notification_message.assert_awaited_once_with(passed_notification)
+
+
+@pytest.mark.anyio
+async def test_delete_notification_message(notification_service):
+    service, mock_repo = notification_service
+
+    user_id = 1
+    notification_id = 123
+
+    # Mock the repository's get and delete methods
+    mock_notification_data = NotificationMessage(
+        notification_message_id=notification_id,
+        message="Test notification",
+        is_read=False,
+        origin_user_profile_id=user_id,
+        related_user_profile_id=2,
+        notification_type_id=1,
+    )
+
+    mock_repo.get_notification_message_by_id = AsyncMock(
+        return_value=mock_notification_data
+    )
+    mock_repo.delete_notification_message = AsyncMock()
+
+    await service.delete_notification_message(notification_id)
+
+    mock_repo.get_notification_message_by_id.assert_awaited_once_with(notification_id)
+    mock_repo.delete_notification_message.assert_awaited_once_with(notification_id)
+
+
+@pytest.mark.anyio
+async def test_create_notification_channel_subscription(notification_service):
+    service, mock_repo = notification_service
+
+    subscription_data = SubscriptionSchema(
+        is_enabled=True,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    created_subscription = NotificationChannelSubscription(
+        notification_channel_subscription_id=123,
+        is_enabled=True,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    mock_repo.create_notification_channel_subscription = AsyncMock(
+        return_value=created_subscription
+    )
+
+    result = await service.create_notification_channel_subscription(subscription_data)
+
+    called_args, _ = mock_repo.create_notification_channel_subscription.await_args
+    passed_subscription = called_args[0]
+
+    assert (
+        result.notification_channel_subscription_id
+        == created_subscription.notification_channel_subscription_id
+    )
+    assert result.is_enabled == created_subscription.is_enabled
+    assert result.user_profile_id == created_subscription.user_profile_id
+    assert result.notification_type_id == created_subscription.notification_type_id
+    assert (
+        result.notification_channel_id == created_subscription.notification_channel_id
+    )
+
+    assert passed_subscription.is_enabled == subscription_data.is_enabled
+    assert passed_subscription.user_profile_id == subscription_data.user_profile_id
+    assert (
+        passed_subscription.notification_type_id
+        == subscription_data.notification_type_id
+    )
+    assert (
+        passed_subscription.notification_channel_id
+        == subscription_data.notification_channel_id
+    )
+
+
+@pytest.mark.anyio
+async def test_get_notification_channel_subscriptions_by_user_id(notification_service):
+    service, mock_repo = notification_service
+
+    user_id = 1
+    expected_subscriptions = [
+        NotificationChannelSubscription(
+            notification_channel_subscription_id=123,
+            is_enabled=True,
+            user_profile_id=user_id,
+            notification_type_id=2,
+            notification_channel_id=3,
+        )
+    ]
+
+    mock_repo.get_notification_channel_subscriptions_by_user = AsyncMock(
+        return_value=expected_subscriptions
+    )
+
+    result = await service.get_notification_channel_subscriptions_by_user_id(user_id)
+
+    assert result == expected_subscriptions
+    mock_repo.get_notification_channel_subscriptions_by_user.assert_awaited_once_with(
+        user_id
+    )
+
+
+@pytest.mark.anyio
+async def test_get_notification_channel_subscription_by_id(notification_service):
+    service, mock_repo = notification_service
+
+    subscription_id = 123
+    expected_subscription = NotificationChannelSubscription(
+        notification_channel_subscription_id=subscription_id,
+        is_enabled=True,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    mock_repo.get_notification_channel_subscription_by_id = AsyncMock(
+        return_value=expected_subscription
+    )
+
+    result = await service.get_notification_channel_subscription_by_id(subscription_id)
+
+    assert result == expected_subscription
+    mock_repo.get_notification_channel_subscription_by_id.assert_awaited_once_with(
+        subscription_id
+    )
+
+
+@pytest.mark.anyio
+async def test_update_notification_channel_subscription(notification_service):
+    service, mock_repo = notification_service
+
+    subscription_data = SubscriptionSchema(
+        notification_channel_subscription_id=123,
+        is_enabled=False,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    updated_subscription = NotificationChannelSubscription(
+        notification_channel_subscription_id=123,
+        is_enabled=False,
+        user_profile_id=1,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    mock_repo.update_notification_channel_subscription = AsyncMock(
+        return_value=updated_subscription
+    )
+
+    result = await service.update_notification_channel_subscription(subscription_data)
+
+    called_args, _ = mock_repo.update_notification_channel_subscription.await_args
+    passed_subscription = called_args[0]
+    assert (
+        passed_subscription.notification_channel_subscription_id
+        == updated_subscription.notification_channel_subscription_id
+    )
+    assert passed_subscription.is_enabled == subscription_data.is_enabled
+    assert passed_subscription.user_profile_id == subscription_data.user_profile_id
+    assert (
+        passed_subscription.notification_type_id
+        == subscription_data.notification_type_id
+    )
+    assert (
+        passed_subscription.notification_channel_id
+        == subscription_data.notification_channel_id
+    )
+
+
+@pytest.mark.anyio
+async def test_delete_notification_channel_subscription(notification_service):
+    service, mock_repo = notification_service
+
+    user_id = 1
+    subscription_id = 456
+
+    mock_subscription_data = NotificationChannelSubscription(
+        notification_channel_subscription_id=subscription_id,
+        is_enabled=True,
+        user_profile_id=user_id,
+        notification_type_id=2,
+        notification_channel_id=3,
+    )
+
+    mock_repo.get_notification_channel_subscription_by_id = AsyncMock(
+        return_value=mock_subscription_data
+    )
+    mock_repo.delete_notification_channel_subscription = AsyncMock()
+
+    await service.delete_notification_channel_subscription(subscription_id)
+
+    mock_repo.get_notification_channel_subscription_by_id.assert_awaited_once_with(
+        subscription_id
+    )
+    mock_repo.delete_notification_channel_subscription.assert_awaited_once_with(
+        subscription_id
+    )

--- a/backend/lcfs/tests/notification/test_notification_views.py
+++ b/backend/lcfs/tests/notification/test_notification_views.py
@@ -1,0 +1,259 @@
+from lcfs.web.api.notification.schema import (
+    SubscriptionSchema,
+    NotificationMessageSchema,
+)
+from lcfs.web.api.notification.services import NotificationService
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from lcfs.db.models.user.Role import RoleEnum
+
+# Mock data for reuse
+mock_notification = NotificationMessageSchema(
+    notification_message_id=1,
+    message="Test message",
+    is_read=False,
+    origin_user_profile_id=1,
+    related_user_profile_id=2,
+    notification_type_id=1,
+)
+
+# Mock data for subscription
+mock_subscription = SubscriptionSchema(
+    notification_channel_subscription_id=1,
+    is_enabled=True,
+    notification_channel_id=1,
+    user_profile_id=1,
+    notification_type_id=1,
+)
+
+
+@pytest.fixture
+def mock_notification_service():
+    return MagicMock(spec=NotificationService)
+
+
+@pytest.mark.anyio
+async def test_mark_notification_as_read(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.update_notification"
+    ) as mock_update_notification:
+        # Set the mock response data to include all required fields in camelCase
+        mock_update_notification.return_value = {
+            "notificationMessageId": 1,
+            "isRead": True,
+            "message": "Mark as read test",
+            "originUserProfileId": 1,
+            "relatedUserProfileId": 1,
+            "notificationTypeId": 1,
+        }
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for("save_notification")
+
+        payload = {
+            "notification_message_id": 1,
+            "is_read": True,
+            "message": "Mark as read test",
+            "origin_user_profile_id": 1,
+            "related_user_profile_id": 1,
+            "notification_type_id": 1,
+        }
+
+        response = await client.post(url, json=payload)
+
+        assert response.status_code == 200
+        response_data = response.json()
+
+        assert response_data["notificationMessageId"] == 1
+        assert response_data["isRead"] is True
+        assert response_data["message"] == "Mark as read test"
+        assert response_data["originUserProfileId"] == 1
+        assert response_data["relatedUserProfileId"] == 1
+        assert response_data["notificationTypeId"] == 1
+
+        # Verify that the update_notification method was called with expected payload
+        called_schema = NotificationMessageSchema(**payload)
+        mock_update_notification.assert_called_once_with(called_schema)
+
+
+@pytest.mark.anyio
+async def test_create_notification(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.create_notification_message"
+    ) as mock_create_notification:
+        notification_data = {
+            "message": "New notification",
+            "notification_type_id": 1,
+            "related_user_profile_id": 1,
+            "related_organization_id": 1,
+        }
+
+        mock_create_notification.return_value = notification_data
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for("save_notification")
+
+        response = await client.post(url, json=notification_data)
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "New notification"
+        mock_create_notification.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_notification(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.delete_notification_message",
+        return_value=None,
+    ) as mock_delete_notification:
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        mock_delete_notification.return_value = {
+            "message": "Notification Message deleted successfully"
+        }
+
+        url = fastapi_app.url_path_for("save_notification")  # No notification_id here
+
+        response = await client.post(
+            url, json={"notification_message_id": 1, "deleted": True}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Notification Message deleted successfully"
+        mock_delete_notification.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_get_notifications_by_id(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.get_notification_message_by_id"
+    ) as mock_get_notifications:
+        mock_get_notifications.return_value = mock_notification.model_dump(
+            by_alias=True
+        )
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for(
+            "get_notification_message_by_id", notification_id=1
+        )
+
+        response = await client.get(url)
+
+        assert response.status_code == 200
+        assert response.json() == mock_notification.model_dump(by_alias=True)
+        mock_get_notifications.assert_called_once_with(notification_id=1)
+
+
+@pytest.mark.anyio
+async def test_get_notification_channel_subscription_by_id(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.get_notification_channel_subscription_by_id"
+    ) as mock_get_subscription:
+        mock_get_subscription.return_value = mock_subscription.model_dump(by_alias=True)
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for(
+            "get_notification_channel_subscription_by_id",
+            notification_channel_subscription_id=1,
+        )
+
+        response = await client.get(url)
+
+        assert response.status_code == 200
+        assert response.json() == mock_subscription.model_dump(by_alias=True)
+        mock_get_subscription.assert_called_once_with(
+            notification_channel_subscription_id=1
+        )
+
+
+@pytest.mark.anyio
+async def test_create_subscription(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.create_notification_channel_subscription"
+    ) as mock_create_subscription:
+        subscription_data = {
+            "is_enabled": True,
+            "notification_channel_id": 1,
+            "user_profile_id": 1,
+            "notification_type_id": 1,
+        }
+
+        mock_create_subscription.return_value = subscription_data
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for("save_subscription")
+
+        response = await client.post(url, json=subscription_data)
+
+        assert response.status_code == 200
+
+        assert response.json()["isEnabled"] is True
+        mock_create_subscription.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_subscription(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.delete_notification_channel_subscription",
+        return_value=None,
+    ) as mock_delete_subscription:
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        mock_delete_subscription.return_value = {
+            "message": "Notification Subscription deleted successfully"
+        }
+
+        subscription_data = {"notification_channel_subscription_id": 1, "deleted": True}
+
+        url = fastapi_app.url_path_for("save_subscription")
+
+        response = await client.post(url, json=subscription_data)
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Notification Subscription deleted successfully"
+        mock_delete_subscription.assert_called_once_with(1)
+
+
+@pytest.mark.anyio
+async def test_update_subscription(client, fastapi_app, set_mock_user):
+    with patch(
+        "lcfs.web.api.notification.views.NotificationService.update_notification_channel_subscription"
+    ) as mock_update_subscription:
+        updated_subscription_data = {
+            "notification_channel_subscription_id": 1,
+            "is_enabled": False,
+            "notification_channel_id": 1,
+            "user_profile_id": 1,
+            "notification_type_id": 1,
+        }
+
+        mock_update_subscription.return_value = updated_subscription_data
+
+        set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
+
+        url = fastapi_app.url_path_for("save_subscription")
+
+        response = await client.post(url, json=updated_subscription_data)
+
+        assert response.status_code == 200
+        assert response.json()["isEnabled"] is False
+        mock_update_subscription.assert_called_once_with(
+            SubscriptionSchema(**updated_subscription_data)
+        )

--- a/backend/lcfs/web/api/notification/repo.py
+++ b/backend/lcfs/web/api/notification/repo.py
@@ -77,7 +77,7 @@ class NotificationRepository:
             (NotificationMessage.notification_message_id == notification_id)
         )
         result = await self.db.execute(query)
-        notification = result.scalar_one()
+        notification = result.scalar_one_or_none()
 
         if not notification:
             raise DataNotFoundException(

--- a/backend/lcfs/web/api/notification/repo.py
+++ b/backend/lcfs/web/api/notification/repo.py
@@ -1,0 +1,229 @@
+from lcfs.db.models.notification import (
+    NotificationChannelSubscription,
+    NotificationMessage,
+)
+from lcfs.web.api.notification.schema import NotificationMessageSchema
+import structlog
+from datetime import date
+from typing import List, Dict, Any, Optional, Union
+from fastapi import Depends
+from lcfs.db.dependencies import get_async_db_session
+from lcfs.web.exception.exceptions import DataNotFoundException
+
+from sqlalchemy import and_, delete, or_, select, func, text, update, distinct
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, contains_eager, selectinload
+from sqlalchemy.exc import NoResultFound
+from fastapi import HTTPException
+
+from lcfs.web.core.decorators import repo_handler
+
+logger = structlog.get_logger(__name__)
+
+
+class NotificationRepository:
+    def __init__(self, db: AsyncSession = Depends(get_async_db_session)):
+        self.db = db
+
+    @repo_handler
+    async def create_notification_message(
+        self, notification_message: NotificationMessage
+    ) -> NotificationMessage:
+        """
+        Create a new notification message
+        """
+        self.db.add(notification_message)
+        await self.db.flush()
+        await self.db.refresh(
+            notification_message,
+            [
+                "related_organization",
+                "origin_user_profile_id",
+                "related_user_profile_id",
+                "notification_type",
+            ],
+        )
+        # await self.db.refresh(notification_message)
+        return notification_message
+
+    @repo_handler
+    async def get_notification_messages_by_user(
+        self, user_profile_id: int, is_read: Optional[bool] = None
+    ) -> list[NotificationMessage]:
+        """
+        Retrieve all notification messages for a user
+        """
+        # Start building the query
+        query = select(NotificationMessage).where(
+            NotificationMessage.related_user_profile_id == user_profile_id
+        )
+
+        # Apply additional filter for `is_read` if provided
+        if is_read is not None:
+            query = query.where(NotificationMessage.is_read == is_read)
+
+        # Execute the query and retrieve the results
+        result = await self.db.execute(query)
+        return result.scalars().all()
+
+    @repo_handler
+    async def get_notification_message_by_id(
+        self, notification_id: int
+    ) -> Optional[NotificationMessage]:
+        """
+        Retrieve notification message by id
+        """
+        query = select(NotificationMessage).where(
+            (NotificationMessage.notification_message_id == notification_id)
+        )
+        result = await self.db.execute(query)
+        notification = result.scalar_one()
+
+        if not notification:
+            raise DataNotFoundException(
+                f"notification id '{notification_id}' not found"
+            )
+
+        return notification
+
+    @repo_handler
+    async def get_unread_notification_message_count_by_user_id(
+        self, user_id: int
+    ) -> int:
+        """
+        Retrieve count of unread notification message by user id
+        """
+        query = select(func.count(NotificationMessage.notification_message_id)).where(
+            NotificationMessage.related_user_profile_id == user_id,
+            NotificationMessage.is_read == False,
+        )
+
+        result = await self.db.execute(query)
+        count = result.scalar_one()
+
+        return count
+
+    @repo_handler
+    async def update_notification_message(self, notification) -> NotificationMessage:
+        """
+        Update a notification message
+        """
+        merged_notification = await self.db.merge(notification)
+        await self.db.flush()
+
+        return merged_notification
+
+    @repo_handler
+    async def delete_notification_message(self, notification_id: int):
+        """
+        Delete a notification_message by id
+        """
+        query = delete(NotificationMessage).where(
+            NotificationMessage.notification_message_id == notification_id
+        )
+        await self.db.execute(query)
+        await self.db.flush()
+
+    @repo_handler
+    async def mark_notification_as_read(
+        self, notification_id
+    ) -> Optional[NotificationMessage]:
+        """
+        Mark a notification message as read
+        """
+        query = select(NotificationMessage).where(
+            NotificationMessage.notification_message_id == notification_id
+        )
+        result = await self.db.execute(query)
+        notification = result.scalar_one_or_none()
+
+        if notification:
+            notification.is_read = True
+            await self.db.commit()
+            await self.db.refresh(notification)
+
+        return notification
+
+    @repo_handler
+    async def create_notification_channel_subscription(
+        self, notification_channel_subscription: NotificationChannelSubscription
+    ) -> NotificationChannelSubscription:
+        """
+        Create a new notification channel subscription
+        """
+        self.db.add(notification_channel_subscription)
+        await self.db.flush()
+        await self.db.refresh(
+            notification_channel_subscription,
+            ["notification_type", "user_profile", "notification_channel"],
+        )
+        return notification_channel_subscription
+
+    @repo_handler
+    async def get_notification_channel_subscriptions_by_user(
+        self, user_profile_id: int
+    ) -> Optional[NotificationChannelSubscription]:
+        """
+        Retrieve channel subscriptions for a user
+        """
+        query = select(NotificationChannelSubscription).where(
+            NotificationChannelSubscription.user_profile_id == user_profile_id
+        )
+        result = await self.db.execute(query)
+        subscriptions = result.scalars().all()
+
+        if not subscriptions:
+            raise DataNotFoundException(
+                f"Channel subscriptions not found for user id: '{user_profile_id}'"
+            )
+
+        return subscriptions
+
+    @repo_handler
+    async def get_notification_channel_subscription_by_id(
+        self, notification_channel_subscription_id: int
+    ) -> Optional[NotificationChannelSubscription]:
+        """
+        Retrieve a channel subscription by id
+        """
+        query = select(NotificationChannelSubscription).where(
+            (
+                NotificationChannelSubscription.notification_channel_subscription_id
+                == notification_channel_subscription_id
+            )
+        )
+        result = await self.db.execute(query)
+        subscription = result.scalar_one()
+
+        if not subscription:
+            raise DataNotFoundException(
+                f"Channel subscription with id '{notification_channel_subscription_id}'not found."
+            )
+
+        return subscription
+
+    @repo_handler
+    async def update_notification_channel_subscription(
+        self, notification_channel_subscription: NotificationChannelSubscription
+    ) -> NotificationChannelSubscription:
+        """
+        Update a notification chanel subscription
+        """
+        merged_subscription = await self.db.merge(notification_channel_subscription)
+        await self.db.flush()
+
+        return merged_subscription
+
+    @repo_handler
+    async def delete_notification_channel_subscription(
+        self, notification_channel_subscription_id: int
+    ):
+        """
+        Delete a channel subscription by id
+        """
+        query = delete(NotificationChannelSubscription).where(
+            NotificationChannelSubscription.notification_channel_subscription_id
+            == notification_channel_subscription_id
+        )
+        await self.db.execute(query)
+        await self.db.flush()

--- a/backend/lcfs/web/api/notification/schema.py
+++ b/backend/lcfs/web/api/notification/schema.py
@@ -3,12 +3,44 @@ from typing import Optional
 from lcfs.web.api.base import BaseSchema
 
 
-class NotificationMessageRequest(BaseSchema):
-    is_read: bool
-    is_archived: bool
+class NotificationMessageSchema(BaseSchema):
+    notification_message_id: Optional[int] = None
+    is_read: Optional[bool] = False
+    is_archived: Optional[bool] = False
+    is_warning: Optional[bool] = False
+    is_error: Optional[bool] = False
+    message: Optional[str] = None
+    related_organization_id: Optional[int] = None
+    origin_user_profile_id: Optional[int] = None
+    related_user_profile_id: Optional[int] = None
+    notification_type_id: Optional[int] = None
+    deleted: Optional[bool] = None
+
+class NotificationCountSchema(BaseSchema):
+    count: int
+
+class DeleteNotificationMessageSchema(BaseSchema):
+    notification_message_id: int
+    deleted: bool
 
 
-class NotificationChannelSubscriptionRequest(BaseSchema):
-    is_enabled: bool
-    channel_id: int
-    notification_type_id: int
+class DeleteNotificationMessageResponseSchema(BaseSchema):
+    message: str
+
+
+class SubscriptionSchema(BaseSchema):
+    notification_channel_subscription_id: Optional[int] = None
+    is_enabled: Optional[bool] = True
+    notification_channel_id: Optional[int] = None
+    user_profile_id: Optional[int]= None
+    notification_type_id: Optional[int] = None
+    deleted: Optional[bool] = None
+
+
+class DeleteSubscriptionSchema(BaseSchema):
+    notification_channel_subscription_id: int
+    deleted: bool
+
+
+class DeleteNotificationChannelSubscriptionResponseSchema(BaseSchema):
+    message: str

--- a/backend/lcfs/web/api/notification/services.py
+++ b/backend/lcfs/web/api/notification/services.py
@@ -1,0 +1,176 @@
+from typing import Optional
+from lcfs.db.models.notification import (
+    NotificationChannelSubscription,
+    NotificationMessage,
+)
+from lcfs.web.api.notification.schema import (
+    SubscriptionSchema,
+    NotificationMessageSchema,
+)
+from lcfs.web.exception.exceptions import DataNotFoundException
+import structlog
+import math
+from fastapi import Depends
+from lcfs.web.api.notification.repo import NotificationRepository
+from lcfs.web.core.decorators import service_handler
+
+logger = structlog.get_logger(__name__)
+
+
+class NotificationService:
+    def __init__(
+        self, repo: NotificationRepository = Depends(NotificationRepository)
+    ) -> None:
+        self.repo = repo
+
+    @service_handler
+    async def get_notification_messages_by_user_id(
+        self, user_id: int, is_read: Optional[bool] = None
+    ):
+        """
+        Retrieve all notifications for a given user.
+        Optionally filter by read status.
+        """
+        notification_models = await self.repo.get_notification_messages_by_user(
+            user_profile_id=user_id, is_read=is_read
+        )
+
+        return [
+            NotificationMessageSchema.model_validate(message)
+            for message in notification_models
+        ]
+
+    @service_handler
+    async def get_notification_message_by_id(self, notification_id: int):
+        """
+        Retrieve a specific notification by ID.
+        """
+        notification = await self.repo.get_notification_message_by_id(notification_id)
+
+        return NotificationMessageSchema.model_validate(notification)
+
+    @service_handler
+    async def count_unread_notifications_by_user_id(self, user_id: int):
+        """
+        Retrieve notification count by user id
+        """
+        return await self.repo.get_unread_notification_message_count_by_user_id(
+            user_id=user_id
+        )
+
+    @service_handler
+    async def mark_notification_as_read(self, notification_id: int):
+        """
+        Mark a specific notification as read.
+        """
+        notification = await self.repo.mark_notification_as_read(notification_id)
+        if not notification:
+            raise DataNotFoundException(
+                f"Notification with ID {notification_id} not found."
+            )
+        return notification
+
+    @service_handler
+    async def create_notification_message(
+        self, notification_data: NotificationMessageSchema
+    ):
+        """
+        Create a new notification message.
+        """
+        notification = NotificationMessage(
+            **notification_data.model_dump(exclude={"deleted"})
+        )
+        return await self.repo.create_notification_message(notification)
+
+    @service_handler
+    async def update_notification(self, notification_data: NotificationMessageSchema):
+        """
+        Update an existing notification.
+        """
+        notification = NotificationMessage(
+            **notification_data.model_dump(exclude={"deleted"})
+        )
+        return await self.repo.update_notification_message(notification)
+
+    @service_handler
+    async def delete_notification_message(self, notification_id: int):
+        """
+        Delete a notification.
+        """
+        # Fetch the notification to confirm it exists
+        notification = await self.repo.get_notification_message_by_id(notification_id)
+
+        if notification:
+            await self.repo.delete_notification_message(notification_id)
+            logger.info(f"Notification with ID {notification_id} has been deleted.")
+        else:
+            raise DataNotFoundException(f"Notification with ID {notification_id}.")
+
+    @service_handler
+    async def create_notification_channel_subscription(
+        self, subscription_data: SubscriptionSchema
+    ):
+        """
+        Create a new notification channel subscription.
+        """
+        subscription = NotificationChannelSubscription(
+            **subscription_data.model_dump(exclude={"deleted"})
+        )
+        created_subscription = await self.repo.create_notification_channel_subscription(
+            subscription
+        )
+
+        # Convert the SQLAlchemy model instance to the Pydantic model
+        return SubscriptionSchema.model_validate(created_subscription)
+
+    @service_handler
+    async def get_notification_channel_subscriptions_by_user_id(self, user_id: int):
+        """
+        Retrieve all notification channel subscriptions for a user.
+        """
+        return await self.repo.get_notification_channel_subscriptions_by_user(user_id)
+
+    @service_handler
+    async def get_notification_channel_subscription_by_id(
+        self, notification_channel_subscription_id: int
+    ):
+        """
+        Retrieve a specific notification channel subscription by ID.
+        """
+        return await self.repo.get_notification_channel_subscription_by_id(
+            notification_channel_subscription_id
+        )
+
+    @service_handler
+    async def update_notification_channel_subscription(
+        self, subscription_data: SubscriptionSchema
+    ):
+        """
+        Update an existing notification channel subscription.
+        """
+        subscription = NotificationChannelSubscription(
+            **subscription_data.model_dump(exclude={"deleted"})
+        )
+        return await self.repo.update_notification_channel_subscription(subscription)
+
+    @service_handler
+    async def delete_notification_channel_subscription(
+        self, subscription_id: int
+    ):
+        """
+        Delete a notification channel subscription.
+        """
+        # Ensure the subscription exists
+        subscription = await self.repo.get_notification_channel_subscription_by_id(
+            subscription_id
+        )
+        if not subscription:
+            raise DataNotFoundException(
+                f"Subscription with ID {subscription_id} not found."
+            )
+
+        # Proceed to delete if it exists and belongs to the user
+        await self.repo.delete_notification_channel_subscription(subscription_id)
+        logger.info(
+            f"Deleted notification channel subscription {subscription_id}."
+        )

--- a/backend/lcfs/web/api/notification/views.py
+++ b/backend/lcfs/web/api/notification/views.py
@@ -1,123 +1,175 @@
-from typing import Annotated
-from fastapi import APIRouter, Depends
-from fastapi.responses import Response
-from lcfs.web.api.base import EntityResponse
-from lcfs.web.api.notification.schema import (
-    NotificationChannelSubscriptionRequest,
-    NotificationMessageRequest,
-)
-from starlette import status
-from sqlalchemy.ext.asyncio import AsyncSession
-from lcfs.db.dependencies import get_async_db_session
-from lcfs.db.models import NotificationMessage, UserProfile
+"""
+Notification endpoints
+"""
 
-from sqlalchemy import select, update
+from typing import Union, List
+from lcfs.web.exception.exceptions import DataNotFoundException
+import structlog
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Query
+from lcfs.db import dependencies
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.web.api.notification.schema import (
+    DeleteNotificationChannelSubscriptionResponseSchema,
+    DeleteNotificationMessageResponseSchema,
+    DeleteSubscriptionSchema,
+    DeleteNotificationMessageSchema,
+    SubscriptionSchema,
+    NotificationMessageSchema,
+    NotificationCountSchema,
+)
+from lcfs.web.api.notification.services import NotificationService
+from lcfs.web.core.decorators import view_handler
+from starlette import status
+
 
 router = APIRouter()
+logger = structlog.get_logger(__name__)
 
 
-# all routes should have a User dependency
-
-
-@router.get("/", status_code=status.HTTP_200_OK)
-async def get_notifications(
-    user,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    response_model=EntityResponse,
-) -> EntityResponse:
-    # get all notifications of a user
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # return db.execute(select(NotificationMessage).where(NotificationMessage.user_id == user.user_id))
-    return
-
-
-@router.get("/{notification_id}", status_code=status.HTTP_200_OK)
-async def get_notification(
-    user,
-    notification_id: int,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    response_model=EntityResponse,
-) -> EntityResponse:
-    # get a single notitification of a user
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # get notification by id
-    # return db.execute(select(NotificationMessage).where(NotificationMessage.notification_id == notification_id))
-    return
-
-
-@router.put("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def update_notification(
-    user,
-    notification_id: int,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    reqeust: NotificationMessageRequest,
-    response_model=EntityResponse,
-) -> Response:
-    # update a notification of a user
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # return db.execute(update(NotificationMessage).where(NotificationMessage.notification_id == notification_id).values())
-    return Response(content=None, status_code=status.HTTP_204_NO_CONTENT)
-
-
-@router.get("/", status_code=status.HTTP_200_OK)
-async def get_notifications_channel_subscriptions(
-    user,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    response_model=EntityResponse,
-) -> Response:
-    # get all notification subscriptions
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # return db.execute(select(NotificationChannelSubscription).where(NotificationChannelSubscription.user_id == user.user_id))
-    return
-
-
-@router.get("/{notification_channel_subscription_id}", status_code=status.HTTP_200_OK)
-async def get_notification_channel_subscription(
-    user,
-    notification_channel_subscription_id: int,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    response_model=EntityResponse,
-) -> EntityResponse:
-    # get a single notification subscriptions
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # get notification subscription by id
-    # return db.execute(select(NotificationChannelSubscription).where(NotificationChannelSubscription.notification_channel_subscription_id == notification_channel_subscription_id))
-    return
-
-
-@router.put(
-    "/{notification_channel_subscription_id}", status_code=status.HTTP_204_NO_CONTENT
+@router.get(
+    "/", response_model=List[NotificationMessageSchema], status_code=status.HTTP_200_OK
 )
-async def update_notification_channel_subscription(
-    user,
-    notification_channel_subscription_id: int,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    request: NotificationChannelSubscriptionRequest,
-    response_model=EntityResponse,
-) -> Response:
-    # update a notification subscription of a user
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # return db.execute(update(NotificationChannelSubscription).where(NotificationChannelSubscription.notification_channel_subscription_id == notification_channel_subscription_id).values())
-    return Response(content=None, status_code=status.HTTP_204_NO_CONTENT)
+@view_handler([RoleEnum.GOVERNMENT])
+async def get_notification_messages_by_user_id(
+    request: Request,
+    related_user_profile_id: int,
+    is_read: bool = None,
+    service: NotificationService = Depends(),
+):
+    """
+    Retrieve all notifications of a user
+    """
+
+    return await service.get_notification_messages_by_user_id(
+        user_id=related_user_profile_id, is_read=is_read
+    )
 
 
-@router.delete(
-    "/{notification_channel_subscription_id}", status_code=status.HTTP_204_NO_CONTENT
+@router.get(
+    "/count",
+    response_model=NotificationCountSchema,
+    status_code=status.HTTP_200_OK,
 )
-async def delete_notification_channel_subscription(
-    user,
+@view_handler([RoleEnum.GOVERNMENT])
+async def get_unread_notifications(
+    request: Request,
+    user_id: int,
+    service: NotificationService = Depends()
+):
+    """
+    Retrieve counter for unread notifications by user id
+    """
+    # Ensure that user_id is being parsed correctly
+    if not isinstance(user_id, int):
+        raise HTTPException(status_code=422, detail="Invalid user_id; must be an integer.")
+
+    count = await service.count_unread_notifications_by_user_id(user_id=user_id)
+    return NotificationCountSchema(count=count)
+
+
+@router.get(
+    "/{notification_id}",
+    response_model=NotificationMessageSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT])
+async def get_notification_message_by_id(
+    request: Request, notification_id: int, service: NotificationService = Depends()
+):
+    """
+    Retrieve a single notification by ID
+    """
+
+    return await service.get_notification_message_by_id(notification_id=notification_id)
+
+
+@router.post(
+    "/save",
+    response_model=Union[
+        NotificationMessageSchema, DeleteNotificationMessageResponseSchema
+    ],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT])
+async def save_notification(
+    request: Request,
+    request_data: Union[
+        NotificationMessageSchema, DeleteNotificationMessageSchema
+    ] = Body(...),
+    service: NotificationService = Depends(),
+):
+    """
+    Save a single notification
+    """
+    notification_id = request_data.notification_message_id
+    if request_data.deleted:
+        try:
+            await service.delete_notification_message(notification_id)
+            return DeleteNotificationMessageResponseSchema(
+                message="Notification Message deleted successfully"
+            )
+        except DataNotFoundException as e:
+            raise HTTPException(status_code=404, detail=str(e))
+    elif notification_id:
+        return await service.update_notification(request_data)
+    else:
+        return await service.create_notification_message(request_data)
+
+
+@router.get(
+    "/subscriptions",
+    response_model=SubscriptionSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT])
+async def get_notifications_channel_subscriptions_by_user_id(
+    request: Request, user_id, service: NotificationService = Depends()
+):
+
+    return await service.get_notification_channel_subscriptions_by_user_id(
+        user_id=user_id
+    )
+
+
+@router.get(
+    "/subscriptions/{notification_channel_subscription_id}",
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT])
+async def get_notification_channel_subscription_by_id(
+    request: Request,
     notification_channel_subscription_id: int,
-    db: Annotated[AsyncSession, Depends(get_async_db_session)],
-    response_model=EntityResponse,
-) -> Response:
-    # delete a notification subscription of a user
-    # check for user auth. raise otherwise
-    # raise HTTPException()
-    # return db.execute(delete(NotificationChannelSubscription).where(NotificationChannelSubscription.notification_channel_subscription_id == notification_channel_subscription_id))
-    return Response(content=None, status_code=status.HTTP_204_NO_CONTENT)
+    service: NotificationService = Depends(),
+):
+
+    return await service.get_notification_channel_subscription_by_id(
+        notification_channel_subscription_id=notification_channel_subscription_id
+    )
+
+
+@router.post(
+    "/subscriptions/save",
+    response_model=Union[
+        SubscriptionSchema, DeleteNotificationChannelSubscriptionResponseSchema
+    ],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT])
+async def save_subscription(
+    request: Request,
+    request_data: Union[SubscriptionSchema, DeleteSubscriptionSchema] = Body(...),
+    service: NotificationService = Depends(),
+):
+    subscription_id = request_data.notification_channel_subscription_id
+    if request_data.deleted:
+        try:
+            await service.delete_notification_channel_subscription(subscription_id)
+            return DeleteNotificationChannelSubscriptionResponseSchema(
+                message="Notification Subscription deleted successfully"
+            )
+        except DataNotFoundException as e:
+            raise HTTPException(status_code=404, detail=str(e))
+    elif subscription_id:
+        return await service.update_notification_channel_subscription(request_data)
+    else:
+        return await service.create_notification_channel_subscription(request_data)

--- a/backend/lcfs/web/core/decorators.py
+++ b/backend/lcfs/web/core/decorators.py
@@ -197,7 +197,7 @@ def view_handler(required_roles: List[Union[RoleEnum, Literal["*"]]]):
                     exc_info=e,
                 )
                 if e.status_code == 403:
-                    raise HTTPException(status_code=404, detail="Not Found")
+                    raise HTTPException(status_code=403, detail="Forbidden resource")
                 raise
             except DataNotFoundException:
                 raise HTTPException(status_code=404, detail="Not Found")


### PR DESCRIPTION
Include the following endpoints:

Description: Get all Notifications by User ID
GET /api/notifications/

Description: Get a Notification by ID
GET /api/notifications/{notification_id}

Description: Get Unread Notifications
GET /api/notifications/count

Description: Save a Notification
POST /api/notifications/save

Description: Get Notification Channel Subscriptions by User ID
GET /api/notifications/subscriptions

Description: Get Notifications Channel Subscriptions By ID
GET /api/notifications/subscriptions/{notification_channel_subscription_id}

Description: Save a Notification Channel Subscription
POST /api/notifications/subscriptions/save


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=85582754&issue=bcgov%7Clcfs%7C1149)