### PR TITLE
feat: Add can_sign to compliance summary

### DIFF
--- a/backend/lcfs/tests/compliance_report/conftest.py
+++ b/backend/lcfs/tests/compliance_report/conftest.py
@@ -195,6 +195,7 @@ def compliance_report_summary_schema(
         version=1,
         is_locked=False,
         quarter=None,
+        can_sign=False
     ):
 
         return ComplianceReportSummarySchema(
@@ -206,6 +207,7 @@ def compliance_report_summary_schema(
             version=version,
             is_locked=is_locked,
             quarter=quarter,
+            can_sign=can_sign
         )
 
     return _create_compliance_report_summary

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, AsyncMock
+
 import pytest
 from datetime import datetime
 import uuid
@@ -927,54 +929,6 @@ async def test_get_issued_compliance_units_not_found(compliance_report_repo):
 
 
 @pytest.mark.anyio
-async def test_calculate_fuel_quantities_success_not_fossil_derived(
-    compliance_report_repo,
-    compliance_reports,
-    fuel_supplies,
-):
-    # Filter non-fossil-derived fuel supplies
-    non_fossil_fuel_supplies = [
-        fs for fs in fuel_supplies if not fs.fuel_type.fossil_derived
-    ]
-
-    # Mock the method
-    compliance_report_repo.fuel_supply_repo.get_effective_fuel_supplies.return_value = (
-        non_fossil_fuel_supplies
-    )
-
-    result = await compliance_report_repo.calculate_fuel_quantities(
-        compliance_report_id=compliance_reports[0].compliance_report_id,
-        effective_fuel_supplies=non_fossil_fuel_supplies,
-        fossil_derived=False,
-    )
-
-    assert result == {"gasoline": 1.0, "diesel": 1.0}
-
-
-@pytest.mark.anyio
-async def test_calculate_fuel_quantities_success_fossil_derived(
-    compliance_report_repo,
-    compliance_reports,
-    fuel_supplies,
-):
-    # Filter fossil-derived fuel supplies
-    fossil_fuel_supplies = [fs for fs in fuel_supplies if fs.fuel_type.fossil_derived]
-
-    # Mock the method
-    compliance_report_repo.fuel_supply_repo.get_effective_fuel_supplies.return_value = (
-        fossil_fuel_supplies
-    )
-
-    result = await compliance_report_repo.calculate_fuel_quantities(
-        compliance_report_id=compliance_reports[0].compliance_report_id,
-        effective_fuel_supplies=fossil_fuel_supplies,
-        fossil_derived=True,
-    )
-
-    assert result == {"gasoline": 1.0, "diesel": 1.0}
-
-
-@pytest.mark.anyio
 async def test_get_all_org_reported_years_success(
     compliance_report_repo, compliance_reports, compliance_periods
 ):
@@ -996,3 +950,48 @@ async def test_get_all_org_reported_years_not_found(
     )
 
     assert len(periods) == 0
+
+
+@pytest.mark.parametrize(
+    "fossil_derived, expected",
+    [
+        (True, {"diesel": 1.0, "gasoline": 1.0}),
+        (False, {"diesel": 1.0, "gasoline": 1.0}),
+    ],
+)
+def test_aggregate_fuel_supplies(
+    compliance_report_repo, fuel_supplies, fossil_derived, expected
+):
+    result = compliance_report_repo.aggregate_fuel_supplies(
+        fuel_supplies, fossil_derived
+    )
+
+    assert result == expected
+
+
+@pytest.mark.anyio
+async def test_aggregate_other_uses(compliance_report_repo, dbsession):
+    mock_result = [
+        MagicMock(category="Gasoline", quantity=50.0),
+        MagicMock(category="Ethanol", quantity=75.0),
+    ]
+    dbsession.execute = AsyncMock(return_value=mock_result)
+
+    result = await compliance_report_repo.aggregate_other_uses(1, True)
+
+    assert result == {"gasoline": 50.0, "ethanol": 75.0}
+    dbsession.execute.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_aggregate_allocation_agreements(compliance_report_repo, dbsession):
+    mock_result = [
+        MagicMock(category="Biogas", quantity=25.0),
+        MagicMock(category="Biodiesel", quantity=100.0),
+    ]
+    dbsession.execute = AsyncMock(return_value=mock_result)
+
+    result = await compliance_report_repo.aggregate_allocation_agreements(2)
+
+    assert result == {"biogas": 25.0, "biodiesel": 100.0}
+    dbsession.execute.assert_awaited_once()

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
@@ -943,7 +943,8 @@ async def test_calculate_fuel_quantities_success_not_fossil_derived(
     )
 
     result = await compliance_report_repo.calculate_fuel_quantities(
-        compliance_report=compliance_reports[0],
+        compliance_report_id=compliance_reports[0].compliance_report_id,
+        effective_fuel_supplies=non_fossil_fuel_supplies,
         fossil_derived=False,
     )
 
@@ -965,7 +966,8 @@ async def test_calculate_fuel_quantities_success_fossil_derived(
     )
 
     result = await compliance_report_repo.calculate_fuel_quantities(
-        compliance_report=compliance_reports[0],
+        compliance_report_id=compliance_reports[0].compliance_report_id,
+        effective_fuel_supplies=fossil_fuel_supplies,
         fossil_derived=True,
     )
 

--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lcfs.db.models.compliance.ComplianceReportSummary import ComplianceReportSummary
-from lcfs.web.api.compliance_report.schema import ComplianceReportSummaryRowSchema
+from lcfs.web.api.compliance_report.schema import (
+    ComplianceReportSummaryRowSchema,
+)
 
 
 @pytest.mark.anyio
@@ -670,3 +672,94 @@ async def test_calculate_renewable_fuel_target_summary_no_copy_lines_6_and_8(
     assert result[7].gasoline == 0  # Line 8 should not be copied
     assert result[7].diesel == 0
     assert result[7].jet_fuel == 0
+
+
+@pytest.mark.anyio
+async def test_can_sign_flag_logic(
+    compliance_report_summary_service, mock_repo, mock_trxn_repo
+):
+    # Scenario 1: All conditions met
+    mock_effective_fuel_supplies = [MagicMock()]
+    mock_notional_transfers = MagicMock(notional_transfers=[MagicMock()])
+    mock_fuel_exports = [MagicMock()]
+    mock_allocation_agreements = [MagicMock()]
+    mock_compliance_report = MagicMock(
+        compliance_report_group_uuid="mock-group-uuid",
+        compliance_period=MagicMock(effective_date=MagicMock(year=2024)),
+        organization_id=1,
+        compliance_report_id=1,
+        summary=MagicMock(is_locked=False),
+    )
+
+    mock_trxn_repo.calculate_available_balance_for_period.return_value = 1000
+
+    # Mock previous retained and obligation dictionaries
+    previous_retained = {"gasoline": 10, "diesel": 20, "jet_fuel": 30}
+    previous_obligation = {"gasoline": 5, "diesel": 10, "jet_fuel": 15}
+
+    # Mock repository methods
+    mock_repo.get_compliance_report_by_id = AsyncMock(
+        return_value=mock_compliance_report
+    )
+    mock_repo.calculate_fuel_quantities = AsyncMock(
+        return_value={
+            "gasoline": 100,
+            "diesel": 50,
+            "jet_fuel": 25,
+        }
+    )
+    mock_repo.get_assessed_compliance_report_by_period = AsyncMock(
+        return_value=MagicMock(
+            summary=MagicMock(
+                line_6_renewable_fuel_retained_gasoline=previous_retained["gasoline"],
+                line_6_renewable_fuel_retained_diesel=previous_retained["diesel"],
+                line_6_renewable_fuel_retained_jet_fuel=previous_retained["jet_fuel"],
+                line_8_obligation_deferred_gasoline=previous_obligation["gasoline"],
+                line_8_obligation_deferred_diesel=previous_obligation["diesel"],
+                line_8_obligation_deferred_jet_fuel=previous_obligation["jet_fuel"],
+            )
+        )
+    )
+
+    compliance_report_summary_service.fuel_supply_repo.get_effective_fuel_supplies = (
+        AsyncMock(return_value=mock_effective_fuel_supplies)
+    )
+    compliance_report_summary_service.notional_transfer_service.calculate_notional_transfers = AsyncMock(
+        return_value=mock_notional_transfers
+    )
+    compliance_report_summary_service.fuel_export_repo.get_effective_fuel_exports = (
+        AsyncMock(return_value=mock_fuel_exports)
+    )
+    compliance_report_summary_service.allocation_agreement_repo.get_allocation_agreements = AsyncMock(
+        return_value=mock_allocation_agreements
+    )
+
+    # Call the method
+    result = (
+        await compliance_report_summary_service.calculate_compliance_report_summary(1)
+    )
+
+    # Assert that `can_sign` is True
+    assert result.can_sign is True
+
+    # Scenario 2: No conditions met
+    compliance_report_summary_service.fuel_supply_repo.get_effective_fuel_supplies = (
+        AsyncMock(return_value=[])
+    )
+    compliance_report_summary_service.notional_transfer_service.calculate_notional_transfers = AsyncMock(
+        return_value=MagicMock(notional_transfers=[])
+    )
+    compliance_report_summary_service.fuel_export_repo.get_effective_fuel_exports = (
+        AsyncMock(return_value=[])
+    )
+    compliance_report_summary_service.allocation_agreement_repo.get_allocation_agreements = AsyncMock(
+        return_value=[]
+    )
+
+    # Call the method again
+    result = (
+        await compliance_report_summary_service.calculate_compliance_report_summary(1)
+    )
+
+    # Assert that `can_sign` is False
+    assert result.can_sign is False

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -666,32 +666,27 @@ class ComplianceReportRepository:
         )
         return result or 0
 
-    @repo_handler
-    async def calculate_fuel_quantities(
-        self,
-        compliance_report_id: int,
-        effective_fuel_supplies: List[FuelSupply],
-        fossil_derived: bool,
+    def aggregate_fuel_supplies(
+        self, fuel_supplies: List[FuelSupply], fossil_derived: bool
     ) -> Dict[str, float]:
-        """
-        Calculate the total quantities of fuels, separated by fuel category and fossil_derived flag.
-        """
+        """Aggregate quantities from fuel supplies based on fossil_derived flag."""
         fuel_quantities = defaultdict(float)
 
-        # Filter fuel supplies based on fossil_derived flag
-        filtered_fuel_supplies = [
-            fs
-            for fs in effective_fuel_supplies
-            if fs.fuel_type.fossil_derived == fossil_derived
-        ]
-
-        # Aggregate quantities from fuel supplies
-        for fs in filtered_fuel_supplies:
-            fuel_category = fs.fuel_category.category.lower().replace(" ", "_")
+        # Use a list comprehension to filter and iterate in one step
+        for fs in (
+            fs for fs in fuel_supplies if fs.fuel_type.fossil_derived == fossil_derived
+        ):
+            fuel_category = self._format_category(fs.fuel_category.category)
             fuel_quantities[fuel_category] += fs.quantity
 
-        # Aggregate other uses quantities (OtherUses does NOT have versioning)
-        other_uses_query = (
+        return dict(fuel_quantities)
+
+    @repo_handler
+    async def aggregate_other_uses(
+        self, compliance_report_id: int, fossil_derived: bool
+    ) -> Dict[str, float]:
+        """Aggregate quantities from other uses."""
+        query = (
             select(
                 FuelCategory.category,
                 func.coalesce(func.sum(OtherUses.quantity_supplied), 0).label(
@@ -712,42 +707,42 @@ class ComplianceReportRepository:
             .group_by(FuelCategory.category)
         )
 
-        other_uses_result = await self.db.execute(other_uses_query)
-        for row in other_uses_result:
-            fuel_category = row.category.lower().replace(" ", "_")
-            fuel_quantities[fuel_category] += row.quantity
+        result = await self.db.execute(query)
+        return {self._format_category(row.category): row.quantity for row in result}
 
-        # Aggregate allocation agreement quantities for renewable fuels (AllocationAgreement does NOT have versioning)
-        if not fossil_derived:
-            allocation_agreement_query = (
-                select(
-                    FuelCategory.category,
-                    func.coalesce(func.sum(AllocationAgreement.quantity), 0).label(
-                        "quantity"
-                    ),
-                )
-                .select_from(AllocationAgreement)
-                .join(
-                    FuelType, AllocationAgreement.fuel_type_id == FuelType.fuel_type_id
-                )
-                .join(
-                    FuelCategory,
-                    AllocationAgreement.fuel_category_id
-                    == FuelCategory.fuel_category_id,
-                )
-                .where(
-                    AllocationAgreement.compliance_report_id == compliance_report_id,
-                    FuelType.fossil_derived.is_(False),
-                    FuelType.other_uses_fossil_derived.is_(False),
-                )
-                .group_by(FuelCategory.category)
+    @repo_handler
+    async def aggregate_allocation_agreements(
+        self, compliance_report_id: int
+    ) -> Dict[str, float]:
+        """Aggregate quantities from allocation agreements for renewable fuels."""
+        query = (
+            select(
+                FuelCategory.category,
+                func.coalesce(func.sum(AllocationAgreement.quantity), 0).label(
+                    "quantity"
+                ),
             )
-            allocation_result = await self.db.execute(allocation_agreement_query)
-            for row in allocation_result:
-                fuel_category = row.category.lower().replace(" ", "_")
-                fuel_quantities[fuel_category] += row.quantity
+            .select_from(AllocationAgreement)
+            .join(FuelType, AllocationAgreement.fuel_type_id == FuelType.fuel_type_id)
+            .join(
+                FuelCategory,
+                AllocationAgreement.fuel_category_id == FuelCategory.fuel_category_id,
+            )
+            .where(
+                AllocationAgreement.compliance_report_id == compliance_report_id,
+                FuelType.fossil_derived.is_(False),
+                FuelType.other_uses_fossil_derived.is_(False),
+            )
+            .group_by(FuelCategory.category)
+        )
 
-        return dict(fuel_quantities)
+        result = await self.db.execute(query)
+        return {self._format_category(row.category): row.quantity for row in result}
+
+    @staticmethod
+    def _format_category(category: str) -> str:
+        """Format the fuel category string."""
+        return category.lower().replace(" ", "_")
 
     @repo_handler
     async def get_all_org_reported_years(self, organization_id: int):

--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import ClassVar, Optional, List, Union
 from datetime import datetime, date
 from enum import Enum
-from lcfs.web.api.fuel_code.schema import EndUseTypeSchema,EndUserTypeSchema
+from lcfs.web.api.fuel_code.schema import EndUseTypeSchema, EndUserTypeSchema
 
 from lcfs.web.api.base import BaseSchema, FilterModel, SortOrder
 from lcfs.web.api.base import PaginationResponseSchema
@@ -26,9 +26,11 @@ class ReportingFrequency(str, Enum):
     ANNUAL = "Annual"
     QUARTERLY = "Quarterly"
 
+
 class PortsEnum(str, Enum):
     SINGLE = "Single port"
     DUAL = "Dual port"
+
 
 class CompliancePeriodSchema(BaseSchema):
     compliance_period_id: int
@@ -185,11 +187,20 @@ class ComplianceReportSummarySchema(BaseSchema):
     renewable_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
     low_carbon_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
     non_compliance_penalty_summary: List[ComplianceReportSummaryRowSchema]
+    can_sign: bool = False
     summary_id: Optional[int] = None
     compliance_report_id: Optional[int] = None
     version: Optional[int] = None
     is_locked: Optional[bool] = False
     quarter: Optional[int] = None
+
+
+class ComplianceReportSummaryUpdateSchema(BaseSchema):
+    compliance_report_id: int
+    renewable_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
+    low_carbon_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
+    non_compliance_penalty_summary: List[ComplianceReportSummaryRowSchema]
+    summary_id: int
 
 
 class CommonPaginatedReportRequestSchema(BaseSchema):

--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -25,7 +25,7 @@ from lcfs.web.api.compliance_report.schema import (
     ComplianceReportBaseSchema,
     ComplianceReportListSchema,
     ComplianceReportSummarySchema,
-    ComplianceReportUpdateSchema,
+    ComplianceReportUpdateSchema, ComplianceReportSummaryUpdateSchema,
 )
 from lcfs.web.api.compliance_report.services import ComplianceReportServices
 from lcfs.web.api.compliance_report.summary_service import (
@@ -120,7 +120,7 @@ async def get_compliance_report_summary(
 async def update_compliance_report_summary(
     request: Request,
     report_id: int,
-    summary_data: ComplianceReportSummarySchema,
+    summary_data: ComplianceReportSummaryUpdateSchema,
     summary_service: ComplianceReportSummaryService = Depends(),
     validate: ComplianceReportValidation = Depends(),
 ) -> ComplianceReportSummarySchema:

--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -126,6 +126,7 @@
   "compareReports": "Compare summary data between the following 2 report versions",
   "fuelType": "Fuel Type",
   "signingAuthorityDeclaration": "Signing authority declaration",
+  "cannotSubmit": "You must report fuel activity information to sign and submit a report (FSE data alone is not sufficient)",
   "declarationText": "I certify that the information in this report is true and complete to the best of my knowledge and I understand that I may be required to provide to the Director records evidencing the truth of that information.",
   "submitReport": "Submit Report",
   "pleaseCheckDeclaration": "Please certify the information before submitting",

--- a/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
+++ b/frontend/src/views/ComplianceReports/components/ComplianceReportSummary.jsx
@@ -36,6 +36,7 @@ const ComplianceReportSummary = ({
   alertRef
 }) => {
   const [summaryData, setSummaryData] = useState(null)
+  const [canSign, setCanSign] = useState(false)
   const { t } = useTranslation(['report'])
 
   const { data, isLoading, isError, error } =
@@ -63,9 +64,13 @@ const ComplianceReportSummary = ({
         data?.nonCompliancePenaltySummary[0]?.totalValue <= 0 ||
           data?.nonCompliancePenaltySummary[1].totalValue <= 0
       )
+      setCanSign(data && data.canSign)
     }
     if (isError) {
-      alertRef.current?.triggerAlert({ message: error?.response?.data?.detail || error.message, severity: 'error' })
+      alertRef.current?.triggerAlert({
+        message: error?.response?.data?.detail || error.message,
+        severity: 'error'
+      })
     }
   }, [alertRef, data, error, isError, setHasMet])
 
@@ -133,6 +138,7 @@ const ComplianceReportSummary = ({
           {currentStatus === COMPLIANCE_REPORT_STATUSES.DRAFT && (
             <>
               <SigningAuthorityDeclaration
+                disabled={!canSign}
                 onChange={setIsSigningAuthorityDeclared}
               />
               <Stack direction="row" justifyContent="flex-end" mt={2} gap={2}>

--- a/frontend/src/views/ComplianceReports/components/SigningAuthorityDeclaration.jsx
+++ b/frontend/src/views/ComplianceReports/components/SigningAuthorityDeclaration.jsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Checkbox, FormControlLabel, Paper } from '@mui/material'
 import BCTypography from '@/components/BCTypography'
+import BCAlert from '@/components/BCAlert'
+import Box from '@mui/material/Box'
 
-const SigningAuthorityDeclaration = ({ onChange }) => {
+const SigningAuthorityDeclaration = ({ onChange, disabled }) => {
   const { t } = useTranslation(['report'])
   const [checked, setChecked] = useState(false)
 
@@ -28,9 +30,17 @@ const SigningAuthorityDeclaration = ({ onChange }) => {
       <BCTypography color="primary" variant="h6">
         {t('report:signingAuthorityDeclaration')}
       </BCTypography>
+      {disabled && (
+        <Box sx={{ mt: '8px' }}>
+          <BCAlert data-test="alert-box" severity="warning" noFade={true}>
+            {t('report:cannotSubmit')}
+          </BCAlert>
+        </Box>
+      )}
       <FormControlLabel
         control={
           <Checkbox
+            disabled={disabled}
             checked={checked}
             onChange={handleChange}
             id="signing-authority-declaration"


### PR DESCRIPTION
* Add new UI for SigningAuthorityDeclaration to have a disabled state with a warning message
* Calculate can_sign based on number of records in each schedule and use to set flag
* Update submit logic to check the same flag and raise an error
* Update compliance summary calculation to only call get effective records one
* Update / Add tests accordingly