### PR TITLE
LCFS-1801: 500 error in Compliance report summary in TEST

### DIFF
--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -301,7 +301,7 @@ class ComplianceReportSummaryService:
         # need to get these values from the db after fuel supply is implemented
 
         # If report for previous period copy carryover amounts
-        if prev_compliance_report:
+        if prev_compliance_report and prev_compliance_report.legacy_id is None:
             # TODO: if previous report exists then ensure in the UI we're disabling the line 7 & 9 for editing
             previous_retained = {
                 "gasoline": prev_compliance_report.summary.line_6_renewable_fuel_retained_gasoline,

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -535,8 +535,8 @@ class ComplianceReportSummaryService:
             category: round(
                 max(
                     0,
-                    eligible_renewable_fuel_required.get(category, 0)
-                    - net_renewable_supplied.get(category, 0),
+                    int(eligible_renewable_fuel_required.get(category, 0))
+                    - int(net_renewable_supplied.get(category, 0)),
                 )
                 * PRESCRIBED_PENALTY_RATE[category],
                 2,


### PR DESCRIPTION
When an organization has compliance reports from previous periods that were copied from TRFS, these reports do not have a corresponding record in compliance_report_summary. To calculate the compliance report summary, the logic searches for previously retained and obligation values. For compliance reports originating from TRFS, these values are derived from the current compliance report using line 7 and 9.

With this change, compliance reports that have previous reports copied from TRFS are now loaded.