### PR TITLE
Feat: Update role subscription notification logic - 1703

### DIFF
--- a/backend/lcfs/db/migrations/versions/2025-01-23-15-38_7f7b03241d7f.py
+++ b/backend/lcfs/db/migrations/versions/2025-01-23-15-38_7f7b03241d7f.py
@@ -6,7 +6,7 @@ It also populates 'role_id' for existing notification types based on their 'noti
 Additionally, it updates the 'IN_APP' notification channel so that 'subscribe_by_default' is enabled.
 
 Revision ID: 7f7b03241d7f
-Revises: ec826b9226df
+Revises: 0576833c005d
 Create Date: 2025-01-23 15:38:19.362993
 """
 
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7f7b03241d7f"
-down_revision = "ec826b9226df"
+down_revision = "0576833c005d"
 branch_labels = None
 depends_on = None
 

--- a/backend/lcfs/db/migrations/versions/2025-01-23-15-38_7f7b03241d7f.py
+++ b/backend/lcfs/db/migrations/versions/2025-01-23-15-38_7f7b03241d7f.py
@@ -1,0 +1,105 @@
+"""
+Add role reference to notification_type
+
+This migration adds a required 'role_id' foreign key to the 'notification_type' table, linking it to the 'role' table. 
+It also populates 'role_id' for existing notification types based on their 'notification_type_id'.
+Additionally, it updates the 'IN_APP' notification channel so that 'subscribe_by_default' is enabled.
+
+Revision ID: 7f7b03241d7f
+Revises: ec826b9226df
+Create Date: 2025-01-23 15:38:19.362993
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7f7b03241d7f"
+down_revision = "ec826b9226df"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add the role_id column to the notification_type table
+    op.add_column(
+        "notification_type",
+        sa.Column(
+            "role_id",
+            sa.Integer(),
+            nullable=True,
+            comment="Foreign key to the role table representing the required role for this notification type.",
+        ),
+    )
+
+    # Add the foreign key constraint
+    op.create_foreign_key(
+        "fk_notification_type_role_id",
+        "notification_type",
+        "role",
+        ["role_id"],
+        ["role_id"],
+        ondelete="SET NULL",
+    )
+
+    # Populate role_id for existing notification_type records
+    op.execute(
+        """
+        UPDATE notification_type
+            SET role_id = CASE notification_type_id
+            WHEN 1 THEN 2
+            WHEN 2 THEN 2
+            WHEN 3 THEN 2
+            WHEN 4 THEN 2
+            WHEN 5 THEN 4
+            WHEN 6 THEN 4
+            WHEN 7 THEN 4
+            WHEN 8 THEN 4
+            WHEN 9 THEN 4
+            WHEN 10 THEN 4
+            WHEN 11 THEN 4
+            WHEN 12 THEN 5
+            WHEN 13 THEN 5
+            WHEN 14 THEN 5
+            WHEN 15 THEN 6
+            WHEN 16 THEN 6
+            WHEN 17 THEN 6
+        END;
+    """
+    )
+
+    # Enable subscribe_by_default for the IN_APP channel
+    op.execute(
+        """
+        UPDATE notification_channel
+        SET subscribe_by_default = TRUE
+        WHERE channel_name = 'IN_APP';
+        """
+    )
+
+
+def downgrade() -> None:
+    # Revert role_id fields to NULL
+    op.execute(
+        """
+        UPDATE notification_type
+        SET role_id = NULL
+        """
+    )
+
+    # Drop the foreign key
+    op.drop_constraint(
+        "fk_notification_type_role_id", "notification_type", type_="foreignkey"
+    )
+
+    # Drop the column
+    op.drop_column("notification_type", "role_id")
+
+    # Revert subscribe_by_default for the IN_APP channel
+    op.execute(
+        """
+        UPDATE notification_channel
+        SET subscribe_by_default = FALSE
+        WHERE channel_name = 'IN_APP';
+        """
+    )

--- a/backend/lcfs/db/models/notification/NotificationType.py
+++ b/backend/lcfs/db/models/notification/NotificationType.py
@@ -1,5 +1,5 @@
 from lcfs.db.base import BaseModel, Auditable
-from sqlalchemy import Column, Integer, Text, String
+from sqlalchemy import Column, Integer, Text, String, ForeignKey
 from sqlalchemy.orm import relationship
 
 
@@ -7,11 +7,32 @@ class NotificationType(BaseModel, Auditable):
     __tablename__ = "notification_type"
     __table_args__ = {"comment": "Represents a Notification type"}
 
-    notification_type_id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String(255), nullable=False)
-    description = Column(Text, nullable=True)
-    email_content = Column(Text, nullable=True)
+    # Columns
+    notification_type_id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment="Unique identifier for the notification type",
+    )
+    name = Column(
+        String(255), nullable=False, comment="The name of the notification type"
+    )
+    description = Column(
+        Text, nullable=True, comment="Detailed description of the notification type"
+    )
+    email_content = Column(
+        Text,
+        nullable=True,
+        comment="The email content template for this notification type",
+    )
+    role_id = Column(
+        Integer,
+        ForeignKey("role.role_id"),
+        comment="Foreign key referencing the Role table",
+    )
 
+    # Relationships
     subscriptions = relationship(
         "NotificationChannelSubscription", back_populates="notification_type"
     )
+    role = relationship("Role", back_populates="notification_type_roles")

--- a/backend/lcfs/db/models/user/Role.py
+++ b/backend/lcfs/db/models/user/Role.py
@@ -43,7 +43,9 @@ class Role(BaseModel, Auditable):
     )
     display_order = Column(Integer, comment="Relative rank in display sorting order")
 
+    # Relationships
     user_roles = relationship("UserRole", back_populates="role")
+    notification_type_roles = relationship("NotificationType", back_populates="role")
 
     def __repr__(self):
         return "<Role %r>" % self.name

--- a/backend/lcfs/db/seeders/dev/notification_channel_subscription_seeder.py
+++ b/backend/lcfs/db/seeders/dev/notification_channel_subscription_seeder.py
@@ -1,0 +1,98 @@
+import structlog
+from sqlalchemy import select
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.db.models.user.UserRole import UserRole
+from lcfs.db.models.notification.NotificationType import NotificationType
+from lcfs.db.models.notification.NotificationChannel import NotificationChannel
+from lcfs.db.models.notification.NotificationChannelSubscription import (
+    NotificationChannelSubscription,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+async def seed_notification_channel_subscriptions(session):
+    """
+    Seeds NotificationChannelSubscription records for every user based on their roles,
+    for all channels that are 'enabled' and 'subscribe_by_default'.
+
+    Steps:
+        1. Get all channels that are (enabled=True, subscribe_by_default=True).
+        2. For each user, find their roles.
+        3. For each role, find the NotificationTypes pointing to that role.
+        4. For each NotificationType + channel, insert a subscription if missing.
+    """
+
+    logger.info("Seeding NotificationChannelSubscription...")
+
+    # 1. Fetch all channels that are enabled & subscribe_by_default
+    channels_query = select(NotificationChannel).where(
+        NotificationChannel.enabled == True,
+        NotificationChannel.subscribe_by_default == True,
+    )
+    channels = (await session.execute(channels_query)).scalars().all()
+    if not channels:
+        logger.info("No enabled + subscribe_by_default channels found; skipping.")
+        return
+
+    # Convert to a list of IDs for convenience
+    channel_ids = [ch.notification_channel_id for ch in channels]
+
+    # 2. Fetch all user profiles
+    users_query = select(UserProfile).order_by(UserProfile.user_profile_id)
+    users = (await session.execute(users_query)).scalars().all()
+    if not users:
+        logger.info("No users found; skipping NotificationChannelSubscription seeding.")
+        return
+
+    # For logging summary
+    total_inserts = 0
+
+    for user in users:
+        # 3. For the user's roles, find matching NotificationTypes
+        user_roles_query = select(UserRole).where(
+            UserRole.user_profile_id == user.user_profile_id
+        )
+        user_role_objs = (await session.execute(user_roles_query)).scalars().all()
+        if not user_role_objs:
+            continue  # user has no roles => skip
+
+        for user_role_obj in user_role_objs:
+            # Find the NotificationTypes referencing user_role_obj.role_id
+            notif_types_query = select(NotificationType).where(
+                NotificationType.role_id == user_role_obj.role_id
+            )
+            matching_types = (await session.execute(notif_types_query)).scalars().all()
+            if not matching_types:
+                continue
+
+            # 4. For each NotificationType + each channel -> insert subscription if missing
+            for nt in matching_types:
+                for ch_id in channel_ids:
+                    exists_query = select(NotificationChannelSubscription).where(
+                        NotificationChannelSubscription.user_profile_id
+                        == user.user_profile_id,
+                        NotificationChannelSubscription.notification_type_id
+                        == nt.notification_type_id,
+                        NotificationChannelSubscription.notification_channel_id
+                        == ch_id,
+                    )
+                    existing_sub = (
+                        await session.execute(exists_query)
+                    ).scalar_one_or_none()
+                    if not existing_sub:
+                        # Insert a new subscription
+                        new_sub = NotificationChannelSubscription(
+                            user_profile_id=user.user_profile_id,
+                            notification_type_id=nt.notification_type_id,
+                            notification_channel_id=ch_id,
+                            is_enabled=True,
+                        )
+                        session.add(new_sub)
+                        total_inserts += 1
+
+    await session.flush()
+    logger.info(
+        "Seeding NotificationChannelSubscription complete.",
+        total_inserted=total_inserts,
+    )

--- a/backend/lcfs/db/seeders/dev_seeder.py
+++ b/backend/lcfs/db/seeders/dev_seeder.py
@@ -22,6 +22,9 @@ from lcfs.db.seeders.dev.finished_fuel_transfer_mode_seeder import (
 from lcfs.db.seeders.dev.feedstock_fuel_transfer_mode_seeder import (
     seed_feedstock_fuel_transfer_modes,
 )
+from lcfs.db.seeders.dev.notification_channel_subscription_seeder import (
+    seed_notification_channel_subscriptions,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -63,6 +66,7 @@ async def seed_dev(session: AsyncSession):
     await seed_fuel_codes(session)
     await seed_finished_fuel_transfer_modes(session)
     await seed_feedstock_fuel_transfer_modes(session)
+    await seed_notification_channel_subscriptions(session)
 
     # Update sequences after all seeders have run
     await update_sequences(session)

--- a/backend/lcfs/logging_config.py
+++ b/backend/lcfs/logging_config.py
@@ -80,7 +80,11 @@ def custom_console_renderer():
                     exc_type, exc_value, exc_traceback = sys.exc_info()
                 # Create a Traceback object
                 rich_traceback = Traceback.from_exception(
-                    exc_type, exc_value, exc_traceback, width=console.width
+                    exc_type,
+                    exc_value,
+                    exc_traceback,
+                    width=console.width,
+                    max_frames=5,
                 )
                 console.print(rich_traceback)
             else:

--- a/backend/lcfs/tests/notification/test_notification_services.py
+++ b/backend/lcfs/tests/notification/test_notification_services.py
@@ -1,15 +1,16 @@
-from lcfs.web.api.notification.schema import (
-    SubscriptionSchema,
-    NotificationMessageSchema,
-)
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from lcfs.web.api.notification.services import NotificationService
+from lcfs.db.models.user.Role import RoleEnum
 from lcfs.db.models.notification import (
     NotificationChannelSubscription,
     NotificationMessage,
 )
+from lcfs.web.api.notification.services import NotificationService
 from lcfs.web.api.notification.repo import NotificationRepository
+from lcfs.web.api.notification.schema import (
+    SubscriptionSchema,
+    NotificationMessageSchema,
+)
 
 # Mock common data for reuse
 mock_notification_message = NotificationMessage(
@@ -397,4 +398,34 @@ async def test_delete_notification_channel_subscription(notification_service):
     )
     mock_repo.delete_notification_channel_subscription.assert_awaited_once_with(
         subscription_id
+    )
+
+
+@pytest.mark.anyio
+async def test_service_delete_subscriptions_for_user_role(notification_service):
+    service, mock_repo = notification_service
+    user_profile_id = 1
+    role_enum = RoleEnum.ANALYST
+
+    mock_repo.delete_subscriptions_for_user_role = AsyncMock()
+
+    await service.delete_subscriptions_for_user_role(user_profile_id, role_enum)
+
+    mock_repo.delete_subscriptions_for_user_role.assert_awaited_once_with(
+        user_profile_id, role_enum
+    )
+
+
+@pytest.mark.anyio
+async def test_service_add_subscriptions_for_user_role(notification_service):
+    service, mock_repo = notification_service
+    user_profile_id = 1
+    role_enum = RoleEnum.DIRECTOR
+
+    mock_repo.add_subscriptions_for_user_role = AsyncMock()
+
+    await service.add_subscriptions_for_user_role(user_profile_id, role_enum)
+
+    mock_repo.add_subscriptions_for_user_role.assert_awaited_once_with(
+        user_profile_id, role_enum
     )

--- a/backend/lcfs/web/api/notification/services.py
+++ b/backend/lcfs/web/api/notification/services.py
@@ -283,3 +283,19 @@ class NotificationService:
                 notification.notification_context,
                 notification.notification_data.related_organization_id,
             )
+
+    @service_handler
+    async def delete_subscriptions_for_user_role(
+        self, user_profile_id: int, role_id: int
+    ):
+        """
+        Deletes all notification subscriptions for a user with a given role.
+        """
+        await self.repo.delete_subscriptions_for_user_role(user_profile_id, role_id)
+
+    @service_handler
+    async def add_subscriptions_for_user_role(self, user_profile_id: int, role_id: int):
+        """
+        Adds subscriptions for a user based on their role.
+        """
+        await self.repo.add_subscriptions_for_user_role(user_profile_id, role_id)

--- a/backend/lcfs/web/api/user/repo.py
+++ b/backend/lcfs/web/api/user/repo.py
@@ -331,6 +331,7 @@ class UserRepository:
             org = org_result.scalar_one_or_none()
             db_user_profile.organization = org
         self.db.add(db_user_profile)
+        await self.db.flush()
         return db_user_profile
 
     @repo_handler


### PR DESCRIPTION
This PR updates the logic to align with business requirements, setting default notifications for all subscriptions when a role changes. Users set to Inactive will have their settings cleared.

Backend logs now show less traceback for better clarity and maintainability. 

Closes #1703