### PR TITLE
LCFS-1446: Fuel code Feedstock transport mode & Finished fuel transport mode not displaying values

### DIFF
--- a/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
+++ b/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
@@ -97,7 +97,32 @@ const AddEditFuelCodeBase = () => {
       )
       setColumnDefs(updatedColumnDefs)
     }
-  }, [errors, optionsData, existingFuelCode, hasRoles])
+  }, [errors, optionsData, existingFuelCode])
+
+  useEffect(() => {
+    if (existingFuelCode) {
+      const transformedData = {
+        ...existingFuelCode,
+        feedstockFuelTransportMode: existingFuelCode.feedstockFuelTransportModes.map(
+          (mode) => mode.feedstockFuelTransportMode.transportMode
+        ),
+        finishedFuelTransportMode: existingFuelCode.finishedFuelTransportModes.map(
+          (mode) => mode.finishedFuelTransportMode.transportMode
+        )
+      }
+      setRowData([transformedData])
+    } else {
+      setRowData([
+        {
+          id: uuid(),
+          prefixId: 1,
+          fuelSuffix: optionsData?.fuelCodePrefixes?.find(
+            (item) => item.prefix === 'BCLCF'
+          ).nextFuelCode
+        }
+      ])
+    }
+  }, [optionsData, existingFuelCode, isGridReady])
 
   const onGridReady = (params) => {
     setGridReady(true)


### PR DESCRIPTION
- The _schema for AddEditFuelCode is expecting an array of strings.
- Added transformation for transport modes

Open an existing fuel code/ create a fuel code and confirm the transport modes are included after creation:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/648d7bc6-1914-4d86-bf60-1e7c1b74b3dd" />

