### PR TITLE
LCFS-1426: Upload file attachements compliance reports for Analyst user

### DIFF
--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -40,7 +40,7 @@ async def get_all_documents(
     response_model=FileResponseSchema,
     status_code=status.HTTP_201_CREATED,
 )
-@view_handler([RoleEnum.SUPPLIER])
+@view_handler([RoleEnum.SUPPLIER, RoleEnum.ANALYST])
 async def upload_file(
     request: Request,
     parent_id: int,

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -1,3 +1,6 @@
+from http.client import HTTPException
+from lcfs.db.models.compliance.ComplianceReportStatus import ComplianceReportStatusEnum
+from lcfs.web.api.compliance_report.services import ComplianceReportServices
 import structlog
 from typing import List
 
@@ -47,7 +50,20 @@ async def upload_file(
     parent_type: str,
     file: UploadFile = File(...),
     document_service: DocumentService = Depends(),
+    compliance_report_service: ComplianceReportServices = Depends(),
 ) -> FileResponseSchema:
+    # Fetch the compliance report
+    compliance_report = await compliance_report_service.get_compliance_report_by_id(parent_id)
+    if not compliance_report:
+        raise HTTPException(status_code=404, detail="Compliance report not found")
+
+    # Check if the compliance report is submitted
+    if compliance_report.current_status.status == ComplianceReportStatusEnum.Submitted:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot upload files when the compliance report is submitted",
+        )
+
     document = await document_service.upload_file(file, parent_id, parent_type)
     return FileResponseSchema.model_validate(document)
 

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -50,21 +50,10 @@ async def upload_file(
     parent_type: str,
     file: UploadFile = File(...),
     document_service: DocumentService = Depends(),
-    compliance_report_service: ComplianceReportServices = Depends(),
 ) -> FileResponseSchema:
-    # Fetch the compliance report
-    compliance_report = await compliance_report_service.get_compliance_report_by_id(parent_id)
-    if not compliance_report:
-        raise HTTPException(status_code=404, detail="Compliance report not found")
-
-    # Check if the compliance report is submitted
-    if compliance_report.current_status.status == ComplianceReportStatusEnum.Submitted:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot upload files when the compliance report is submitted",
-        )
-
-    document = await document_service.upload_file(file, parent_id, parent_type)
+    document = await document_service.upload_file(
+        file, parent_id, parent_type, request.user
+    )
     return FileResponseSchema.model_validate(document)
 
 

--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -7,6 +7,7 @@ import BCModal from '@/components/BCModal'
 import BCButton from '@/components/BCButton'
 import Loading from '@/components/Loading'
 import { Role } from '@/components/Role'
+import { roles } from '@/constants/roles'
 import { Fab, Stack, Tooltip } from '@mui/material'
 import BCTypography from '@/components/BCTypography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -80,7 +81,8 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
     hasRoles
   } = useCurrentUser()
   const isGovernmentUser = currentUser?.isGovernmentUser
-
+  const isAnalystRole = currentUser?.roles?.some(role => role.name === roles.analyst) || false;
+  
   const currentStatus = reportData?.report.currentStatus?.status
   const { data: orgData, isLoading } = useOrganization(
     reportData?.report.organizationId
@@ -209,7 +211,7 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
           </Stack>
           {!location.state?.newReport && (
             <>
-              <ReportDetails currentStatus={currentStatus} isGovernmentUser={isGovernmentUser}/>
+              <ReportDetails currentStatus={currentStatus} isAnalystRole={isAnalystRole}/>
               <ComplianceReportSummary
                 reportID={complianceReportId}
                 currentStatus={currentStatus}

--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -209,7 +209,7 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
           </Stack>
           {!location.state?.newReport && (
             <>
-              <ReportDetails currentStatus={currentStatus} />
+              <ReportDetails currentStatus={currentStatus} isGovernmentUser={isGovernmentUser}/>
               <ComplianceReportSummary
                 reportID={complianceReportId}
                 currentStatus={currentStatus}

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -32,8 +32,9 @@ import { FuelExportSummary } from '@/views/FuelExports/FuelExportSummary'
 import { SupportingDocumentSummary } from '@/views/SupportingDocuments/SupportingDocumentSummary'
 import DocumentUploadDialog from '@/components/Documents/DocumentUploadDialog'
 import { useComplianceReportDocuments } from '@/hooks/useComplianceReports'
+import { COMPLIANCE_REPORT_STATUSES } from '@/constants/statuses'
 
-const ReportDetails = ({ currentStatus = 'Draft' }) => {
+const ReportDetails = ({ currentStatus = 'Draft', isGovernmentUser}) => {
   const { t } = useTranslation()
   const { compliancePeriod, complianceReportId } = useParams()
   const navigate = useNavigate()
@@ -214,6 +215,39 @@ const ReportDetails = ({ currentStatus = 'Draft' }) => {
           {t('report:collapseAll')}
         </Link>
       </BCTypography>
+      {/* Supporting Documents */}
+      {isGovernmentUser && (currentStatus === COMPLIANCE_REPORT_STATUSES.SUBMITTED ||
+        currentStatus === COMPLIANCE_REPORT_STATUSES.ASSESSED) && (
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon sx={{ width: '2rem', height: '2rem' }} />}
+            aria-controls="panel1-content"
+          >
+            <BCTypography color="primary" variant="h6" component="div">
+              {t('report:supportingDocs')}
+            </BCTypography>
+            <IconButton
+              color="primary"
+              size="small"
+              aria-label="edit"
+              onClick={(e) => {
+                e.stopPropagation();
+                setFileDialogOpen(true);
+              }}
+            >
+              <FontAwesomeIcon className="small-icon" icon={faPen} />
+            </IconButton>
+          </AccordionSummary>
+          <AccordionDetails>
+            <DocumentUploadDialog
+              parentID={complianceReportId}
+              parentType="compliance_report"
+              open={isFileDialogOpen}
+              close={() => setFileDialogOpen(false)}
+            />
+          </AccordionDetails>
+        </Accordion>
+      )}
       {activityList.map((activity, index) => {
         const { data, error, isLoading } = activity.useFetch(complianceReportId)
         return (

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -40,7 +40,7 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
   const navigate = useNavigate()
 
   const [isFileDialogOpen, setFileDialogOpen] = useState(false)
-  const showSupportingDocs = useMemo(() => {
+  const editSupportingDocs = useMemo(() => {
     return isAnalystRole && (
       currentStatus === COMPLIANCE_REPORT_STATUSES.SUBMITTED ||
       currentStatus === COMPLIANCE_REPORT_STATUSES.ASSESSED
@@ -86,7 +86,7 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
             />
           </>
         ),
-        condition: showSupportingDocs
+        condition: true
       },
       {
         name: t('report:activityLists.supplyOfFuel'),
@@ -239,7 +239,7 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
       {activityList.map((activity, index) => {
         const { data, error, isLoading } = activity.useFetch(complianceReportId)
         return (
-          ((activity.name === t('report:supportingDocs') ? showSupportingDocs : (data && !isArrayEmpty(data)))) && (
+          (data && !isArrayEmpty(data) || activity.name === t('report:supportingDocs')) && (
             <Accordion
               key={index}
               expanded={activity.name === t('report:supportingDocs') ? expanded.includes(`panel${index}`) && !isArrayEmpty(data) : expanded.includes(`panel${index}`)}
@@ -260,7 +260,9 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
                   component="div"
                 >
                   {activity.name}&nbsp;&nbsp;
-                  <Role
+                  {editSupportingDocs && (
+                    <>
+                      <Role
                         roles={[
                           roles.supplier,
                           roles.compliance_reporting,
@@ -280,6 +282,8 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
                           />
                         </IconButton>
                       </Role>
+                    </>
+                  )}
                 </BCTypography>
               </AccordionSummary>
               <AccordionDetails>


### PR DESCRIPTION
Extend the logic of Supporting Documents to allow Analyst to attach Supporting Documents as long as the compliance report status is submitted or assessed. Supporting documents section is visible at all times.

**New Logic:**

- BCeID user can attach supporting documents to a compliance report under `draft`:

<img width="668" alt="image" src="https://github.com/user-attachments/assets/9d5e2d82-bc08-43f3-ac69-e9b80ea8bd5e" />

- Analyst user can check the `submitted` report and attach supporting documents:

<img width="579" alt="image" src="https://github.com/user-attachments/assets/d2399ff2-7e5e-403f-909e-19bab918e20b" />

- Under `submitted` report, BCeID user can see the supporting documents section, but not modify docs in the section:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/c76bdc0d-efd1-4130-9a52-0e970d9c82aa" />


