### PR TITLE
LCFS-1581: Edit icon appearing for IDIR users when compliance reports are in the Submitted status

### DIFF
--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -90,8 +90,7 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
     hasRoles
   } = useCurrentUser()
   const isGovernmentUser = currentUser?.isGovernmentUser
-  const isAnalystRole =
-    currentUser?.roles?.some((role) => role.name === roles.analyst) || false
+  const userRoles = currentUser?.roles
 
   const currentStatus = reportData?.report.currentStatus?.status
   const { data: orgData, isLoading } = useOrganization(
@@ -228,7 +227,7 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
             <>
               <ReportDetails
                 currentStatus={currentStatus}
-                isAnalystRole={isAnalystRole}
+                userRoles={userRoles}
               />
               <ComplianceReportSummary
                 reportID={complianceReportId}

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -34,18 +34,40 @@ import DocumentUploadDialog from '@/components/Documents/DocumentUploadDialog'
 import { useComplianceReportDocuments } from '@/hooks/useComplianceReports'
 import { COMPLIANCE_REPORT_STATUSES } from '@/constants/statuses'
 
-const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
+const ReportDetails = ({ currentStatus = 'Draft', userRoles }) => {
   const { t } = useTranslation()
   const { compliancePeriod, complianceReportId } = useParams()
   const navigate = useNavigate()
 
   const [isFileDialogOpen, setFileDialogOpen] = useState(false)
+  const isAnalystRole = userRoles.some(role => role.name === roles.analyst) || false;
+  const isSupplierRole = userRoles.some(role => role.name === roles.supplier) || false;
+
   const editSupportingDocs = useMemo(() => {
     return isAnalystRole && (
       currentStatus === COMPLIANCE_REPORT_STATUSES.SUBMITTED ||
       currentStatus === COMPLIANCE_REPORT_STATUSES.ASSESSED
-    ) || currentStatus === COMPLIANCE_REPORT_STATUSES.DRAFT;
+    )
   }, [isAnalystRole, currentStatus]);
+
+  const editAnalyst = useMemo(() => {
+    return isAnalystRole && (
+      currentStatus === COMPLIANCE_REPORT_STATUSES.REASSESSED
+    )
+  }, [isAnalystRole, currentStatus]);
+
+  const editSupplier = useMemo(() => {
+    return isSupplierRole && (
+      currentStatus === COMPLIANCE_REPORT_STATUSES.DRAFT
+    )
+  }, [isSupplierRole, currentStatus]);
+
+  const shouldShowEditIcon = (activityName) => {
+    if (activityName === t('report:supportingDocs')) {
+      return editSupportingDocs;
+    }
+    return editAnalyst || editSupplier;
+  };
 
   const isArrayEmpty = useCallback((data) => {
     if (Array.isArray(data)) {
@@ -260,12 +282,11 @@ const ReportDetails = ({ currentStatus = 'Draft', isAnalystRole }) => {
                   component="div"
                 >
                   {activity.name}&nbsp;&nbsp;
-                  {editSupportingDocs && (
+                  {shouldShowEditIcon(activity.name) && (
                     <>
                       <Role
                         roles={[
                           roles.supplier,
-                          roles.compliance_reporting,
                           roles.compliance_reporting,
                           roles.analyst
                         ]}


### PR DESCRIPTION
**Restrict Edit Icon Visibility in Compliance Report Schedules**

For BCeID users:
If the compliance report status is Draft, the edit icon is displayed.
For all other statuses, the edit icon is hidden.

For Analyst users:
If the compliance report status is ReAssessed, the edit icon is displayed.
If the status is Submitted or Assessed, the edit icon is only displayed in the supporting documents section.

<img width="794" alt="image" src="https://github.com/user-attachments/assets/1fb7dc0a-3ec8-438f-a2b5-447688695c13" />


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=92395129&issue=bcgov%7Clcfs%7C1581)