### PR TITLE
LCFS-1453: Legal name of transaction partner

### DIFF
--- a/frontend/src/views/AllocationAgreements/_schema.jsx
+++ b/frontend/src/views/AllocationAgreements/_schema.jsx
@@ -21,7 +21,7 @@ import {
 
 export const PROVISION_APPROVED_FUEL_CODE = 'Fuel code - section 19 (b) (i)'
 
-export const allocationAgreementColDefs = (optionsData, errors) => [
+export const allocationAgreementColDefs = (optionsData, errors, currentUser) => [
   validation,
   actions({
     enableDuplicate: false,
@@ -89,8 +89,11 @@ export const allocationAgreementColDefs = (optionsData, errors) => [
         let path = apiRoutes.organizationSearch
         path += 'org_name=' + queryKey[1]
         const response = await client.get(path)
-        params.node.data.apiDataCache = response.data
-        return response.data
+        const filteredData = response.data.filter(
+          (org) => org.name !== currentUser.organization.name
+        )
+        params.node.data.apiDataCache = filteredData
+        return filteredData
       },
       title: 'transactionPartner',
       api: params.api,

--- a/frontend/src/views/NotionalTransfers/_schema.jsx
+++ b/frontend/src/views/NotionalTransfers/_schema.jsx
@@ -12,7 +12,7 @@ import { formatNumberWithCommas as valueFormatter } from '@/utils/formatters'
 import { apiRoutes } from '@/constants/routes'
 import { StandardCellErrors } from '@/utils/grid/errorRenderers'
 
-export const notionalTransferColDefs = (optionsData, errors) => [
+export const notionalTransferColDefs = (optionsData, errors, currentUser) => [
   validation,
   actions({
     enableDuplicate: false,
@@ -45,8 +45,11 @@ export const notionalTransferColDefs = (optionsData, errors) => [
         let path = apiRoutes.organizationSearch
         path += 'org_name=' + queryKey[1]
         const response = await client.get(path)
-        params.node.data.apiDataCache = response.data
-        return response.data
+        const filteredData = response.data.filter(
+          (org) => org.name !== currentUser.organization.name
+        )
+        params.node.data.apiDataCache = filteredData
+        return filteredData
       },
       title: 'legalName',
       api: params.api


### PR DESCRIPTION
BCeID user cannot add her/his own organization as Transactional Partner in Allocation Agreements and Notional Transfers:

Legal name of transaction partner not showing own organization:
![image](https://github.com/user-attachments/assets/bce1aff8-8f0d-4396-8a19-846264f0fc5d)

When BCeID user type own organization, then an error is displayed:
<img width="597" alt="image" src="https://github.com/user-attachments/assets/388f5270-c382-44d7-a12b-e5be9a2912be" />



[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=90870933&issue=bcgov%7Clcfs%7C1453)