### PR TITLE
Fix: Correct default carbon intensity for 'Other Diesel fuel' type - #1425

### DIFF
--- a/backend/lcfs/db/migrations/versions/2024-12-12-21-43_5d729face5ab.py
+++ b/backend/lcfs/db/migrations/versions/2024-12-12-21-43_5d729face5ab.py
@@ -1,0 +1,35 @@
+"""Update default_carbon_intensity for 'Other diesel' fuel type
+
+Revision ID: 5d729face5ab
+Revises: 7ae38a8413ab
+Create Date: 2024-12-12 21:43:01.414475
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5d729face5ab"
+down_revision = "7ae38a8413ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE fuel_type
+        SET default_carbon_intensity = 100.21
+        WHERE fuel_type_id = 20
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE fuel_type
+        SET default_carbon_intensity = 94.38
+        WHERE fuel_type_id = 20
+        """
+    )

--- a/backend/lcfs/db/seeders/common/seed_fuel_data.json
+++ b/backend/lcfs/db/seeders/common/seed_fuel_data.json
@@ -188,7 +188,7 @@
       "fossil_derived": true,
       "other_uses_fossil_derived": true,
       "provision_1_id": 1,
-      "default_carbon_intensity": 94.38,
+      "default_carbon_intensity": 100.21,
       "units": "L",
       "unrecognized": false
     }


### PR DESCRIPTION
This PR updates the default_carbon_intensity for 'Other diesel' fuel type to 100.21.

Closes #1425
