### PR TITLE
LCFS-1802: Not able to select the fuel category for Alternative Jet fuel in Supply of fuel in TEST

### DIFF
--- a/backend/lcfs/db/migrations/versions/2025-01-27-20-28_26bb41f15dc4.py
+++ b/backend/lcfs/db/migrations/versions/2025-01-27-20-28_26bb41f15dc4.py
@@ -1,0 +1,57 @@
+"""Update end_use_type_id in energy_effectiveness_ratio
+
+Revision ID: 26bb41f15dc4
+Revises: 66b4ae533e8d
+Create Date: 2025-01-27 13:28:15.607968
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "26bb41f15dc4"
+down_revision = "66b4ae533e8d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Update end_use_type_id for specific records"""
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = 24
+        WHERE fuel_category_id = 2 AND fuel_type_id = 13;
+    """)
+
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = 24
+        WHERE fuel_category_id = 3 AND fuel_type_id = 3;
+    """)
+
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = 24
+        WHERE fuel_category_id = 3 AND fuel_type_id = 11;
+    """)
+
+def downgrade():
+    """Revert changes (Replace NULL with original values if known)"""
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = NULL  -- Modify if the original values are known
+        WHERE fuel_category_id = 2 AND fuel_type_id = 13;
+    """)
+
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = NULL
+        WHERE fuel_category_id = 3 AND fuel_type_id = 3;
+    """)
+
+    op.execute("""
+        UPDATE energy_effectiveness_ratio 
+        SET end_use_type_id = NULL
+        WHERE fuel_category_id = 3 AND fuel_type_id = 11;
+    """)

--- a/frontend/src/views/FuelSupplies/AddEditFuelSupplies.jsx
+++ b/frontend/src/views/FuelSupplies/AddEditFuelSupplies.jsx
@@ -212,6 +212,22 @@ export const AddEditFuelSupplies = () => {
             endUseTypes.length === 1 ? endUseTypes[0].type : null
 
           params.node.setDataValue('endUseType', endUseValue)
+
+          if (selectedFuelType.provisions.length === 1 &&
+            !params.node.data.provisionOfTheAct
+          ) {
+            params.node.setDataValue(
+              'provisionOfTheAct',
+              selectedFuelType.provisions[0].name
+            )
+            params.node.setDataValue(
+              'provisionOfTheActId',
+              selectedFuelType.provisions[0].provisionOfTheActId
+            )
+          } else {
+            params.node.setDataValue('provisionOfTheAct', null)
+            params.node.setDataValue('provisionOfTheActId', null)
+          }
         }
       }
     },


### PR DESCRIPTION
There are some fuel types that do not autopopulate fuel category and end use:
fuel_type           |category|
Propane             |Diesel  |
Electricity         |Jet fuel|
Alternative jet fuel|Jet fuel|

**Fix**
Update end_use_type_id in energy_effectiveness_ratio. 
When selecting fuel category, autopopulate determining carbon intensity when only one option.

![image](https://github.com/user-attachments/assets/3f838e04-fd78-499d-b4f9-5721385f2a73)

[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=95369214&issue=bcgov%7Clcfs%7C1802)