### PR TITLE
LCFS-1760: 500 error in compliance report summary lines 6 and 8

### DIFF
--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -206,6 +206,7 @@ class ComplianceReportSummarySchema(BaseSchema):
 
 class ComplianceReportSummaryUpdateSchema(BaseSchema):
     compliance_report_id: int
+    is_locked: Optional[bool] = False
     renewable_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
     low_carbon_fuel_target_summary: List[ComplianceReportSummaryRowSchema]
     non_compliance_penalty_summary: List[ComplianceReportSummaryRowSchema]

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -235,7 +235,6 @@ class ComplianceReportSummaryService:
         """
         Autosave compliance report summary details for a specific summary by ID.
         """
-
         await self.repo.save_compliance_report_summary(summary_data)
         summary_data = await self.calculate_compliance_report_summary(report_id)
 
@@ -450,9 +449,9 @@ class ComplianceReportSummaryService:
             jet_fuel_percentage = 3 / 100
 
         eligible_renewable_fuel_required = {
-            "gasoline": tracked_totals["gasoline"] * 0.05,
-            "diesel": tracked_totals["diesel"] * 0.04,
-            "jet_fuel": tracked_totals["jet_fuel"] * jet_fuel_percentage,
+            "gasoline": round(tracked_totals["gasoline"] * 0.05),
+            "diesel": round(tracked_totals["diesel"] * 0.04),
+            "jet_fuel": round(tracked_totals["jet_fuel"] * jet_fuel_percentage),
         }
 
         # line 6

--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -246,8 +246,8 @@ export const renewableFuelColumns = (
       editable,
       editableCells: gasolineEditableCells,
       cellConstraints: {
-        5: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].gasoline },
-        7: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].gasoline }
+        5: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].gasoline) },
+        7: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].gasoline) }
       }
     },
     {
@@ -258,8 +258,8 @@ export const renewableFuelColumns = (
       editable,
       editableCells: dieselEditableCells,
       cellConstraints: {
-        5: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].diesel },
-        7: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].diesel }
+        5: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].diesel) },
+        7: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].diesel) }
       }
     },
     {
@@ -270,8 +270,8 @@ export const renewableFuelColumns = (
       editable,
       editableCells: jetFuelEditableCells,
       cellConstraints: {
-        5: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].jetFuel },
-        7: { min: 0, max: 0.05 * data[SUMMARY.LINE_4].jetFuel }
+        5: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].jetFuel) },
+        7: { min: 0, max: Math.round(0.05 * data[SUMMARY.LINE_4].jetFuel) }
       }
     }
   ]


### PR DESCRIPTION
- Fixed missing field in ComplianceReportSummaryUpdateSchema, which was causing a backend error:

`AttributeError: 'ComplianceReportSummaryUpdateSchema' object has no attribute 'is_locked'`

- Resolved amount calculation issue where values were stored as integers but calculated using decimals, leading to errors when saving lines 6 and 8. Confirmed with the user that amounts should be calculated using standard rounding (rounding to the nearest integer).

<img width="458" alt="image" src="https://github.com/user-attachments/assets/0af1d0d5-a522-4c34-b050-29eb5ce23f04" />


