### PR TITLE
LCFS-1280: Fuel supply validation (2/2)

### DIFF
--- a/backend/lcfs/web/api/other_uses/schema.py
+++ b/backend/lcfs/web/api/other_uses/schema.py
@@ -85,12 +85,13 @@ class OtherUsesTableOptionsSchema(BaseSchema):
 class OtherUsesCreateSchema(BaseSchema):
     other_uses_id: Optional[int] = None
     compliance_report_id: int
-    quantity_supplied: int
     fuel_type: str
     fuel_category: str
-    expected_use: str
     provision_of_the_act: str
     fuel_code: Optional[str] = None
+    quantity_supplied: int = Field(
+        ..., gt=0, description="Quantity supplied must be greater than 0"
+    )
     units: str
     ci_of_fuel: Optional[float] = None
     expected_use: str

--- a/frontend/src/views/OtherUses/AddEditOtherUses.jsx
+++ b/frontend/src/views/OtherUses/AddEditOtherUses.jsx
@@ -80,6 +80,22 @@ export const AddEditOtherUses = () => {
     return ciOfFuel;
   }, []);
 
+  const validateField = (params, field, validationFn, errorMessage, alertRef) => {
+    const newValue = params.newValue;
+
+    if (params.colDef.field === field) {
+      if (!validationFn(newValue)) {
+        alertRef.current?.triggerAlert({
+          message: errorMessage,
+          severity: 'error',
+        });
+        return false;
+      }
+    }
+
+    return true; // Proceed with the update
+  };
+
   const onGridReady = (params) => {
     const ensureRowIds = (rows) => {
       return rows.map((row) => {
@@ -156,6 +172,16 @@ export const AddEditOtherUses = () => {
 
   const onCellEditingStopped = useCallback(
     async (params) => {
+      const isValid = validateField(
+        params,
+        'quantitySupplied',
+        (value) => value !== null && !isNaN(value) && value > 0,
+        'Quantity supplied must be greater than 0.',
+        alertRef
+      );
+
+      if (!isValid) return;
+
       if (params.oldValue === params.newValue) return
       params.data.complianceReportId = complianceReportId
       params.data.validationStatus = 'pending'

--- a/frontend/src/views/OtherUses/_schema.jsx
+++ b/frontend/src/views/OtherUses/_schema.jsx
@@ -220,11 +220,10 @@ export const otherUsesColDefs = (optionsData, errors) => [
     headerName: i18n.t('otherUses:otherUsesColLabels.quantitySupplied'),
     headerComponent: RequiredHeader,
     cellEditor: NumberEditor,
-    valueFormatter,
+    valueFormatter: (params) => valueFormatter({ value: params.value }),
     type: 'numericColumn',
     cellEditorParams: {
       precision: 0,
-      min: 0,
       showStepperButtons: false
     },
     cellStyle: (params) => StandardCellErrors(params, errors),


### PR DESCRIPTION
- The default **Quantity supplied** value being 0 should not be allow. 
- Zero should not be a valid amount in a fuel supply record and the row should not save until the user has entered a value.



[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=88333582&issue=bcgov%7Clcfs%7C1280)