### PR TITLE
fix: Allow Submissions without enough credits

### DIFF
--- a/backend/lcfs/tests/compliance_report/conftest.py
+++ b/backend/lcfs/tests/compliance_report/conftest.py
@@ -263,11 +263,13 @@ def mock_fuel_supply_repo():
 def mock_fuel_export_repo():
     return AsyncMock(spec=FuelExportRepository)
 
+
 @pytest.fixture
 def mock_other_uses_repo():
     mock_repo = MagicMock()
     mock_repo.get_effective_other_uses = AsyncMock(return_value=MagicMock())
     return mock_repo
+
 
 @pytest.fixture
 def compliance_report_summary_service(
@@ -276,7 +278,7 @@ def compliance_report_summary_service(
     mock_notional_transfer_service,
     mock_fuel_supply_repo,
     mock_fuel_export_repo,
-    mock_other_uses_repo
+    mock_other_uses_repo,
 ):
     service = ComplianceReportSummaryService()
     service.repo = mock_repo
@@ -290,13 +292,14 @@ def compliance_report_summary_service(
 
 @pytest.fixture
 def compliance_report_update_service(
-    mock_repo, compliance_report_summary_service, mock_user_profile
+    mock_repo, mock_org_service, compliance_report_summary_service, mock_user_profile
 ):
     service = ComplianceReportUpdateService()
     service.repo = mock_repo
     service.summary_service = compliance_report_summary_service
     service.request = MagicMock()
     service.request.user = mock_user_profile
+    service.org_service = mock_org_service
     return service
 
 

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -251,19 +251,29 @@ class ComplianceReportUpdateService:
             # Update the report with the new summary
             report.summary = new_summary
 
-        if report.summary.line_20_surplus_deficit_units != 0:
+        credit_change = report.summary.line_20_surplus_deficit_units
+        if credit_change != 0:
             if report.transaction is not None:
                 # Update existing transaction
-                report.transaction.compliance_units = (
-                    report.summary.line_20_surplus_deficit_units
-                )
+                report.transaction.compliance_units = credit_change
             else:
-                # Create a new reserved transaction for receiving organization
-                report.transaction = await self.org_service.adjust_balance(
-                    transaction_action=TransactionActionEnum.Reserved,
-                    compliance_units=report.summary.line_20_surplus_deficit_units,
-                    organization_id=report.organization_id,
+                available_balance = await self.org_service.calculate_available_balance(
+                    report.organization_id
                 )
+                # Only need a Transaction if they have credits
+                if available_balance > 0:
+                    units_to_reserve = credit_change
+
+                    # If not enough credits, reserve what is left
+                    if credit_change < 0 and abs(credit_change) > available_balance:
+                        units_to_reserve = available_balance * -1
+
+                    report.transaction = await self.org_service.adjust_balance(
+                        transaction_action=TransactionActionEnum.Reserved,
+                        compliance_units=units_to_reserve,
+                        organization_id=report.organization_id,
+                    )
+
         await self.repo.update_compliance_report(report)
 
         return calculated_summary


### PR DESCRIPTION
* Previously a supplier would be blocked if they didnt have enough credits
* Now we take as many as we can and allow it