### PR TITLE
Filter instance highlight issue

### DIFF
--- a/frontend/src/components/BCDataGrid/BCGridViewer.jsx
+++ b/frontend/src/components/BCDataGrid/BCGridViewer.jsx
@@ -61,7 +61,12 @@ export const BCGridViewer = ({
       const columnState = JSON.parse(localStorage.getItem(`${gridKey}-column`))
       if (filterState) {
         params.api.setFilterModel(filterState)
-        setFilterModel(filterState)
+        const filterArr = [
+          ...Object.entries(filterState).map(([field, value]) => {
+            return { field, ...value }
+          })
+        ]
+        setFilterModel(filterArr)
       }
       if (columnState) {
         params.api.applyColumnState({
@@ -153,7 +158,7 @@ export const BCGridViewer = ({
         ...defaultFilterModel
       ]
       setFilterModel(filterArr)
-      localStorage.setItem(`${gridKey}-filter`, JSON.stringify(filterArr))
+      localStorage.setItem(`${gridKey}-filter`, JSON.stringify(gridFilters))
     },
     [defaultFilterModel, gridKey, ref]
   )


### PR DESCRIPTION
Fix: After moving back to grid page, the filter instance is not being highlighted.