### PR TITLE
LCFS-1252: Add options the Feedstock Transport mode fuel code

### DIFF
--- a/backend/lcfs/db/migrations/versions/2024-11-22-15-05_043c52082a3b.py
+++ b/backend/lcfs/db/migrations/versions/2024-11-22-15-05_043c52082a3b.py
@@ -1,0 +1,60 @@
+"""Add options to the Feedstock Transport mode fuel code
+
+Revision ID: 043c52082a3b
+Revises: 1974af823b80
+Create Date: 2024-11-22 15:05:12.015327
+
+"""
+from datetime import datetime
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "043c52082a3b"
+down_revision = "1974af823b80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    current_time = datetime.now()
+
+    # Update Marine to Marine-domestic
+    op.execute(
+        """
+        UPDATE transport_mode
+        SET transport_mode = 'Marine-domestic',
+            update_date = '{}',
+            update_user = 'no-user'
+        WHERE transport_mode = 'Marine'
+        """.format(current_time)
+    )
+
+    # Insert Marine-international
+    op.execute(
+        """
+        INSERT INTO transport_mode (transport_mode, create_date, update_date, create_user, update_user)
+        VALUES ('Marine-international', '{}', '{}', 'no_user', 'no_user')
+        """.format(current_time, current_time)
+    )
+
+
+def downgrade():
+    # Revert Marine-domestic back to Marine
+    op.execute(
+        """
+        UPDATE transport_mode
+        SET transport_mode = 'Marine',
+            update_date = '{}',
+            update_user = 'no_user'
+        WHERE transport_mode = 'Marine-domestic'
+        """.format(datetime.utcnow())
+    )
+
+    # Remove Marine-international
+    op.execute(
+        """
+        DELETE FROM transport_mode
+        WHERE transport_mode = 'Marine-international'
+        """
+    )

--- a/backend/lcfs/db/seeders/common/seed_fuel_data.json
+++ b/backend/lcfs/db/seeders/common/seed_fuel_data.json
@@ -225,7 +225,7 @@
     },
     {
       "transport_mode_id": 3,
-      "transport_mode": "Marine"
+      "transport_mode": "Marine-domestic"
     },
     {
       "transport_mode_id": 4,


### PR DESCRIPTION
Edit "Marine" option to "Marine-domestic" and add "Marine-international" as selectable options in the Feedstock Transport Mode column of the Fuel Code Input on the IDIR side.

We have a new option 'Marine-international' and the 'Marine-domestic' option:
![image](https://github.com/user-attachments/assets/b973879f-ea9f-4cfc-b18c-e43ba36a1dd8)

We can see transport mode change from 'Marine' to 'Marine-domestic':
![image](https://github.com/user-attachments/assets/08edde47-4ca4-4df0-a4d2-db4ba04f606b)


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=87721242&issue=bcgov%7Clcfs%7C1252) 