### PR TITLE
LCFS-1197: BUG IDIR users can see compliance reports in "draft' status

### DIFF
--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -352,9 +352,16 @@ class ComplianceReportRepository:
             )
             .where(and_(*conditions))
             .group_by(ComplianceReport.compliance_report_group_uuid)
-            .subquery()
         )
 
+        if not organization_id:
+            subquery = subquery.join(
+                ComplianceReportStatus,
+                ComplianceReport.current_status_id
+                == ComplianceReportStatus.compliance_report_status_id,
+            )
+
+        subquery = subquery.subquery()
         # Join the main ComplianceReport table with the subquery to get the latest version per group
         query = (
             select(ComplianceReport)


### PR DESCRIPTION
- IDIR users are not allowed to see `Draft` compliance reports
- BCEID users are not allowed to se internal status.


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=86543645&issue=bcgov%7Clcfs%7C1197)