### PR TITLE
LCFS-1827: Recorded transfer in BCeID transaction history is showing director user name

### DIFF
--- a/frontend/src/assets/locales/en/common.json
+++ b/frontend/src/assets/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "title": "Low Carbon Fuel Standard",
   "govOrg": "Government of British Columbia",
+  "underAct": "Low Carbon Fuel Standard Act",
   "gov": "Government",
   "yes": "Yes",
   "no": "No",

--- a/frontend/src/assets/locales/en/transfer.json
+++ b/frontend/src/assets/locales/en/transfer.json
@@ -82,5 +82,6 @@
     "Rescinded": "Rescinded"
   },
   "zeroDollarInstructionText": "If proposing a zero-dollar transfer, use the comment box below to provide an explanation for this value.",
-  "categoryCheckbox": "Select the checkbox to set the transfer as <strong>Category D</strong> if the price is significantly less than fair market value. This will override the default category determined by the agreement and approval dates indicated above."
+  "categoryCheckbox": "Select the checkbox to set the transfer as <strong>Category D</strong> if the price is significantly less than fair market value. This will override the default category determined by the agreement and approval dates indicated above.",
+  "director": "Director"
 }

--- a/frontend/src/views/Transfers/components/TransferHistory.jsx
+++ b/frontend/src/views/Transfers/components/TransferHistory.jsx
@@ -4,6 +4,7 @@ import {
   TRANSFER_RECOMMENDATION
 } from '@/constants/statuses'
 import { useTransfer } from '@/hooks/useTransfer'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import BCTypography from '@/components/BCTypography'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
@@ -18,6 +19,7 @@ dayjs.extend(duration)
 function TransferHistory({ transferHistory }) {
   const { transferId } = useParams()
   const { data: transferData } = useTransfer(transferId)
+  const { data: currentUser } = useCurrentUser()
 
   const { t } = useTranslation(['common', 'transfer'])
 
@@ -105,28 +107,38 @@ function TransferHistory({ transferHistory }) {
                 </BCTypography>
               </li>
             )}
-          {transferHistory?.map((item, index) => (
-            <li key={(item.transferStatus?.transferStatusId || index) + index}>
-              <BCTypography variant="body2" component="div">
-                <b>{getTransferStatusLabel(item.transferStatus?.status)}</b>{' '}
-                <span> on </span>
-                {formatDateWithTimezoneAbbr(item.createDate)}
-                <span> by </span>
-                <strong>
-                  {' '}
-                  {item.displayName ||
-                    `${item.userProfile?.firstName} ${item.userProfile?.lastName}`}
-                </strong>{' '}
-                <span> of </span>
-                <strong>
-                  {' '}
-                  {item.userProfile?.organization
-                    ? item.userProfile.organization.name
-                    : t('govOrg')}{' '}
-                </strong>
-              </BCTypography>
-            </li>
-          ))}
+          {transferHistory?.map((item, index) => {
+            const isRecordedStatus = item.transferStatus?.status === TRANSFER_STATUSES.RECORDED;
+            const isBCeIDUser = !currentUser?.isGovernmentUser;
+            return (
+              <li key={(item.transferStatus?.transferStatusId || index) + index}>
+                <BCTypography variant="body2" component="div">
+                  <b>{getTransferStatusLabel(item.transferStatus?.status)}</b>
+                  <span> on </span>
+                  {formatDateWithTimezoneAbbr(item.createDate)}
+                  <span> by </span>
+                  {isRecordedStatus && isBCeIDUser ? (
+                    <>
+                      the <strong>{t('transfer:director')}</strong> under the <i>{t('underAct')}</i>
+                    </>
+                  ) : (
+                    <>
+                      <strong>
+                        {item.displayName ||
+                          `${item.userProfile?.firstName} ${item.userProfile?.lastName}`}
+                      </strong>
+                      <span> of </span>
+                      <strong>
+                        {item.userProfile?.organization
+                          ? item.userProfile.organization.name
+                          : t('govOrg')}
+                      </strong>
+                    </>
+                  )}
+                </BCTypography>
+              </li>
+            )}
+          )}
         </ul>
       </BCBox>
     </BCBox>

--- a/frontend/src/views/Transfers/components/__tests__/TransferHistory.test.jsx
+++ b/frontend/src/views/Transfers/components/__tests__/TransferHistory.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, cleanup } from '@testing-library/react'
 import TransferHistory from '../TransferHistory'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTransfer } from '@/hooks/useTransfer'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { wrapper } from '@/tests/utils/wrapper'
 import {
   TRANSFER_STATUSES,
@@ -11,6 +12,7 @@ import {
 import dayjs from 'dayjs'
 
 vi.mock('@/hooks/useTransfer')
+vi.mock('@/hooks/useCurrentUser')
 
 vi.mock('react-router-dom', () => ({
   useParams: () => ({ transferId: '1' })
@@ -55,6 +57,10 @@ describe('TransferHistory Component', () => {
 
   // Before each test, set up mocks and fix the Date object
   beforeEach(() => {
+     // Mock useCurrentUser for IDIR user by default
+    useCurrentUser.mockReturnValue({
+      data: { isGovernmentUser: true }
+    })
     // Mock 'useTransfer' to return consistent data
     useTransfer.mockReturnValue({
       data: {


### PR DESCRIPTION
User login as BCeID Organization does not show name of Director:
<img width="952" alt="image" src="https://github.com/user-attachments/assets/4152de34-ed39-40c7-bc23-ff96f1d9d4d5" />

IDIR users can see the name of Director:
<img width="959" alt="image" src="https://github.com/user-attachments/assets/db133caf-9eb9-4fa1-84f5-ed20aac89182" />
