### PR TITLE
hotfix: Replace Typography with BCTypography

### DIFF
--- a/frontend/src/views/FinalSupplyEquipments/_schema.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/_schema.jsx
@@ -50,7 +50,7 @@ export const finalSupplyEquipmentColDefs = (
     cellEditor: AutocompleteCellEditor,
     cellRenderer: (params) =>
       params.value ||
-      (!params.value && <Typography variant="body4">Select</Typography>),
+      (!params.value && <BCTypography variant="body4">Select</BCTypography>),
     cellEditorParams: {
       options: optionsData?.organizationNames?.sort() || [],
       multiple: false,


### PR DESCRIPTION
User can not access FinaL Supply Equipment due to error in Typography not found. This component was replaced for BCTypography.