### PR TITLE
LCFS-1457: Large number of records in Fuel Supply breaks report

### DIFF
--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -443,20 +443,23 @@ class FuelSupplyRepository:
         query = (
             select(FuelSupply)
             .options(
-                # Use joinedload for scalar relationships
-                joinedload(FuelSupply.fuel_code).options(
-                    joinedload(FuelCode.fuel_code_status),
-                    joinedload(FuelCode.fuel_code_prefix),
+                # Use selectinload for collections
+                selectinload(FuelSupply.fuel_code).options(
+                    selectinload(FuelCode.fuel_code_status),
+                    selectinload(FuelCode.fuel_code_prefix),
                 ),
-                joinedload(FuelSupply.fuel_category).options(
-                    joinedload(FuelCategory.target_carbon_intensities),
-                    joinedload(FuelCategory.energy_effectiveness_ratio),
+                # Use selectinload for one-to-many relationships
+                selectinload(FuelSupply.fuel_category).options(
+                    selectinload(FuelCategory.target_carbon_intensities),
+                    selectinload(FuelCategory.energy_effectiveness_ratio),
                 ),
+                # Use joinedload for many-to-one relationships
                 joinedload(FuelSupply.fuel_type).options(
                     joinedload(FuelType.energy_density),
                     joinedload(FuelType.additional_carbon_intensity),
                     joinedload(FuelType.energy_effectiveness_ratio),
                 ),
+                # Use joinedload for single relationships
                 joinedload(FuelSupply.provision_of_the_act),
                 selectinload(FuelSupply.end_use_type),
             )
@@ -467,6 +470,7 @@ class FuelSupplyRepository:
                     FuelSupply.version == valid_fuel_supplies_subq.c.max_version,
                     user_type_priority == valid_fuel_supplies_subq.c.max_role_priority,
                 ),
+                isouter=False # Explicit inner join
             )
             .order_by(FuelSupply.create_date.asc())
         )


### PR DESCRIPTION
When there are more than 40 Fuel-supplies records, the time taken to load the records grows. 

Endpoint /api/fuel-supply/list-all calls the function `get_effective_fuel_supplies` which is executing a query to obtain the fuel supplies lasting 23 secs aprox.

The current changes are reducing significativily the time to  3 secs aprox

Used the following 54 FS records:
```
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,20,'Litres',0,NULL,88.83,36.00,1.00,720,NULL,3,NULL,11,3,NULL,'2024-12-19 04:32:52.805161-07','2024-12-19 04:32:52.805161-07','lcfs1','lcfs1','73d433ad-354b-417f-8c3a-f3a0f3c8ba9c',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,100.21,35.40,1.00,708,NULL,2,NULL,1,3,NULL,'2024-12-19 04:33:05.633352-07','2024-12-19 04:33:05.633352-07','lcfs1','lcfs1','56c77e77-d307-42b3-9bfa-9eb139442801',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Cubic_metres',0,NULL,63.91,38.27,0.90,765,NULL,2,NULL,2,3,NULL,'2024-12-19 04:33:22.589058-07','2024-12-19 04:33:22.589058-07','lcfs1','lcfs1','48f9bdbc-4151-4476-b80e-5e37c4a8fba4',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Cubic_metres',0,NULL,63.91,38.27,0.90,765,NULL,1,NULL,2,3,NULL,'2024-12-19 04:33:41.847706-07','2024-12-19 04:33:41.847706-07','lcfs1','lcfs1','2385c02b-c11b-47de-b345-4d7abf77e398',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,3.80,72,NULL,2,NULL,3,3,4,'2024-12-19 04:34:00.819351-07','2024-12-19 04:34:00.819351-07','lcfs1','lcfs1','1e1719cd-412b-490b-b849-5a3bf39d671b',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,3.20,72,NULL,2,NULL,3,3,5,'2024-12-19 04:34:22.281557-07','2024-12-19 04:34:22.281557-07','lcfs1','lcfs1','5b2f90fa-d3f8-44c7-8837-b6bd34539d44',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,2.50,72,NULL,2,NULL,3,3,6,'2024-12-19 04:34:39.949328-07','2024-12-19 04:34:39.949328-07','lcfs1','lcfs1','6c202cee-08f8-44c7-b059-bf712290925d',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,2.90,72,NULL,2,NULL,3,3,7,'2024-12-19 04:34:59.79467-07','2024-12-19 04:34:59.79467-07','lcfs1','lcfs1','48716c4b-22d4-4820-801f-f988d6ddc716',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,2.50,72,NULL,2,NULL,3,3,8,'2024-12-19 04:35:20.245663-07','2024-12-19 04:35:20.245663-07','lcfs1','lcfs1','0dbeb7e5-5939-4424-b0a3-d033a9b9bbe5',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,3.90,72,NULL,2,NULL,3,3,9,'2024-12-19 04:35:42.763321-07','2024-12-19 04:35:42.763321-07','lcfs1','lcfs1','a805c235-4e37-470e-ae16-68c7f252a0ce',0,'SUPPLIER','CREATE',NULL);
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,1.00,72,NULL,2,NULL,3,3,2,'2024-12-19 04:36:05.540417-07','2024-12-19 04:36:05.540417-07','lcfs1','lcfs1','ac39e748-bee3-4d21-b5de-4b8138ac3cd9',0,'SUPPLIER','CREATE',NULL),
	 (1,30,'Kilowatt_hour',0,NULL,12.14,3.60,2.80,108,NULL,2,NULL,3,3,10,'2024-12-19 04:36:25.482166-07','2024-12-19 04:36:25.482166-07','lcfs1','lcfs1','6acc35b8-2dd0-4b80-bdc6-e7792dde27df',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,2.40,72,NULL,2,NULL,3,3,11,'2024-12-19 04:36:48.756149-07','2024-12-19 04:36:48.756149-07','lcfs1','lcfs1','cda6ba7a-7d2d-4492-b3a5-4ae6a57052ed',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,3.50,72,NULL,1,NULL,3,3,1,'2024-12-19 04:37:16.787356-07','2024-12-19 04:37:16.787356-07','lcfs1','lcfs1','b0e8f47c-1570-4dbd-95ed-966feab8f0b5',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Kilowatt_hour',0,NULL,12.14,3.60,1.00,36,NULL,1,NULL,3,3,2,'2024-12-19 04:37:34.487145-07','2024-12-19 04:37:34.487145-07','lcfs1','lcfs1','f7384e89-4d77-4311-a112-c00ece1e9c50',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilowatt_hour',0,NULL,12.14,3.60,2.50,72,NULL,3,NULL,3,3,NULL,'2024-12-19 04:37:52.862554-07','2024-12-19 04:37:52.862554-07','lcfs1','lcfs1','dc2f23d3-1f08-4552-9ae6-c2740a7663de',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,93.67,23.58,1.00,471,NULL,1,NULL,4,3,NULL,'2024-12-19 04:38:10.000708-07','2024-12-19 04:38:10.000708-07','lcfs1','lcfs1','407fed73-82e8-4f31-b01d-23872df14faf',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,94.38,38.65,1.00,773,NULL,2,NULL,16,1,NULL,'2024-12-19 04:38:27.646702-07','2024-12-19 04:38:27.646702-07','lcfs1','lcfs1','f77eb171-56ed-496f-a027-cca1183435fe',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,93.67,34.69,1.00,693,NULL,1,NULL,17,1,NULL,'2024-12-19 04:38:46.815319-07','2024-12-19 04:38:46.815319-07','lcfs1','lcfs1','e04f5d7d-488a-4925-827b-0b427754ee6a',0,'SUPPLIER','CREATE',NULL),
	 (1,30,'Litres',0,NULL,88.83,37.40,1.00,1122,NULL,3,NULL,18,1,NULL,'2024-12-19 04:39:07.252695-07','2024-12-19 04:39:07.252695-07','lcfs1','lcfs1','8e546060-401a-4b6b-8d2e-b573afe0b494',0,'SUPPLIER','CREATE',NULL);
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,20,'Litres',0,NULL,100.21,37.89,1.00,757,NULL,2,NULL,5,3,NULL,'2024-12-19 04:39:24.514693-07','2024-12-19 04:39:24.514693-07','lcfs1','lcfs1','37691c80-e627-4ebd-a4d1-70e5f57bcdab',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilograms',0,NULL,123.96,141.76,1.80,2835,NULL,2,NULL,6,3,3,'2024-12-19 04:40:11.542759-07','2024-12-19 04:40:11.542759-07','lcfs1','lcfs1','f89a4b9a-f807-455d-af18-be3e6ec605a6',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilograms',0,NULL,123.96,141.76,0.90,2835,NULL,2,NULL,6,3,2,'2024-12-19 04:40:34.225376-07','2024-12-19 04:40:34.225376-07','lcfs1','lcfs1','c66de94d-6c8a-4eae-9b8d-1ff709b6a283',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Kilograms',0,NULL,123.96,141.76,2.40,2835,NULL,1,NULL,6,3,3,'2024-12-19 04:40:58.741257-07','2024-12-19 04:40:58.741257-07','lcfs1','lcfs1','a63ad90a-2723-4ad6-a268-12f238146176',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Kilograms',0,NULL,123.96,141.76,0.90,1417,NULL,1,NULL,6,3,2,'2024-12-19 04:41:26.038866-07','2024-12-19 04:41:26.038866-07','lcfs1','lcfs1','5090a366-9ae0-4068-9b9c-15072e009474',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Kilograms',0,NULL,123.96,141.76,1.00,1417,NULL,3,NULL,6,3,NULL,'2024-12-19 04:41:46.542466-07','2024-12-19 04:41:46.542466-07','lcfs1','lcfs1','0c9f3a22-de7c-422f-aba4-d66c03214cab',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Kilograms',0,NULL,90.11,53.54,1.00,535,NULL,2,NULL,7,3,15,'2024-12-19 04:42:08.153852-07','2024-12-19 04:42:08.153852-07','lcfs1','lcfs1','3ea5995f-51c1-4163-bf17-2281adad7d73',0,'SUPPLIER','CREATE',27.30),
	 (1,10,'Kilograms',0,NULL,90.11,53.54,1.00,535,NULL,2,NULL,7,3,16,'2024-12-19 04:42:33.298426-07','2024-12-19 04:42:33.298426-07','lcfs1','lcfs1','319052ae-0386-46cd-aa72-d45430805d59',0,'SUPPLIER','CREATE',17.80),
	 (1,10,'Kilograms',0,NULL,90.11,53.54,1.00,535,NULL,2,NULL,7,3,17,'2024-12-19 04:43:00.0393-07','2024-12-19 04:43:00.0393-07','lcfs1','lcfs1','73ff5ff3-696e-4fbe-a103-fbb882db2cf2',0,'SUPPLIER','CREATE',12.20),
	 (1,10,'Kilograms',0,NULL,90.11,53.54,1.00,535,NULL,2,NULL,7,3,21,'2024-12-19 04:43:20.97134-07','2024-12-19 04:43:20.97134-07','lcfs1','lcfs1','d5068f0b-c05b-48c9-8c9d-50f56d2d165b',0,'SUPPLIER','CREATE',27.30);
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,20,'Kilograms',0,NULL,90.11,53.54,1.00,1070,NULL,2,NULL,7,3,18,'2024-12-19 04:44:10.142346-07','2024-12-19 04:44:10.142346-07','lcfs1','lcfs1','bea25a24-7ac8-4790-9459-1b5aa3e4ccf4',0,'SUPPLIER','CREATE',10.60),
	 (1,20,'Kilograms',0,NULL,90.11,53.54,1.00,1070,NULL,2,NULL,7,3,19,'2024-12-19 04:45:03.795557-07','2024-12-19 04:45:03.795557-07','lcfs1','lcfs1','1199df44-45f9-4a77-89a1-76fc26a74de7',0,'SUPPLIER','CREATE',8.40),
	 (1,20,'Kilograms',0,NULL,90.11,53.54,1.00,1070,NULL,2,NULL,7,3,20,'2024-12-19 04:46:07.607571-07','2024-12-19 04:46:07.607571-07','lcfs1','lcfs1','4cdb1d14-3c68-492f-8dc7-d786fe57c6e1',0,'SUPPLIER','CREATE',8.00),
	 (1,30,'Kilograms',0,NULL,90.11,53.54,0.90,1606,NULL,2,NULL,7,3,23,'2024-12-19 05:31:28.768866-07','2024-12-19 05:31:28.768866-07','lcfs1','lcfs1','ad396113-9ebe-4ed8-adea-d7794481085a',0,'SUPPLIER','CREATE',0.00),
	 (1,30,'Kilograms',0,NULL,90.11,53.54,0.90,1606,NULL,2,NULL,7,3,22,'2024-12-19 05:31:45.521104-07','2024-12-19 05:31:45.521104-07','lcfs1','lcfs1','c86af180-00fb-4c5d-9c25-493b42a51274',0,'SUPPLIER','CREATE',27.30),
	 (1,20,'Kilograms',0,NULL,65.34,53.54,1.00,1070,NULL,2,10,7,2,15,'2024-12-19 05:32:07.95743-07','2024-12-19 05:32:07.95743-07','lcfs1','lcfs1','821121bb-6bbe-437c-bf5e-9d3e6059688b',0,'SUPPLIER','CREATE',27.30),
	 (1,30,'Kilograms',0,NULL,65.34,53.54,1.00,1606,NULL,2,10,7,2,16,'2024-12-19 05:32:32.928647-07','2024-12-19 05:32:32.928647-07','lcfs1','lcfs1','9ca75827-34e3-44bd-8f0c-04af5000499d',0,'SUPPLIER','CREATE',17.80),
	 (1,20,'Kilograms',0,NULL,65.34,53.54,1.00,1070,NULL,2,10,7,2,17,'2024-12-19 05:32:52.828482-07','2024-12-19 05:32:52.828482-07','lcfs1','lcfs1','4fee6e08-7885-4e00-b977-0d28c25bd2e7',0,'SUPPLIER','CREATE',12.20),
	 (1,30,'Kilograms',0,NULL,65.34,53.54,1.00,1606,NULL,2,10,7,2,21,'2024-12-19 05:33:11.27639-07','2024-12-19 05:33:11.27639-07','lcfs1','lcfs1','93495600-47eb-40a1-ae95-6c627e37c449',0,'SUPPLIER','CREATE',27.30),
	 (1,30,'Kilograms',0,NULL,65.34,53.54,1.00,1606,NULL,2,10,7,2,18,'2024-12-19 05:33:30.135814-07','2024-12-19 05:33:30.135814-07','lcfs1','lcfs1','dff1d60f-fe74-40a4-8814-95896f1862d1',0,'SUPPLIER','CREATE',10.60);
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,20,'Kilograms',0,NULL,65.34,53.54,1.00,1070,NULL,2,10,7,2,19,'2024-12-19 05:33:57.466715-07','2024-12-19 05:33:57.466715-07','lcfs1','lcfs1','35eabbe3-69a0-43c3-a2e1-8ca6f76543f2',0,'SUPPLIER','CREATE',8.40),
	 (1,10,'Kilograms',0,NULL,65.34,53.54,1.00,535,NULL,2,10,7,2,20,'2024-12-19 05:34:19.397214-07','2024-12-19 05:34:19.397214-07','lcfs1','lcfs1','db039ea1-259b-4bd1-a628-7356efef076b',0,'SUPPLIER','CREATE',8.00),
	 (1,10,'Kilograms',0,NULL,65.34,53.54,0.90,535,NULL,2,10,7,2,23,'2024-12-19 05:34:40.300724-07','2024-12-19 05:34:40.300724-07','lcfs1','lcfs1','af910397-345b-463d-87a4-69182b8bbce3',0,'SUPPLIER','CREATE',0.00),
	 (1,10,'Kilograms',0,NULL,65.34,53.54,0.90,535,NULL,2,10,7,2,22,'2024-12-19 05:34:59.547812-07','2024-12-19 05:34:59.547812-07','lcfs1','lcfs1','da3d53a4-cd12-46e5-898c-0e185e5d8de9',0,'SUPPLIER','CREATE',27.30),
	 (1,10,'Litres',0,NULL,100.21,NULL,1.00,0,'other fuel type',2,NULL,19,3,NULL,'2024-12-19 05:35:43.287794-07','2024-12-19 05:35:43.287794-07','lcfs1','lcfs1','97b3088b-a738-4064-8aae-a280c8179ff8',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Litres',0,NULL,88.83,NULL,1.00,0,'other jet fuel',3,NULL,19,3,NULL,'2024-12-19 05:36:29.289427-07','2024-12-19 05:36:29.289427-07','lcfs1','lcfs1','95f37055-3c01-4c92-9adb-1054bc953544',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Litres',0,NULL,93.67,NULL,1.00,0,'other gasoline',1,NULL,19,3,NULL,'2024-12-19 05:36:06.487873-07','2024-12-19 05:36:06.487873-07','lcfs1','lcfs1','b077feb3-12af-44af-9b5a-bf117ae0e16b',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Litres',0,NULL,100.21,36.51,1.00,365,NULL,2,NULL,20,1,NULL,'2024-12-19 05:36:48.616271-07','2024-12-19 05:36:48.616271-07','lcfs1','lcfs1','18bdec14-6d89-4ca6-b522-1949f4f36936',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,79.87,25.62,0.90,512,NULL,1,NULL,13,3,NULL,'2024-12-19 05:37:30.463245-07','2024-12-19 05:37:30.463245-07','lcfs1','lcfs1','73f432f6-dcc8-4a4e-8478-122241159931',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,93.67,34.69,1.00,693,NULL,1,NULL,14,3,NULL,'2024-12-19 05:37:56.286044-07','2024-12-19 05:37:56.286044-07','lcfs1','lcfs1','daf10c35-d419-4ba2-98aa-b070dbb71923',0,'SUPPLIER','CREATE',NULL);
INSERT INTO public.fuel_supply (compliance_report_id,quantity,units,compliance_units,target_ci,ci_of_fuel,energy_density,eer,energy,fuel_type_other,fuel_category_id,fuel_code_id,fuel_type_id,provision_of_the_act_id,end_use_id,create_date,update_date,create_user,update_user,group_uuid,"version",user_type,action_type,uci) VALUES
	 (1,10,'Litres',0,NULL,79.87,25.62,0.90,256,NULL,2,NULL,13,3,NULL,'2024-12-19 05:37:14.261351-07','2024-12-19 05:37:14.261351-07','lcfs1','lcfs1','a5d4e79f-3a5c-461b-9ffa-2923a205bc06',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,-9.52,34.69,1.00,693,NULL,1,19,14,2,NULL,'2024-12-19 05:38:16.503071-07','2024-12-19 05:38:16.503071-07','lcfs1','lcfs1','e367deb5-ca20-4adb-9e85-888735d27334',0,'SUPPLIER','CREATE',NULL),
	 (1,10,'Litres',0,NULL,93.67,34.51,1.00,345,NULL,1,NULL,15,3,NULL,'2024-12-19 05:38:51.411151-07','2024-12-19 05:38:51.411151-07','lcfs1','lcfs1','6cc78690-c507-4f67-96b8-cc68848bb817',0,'SUPPLIER','CREATE',NULL),
	 (1,20,'Litres',0,NULL,20.37,34.51,1.00,690,NULL,1,16,15,2,NULL,'2024-12-19 05:39:11.957247-07','2024-12-19 05:39:11.957247-07','lcfs1','lcfs1','3a4027f6-54f8-45ea-b5ee-1f472155ee1a',0,'SUPPLIER','CREATE',NULL);
```


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=90883190&issue=bcgov%7Clcfs%7C1457)