### PR TITLE
Fix: Remove 'Read only' role option - #1294

### DIFF
--- a/frontend/src/views/Users/AddEditUser/AddEditUser.jsx
+++ b/frontend/src/views/Users/AddEditUser/AddEditUser.jsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { useMutation } from '@tanstack/react-query'
 import { useForm, FormProvider } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-// hooks
 import { useUser } from '@/hooks/useUser'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import {
@@ -17,7 +16,6 @@ import {
 } from './_schema'
 import { useApiService } from '@/services/useApiService'
 import { ROUTES } from '@/constants/routes'
-// components
 import { BCFormRadio, BCFormText } from '@/components/BCForm'
 import colors from '@/themes/base/colors'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/frontend/src/views/Users/AddEditUser/__tests__/test.mock.js
+++ b/frontend/src/views/Users/AddEditUser/__tests__/test.mock.js
@@ -8,6 +8,7 @@ export const userData = {
   lastName: 'User2',
   isActive: true
 }
+
 export const govUser = {
   userProfileId: 1,
   keycloakUsername: 'mockUser1',

--- a/frontend/src/views/Users/AddEditUser/components/BCeIDSpecificRoleFields.jsx
+++ b/frontend/src/views/Users/AddEditUser/components/BCeIDSpecificRoleFields.jsx
@@ -16,7 +16,9 @@ export const BCeIDSpecificRoleFields = ({ form, disabled, t }) => {
         options={bceidRoleOptions(t)}
         disabled={disabled}
       />
-      <BCFormRadio
+
+      {/* "Read only" */}
+      {/* <BCFormRadio
         id={nonGovRoles[5].toLowerCase().replace(' ', '-')}
         control={control}
         name="readOnly"
@@ -31,7 +33,7 @@ export const BCeIDSpecificRoleFields = ({ form, disabled, t }) => {
           }
         ]}
         disabled={disabled}
-      />
+      /> */}
     </Box>
   )
 }


### PR DESCRIPTION
This PR hides the "Read only" role from the Edit User page to prevent accidental assignment of an incomplete role, improving security.

Closes #1294