### PR TITLE
fix: FE Cache Fixes

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.DS_Store

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -5,10 +5,11 @@ FROM node:20
 WORKDIR /app
 
 # Copy package files and install dependencies
-COPY package*.json ./
+COPY package.json ./
+COPY package-lock.json ./
 RUN npm install
 
-# Copy other source files
+# Copy other source files - node modules is excluded in .dockerignore
 COPY . .
 
 # Expose port 3000 for the app


### PR DESCRIPTION
FE dockerfile was copying node_modules AFTER running NPM install meaning it used local node_modules over its own. Add a .dockerignore to prevent this.

Use explicit copy instead of copy * to easier track and see layer changes