### PR TITLE
Update line 10 when other lines update

### DIFF
--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -94,6 +94,11 @@ export const useUpdateComplianceReportSummary = (reportID, options) => {
         ['compliance-report-summary', reportID],
         data.data
       )
+
+      // Call original onSuccess callback to set summary data
+      if (options?.onSuccess) {
+        options.onSuccess(data)
+      }
     }
   })
 }


### PR DESCRIPTION
Update line 10 when other lines update

<img width="777" alt="image" src="https://github.com/user-attachments/assets/d31d4c15-a2ff-4479-a8c8-2b27f1450230" />


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=94641247&issue=bcgov%7Clcfs%7C1760)
Note: This PR fixes this comment:  have Line 10 to show updates immediately upon changes made in lines 6-9? Right now Line 10 only updates if you navigate away and then return to the report