### PR TITLE
fix: Don't fire refresh queries when changing compliance report status

### DIFF
--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -107,18 +107,12 @@ export const useUpdateComplianceReportSummary = (reportID, options) => {
 
 export const useUpdateComplianceReport = (reportID, options) => {
   const client = useApiService()
-  const queryClient = useQueryClient()
   const path = apiRoutes.updateComplianceReport.replace(':reportID', reportID)
 
   return useMutation({
     ...options,
     mutationFn: async (data) => {
       return await client.put(path, data)
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries(['compliance-report', reportID])
-      queryClient.invalidateQueries(['compliance-report-summary', reportID])
-      queryClient.invalidateQueries(['compliance-reports'])
     }
   })
 }


### PR DESCRIPTION
* New code navigates to the main listing, so we dont need to refresh all the sub-data
* Firing the refresh in the case of return to supplier was resulting in a 403