### PR TITLE
LCFS-1385: Only ETL Users with Valid Emails

### DIFF
--- a/etl/nifi_scripts/user.groovy
+++ b/etl/nifi_scripts/user.groovy
@@ -24,8 +24,8 @@ def userProfileQuery = """
                     u.id
             ) AS occurrence,
 
-            COALESCE(NULLIF(ucr.keycloak_email, ''), u.email) AS keycloak_email,
-            COALESCE(NULLIF(u.email, ''), '') AS email,
+            COALESCE(NULLIF(ucr.keycloak_email, ''), NULLIF(u.email, ''), 'user@gov.bc.ca') AS keycloak_email,
+            COALESCE(NULLIF(u.email, ''), NULLIF(ucr.keycloak_email, ''), 'user@gov.bc.ca') AS email,
             u.title,
             u.phone,
             u.cell_phone AS mobile_phone,


### PR DESCRIPTION
Modified user.groovy to ensure that the email field is always assigned a valid value.


[Story](https://github.com/orgs/bcgov/projects/137/views/1?filterQuery=arey&pane=issue&itemId=90026159&issue=bcgov%7Clcfs%7C1385)