### PR TITLE
fix: filter showing on other uses summary

### DIFF
--- a/frontend/src/views/OtherUses/OtherUsesSummary.jsx
+++ b/frontend/src/views/OtherUses/OtherUsesSummary.jsx
@@ -109,6 +109,7 @@ export const OtherUsesSummary = ({ data }) => {
           gridKey={'other-uses'}
           getRowId={getRowId}
           columnDefs={columns}
+          defaultColDef={{ filter: false, floatingFilter: false }}
           query={useGetOtherUses}
           queryParams={{ complianceReportId }}
           dataKey={'otherUses'}


### PR DESCRIPTION
- fix: filters showing in header of other uses summary in compliance reports page, closes #1458 