### PR TITLE
fix: Return transaction instead of applying

### DIFF
--- a/frontend/src/views/FinalSupplyEquipments/AddEditFinalSupplyEquipments.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/AddEditFinalSupplyEquipments.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import BCTypography from '@/components/BCTypography'
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
 import { useTranslation } from 'react-i18next'
@@ -19,7 +19,6 @@ import { handleScheduleSave } from '@/utils/schedules.js'
 export const AddEditFinalSupplyEquipments = () => {
   const [rowData, setRowData] = useState([])
   const gridRef = useRef(null)
-
   const [errors, setErrors] = useState({})
   const [warnings, setWarnings] = useState({})
   const [columnDefs, setColumnDefs] = useState([])
@@ -70,7 +69,6 @@ export const AddEditFinalSupplyEquipments = () => {
 
   const onGridReady = useCallback(
     async (params) => {
-      setGridApi(params.api)
       if (isArrayEmpty(data)) {
         setRowData([
           {
@@ -196,10 +194,10 @@ export const AddEditFinalSupplyEquipments = () => {
         modified: true
       }
 
-      const transaction = params.api.applyTransaction({
+      const transaction = {
         add: [rowData],
         addIndex: params.node?.rowIndex + 1
-      })
+      }
 
       setErrors({ [newRowID]: 'finalSupplyEquipment' })
 


### PR DESCRIPTION
* BCGridBase now takes a Transaction returned from onAction and will apply it if it contains rows.
* This was changed so we can focus on the newly added cell, and it looks like this table was not updated