### PR TITLE
Feat: Add instructional text for zero-dollar transfers - #1276

### DIFF
--- a/frontend/src/assets/locales/en/transfer.json
+++ b/frontend/src/assets/locales/en/transfer.json
@@ -80,5 +80,6 @@
     "Refused": "Refused",
     "Declined": "Declined",
     "Rescinded": "Rescinded"
-  }
+  },
+  "zeroDollarInstructionText": "If proposing a zero-dollar transfer, use the comment box below to provide an explanation for this value."
 }

--- a/frontend/src/views/Transfers/components/TransferDetails.jsx
+++ b/frontend/src/views/Transfers/components/TransferDetails.jsx
@@ -186,6 +186,13 @@ export const TransferDetails = () => {
             })} CAD.`}
           </BCTypography>
         </BCTypography>
+        <BCTypography
+          variant="body4"
+          component="div"
+          sx={{ marginTop: '1rem', fontWeight: 'bold' }}
+        >
+          {t('transfer:zeroDollarInstructionText')}
+        </BCTypography>
       </LabelBox>
     </BCBox>
   )

--- a/frontend/src/views/Transfers/components/__tests__/TransferDetails.test.jsx
+++ b/frontend/src/views/Transfers/components/__tests__/TransferDetails.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { TransferDetails } from '../TransferDetails'
 import { useForm, FormProvider } from 'react-hook-form'
@@ -13,7 +12,7 @@ vi.mock('@/hooks/useOrganizations')
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key) => key
-  }),
+  })
 }))
 
 // MockFormProvider Component
@@ -22,9 +21,9 @@ const MockFormProvider = ({ children }) => {
     defaultValues: {
       toOrganizationId: '',
       quantity: '',
-      pricePerUnit: '',
+      pricePerUnit: ''
     },
-    mode: 'onBlur',
+    mode: 'onBlur'
   })
   return <FormProvider {...methods}>{children}</FormProvider>
 }
@@ -94,7 +93,7 @@ describe('TransferDetails Component', () => {
           style: 'currency',
           currency: 'CAD',
           minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
+          maximumFractionDigits: 2
         })} CAD.`
       )
     })
@@ -147,5 +146,17 @@ describe('TransferDetails Component', () => {
     fireEvent.click(option)
 
     expect(selectInput).toHaveTextContent('Org One')
+  })
+
+  it('renders the zero-dollar instructional text', () => {
+    render(
+      <MockFormProvider>
+        <TransferDetails />
+      </MockFormProvider>,
+      { wrapper }
+    )
+    expect(
+      screen.getByText('transfer:zeroDollarInstructionText')
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
This PR adds a line of instructional text to guide users on zero-dollar credit transfers by specifying that an explanation should be added in the comment box.

Closes #1276