### PR TITLE
LCFS-1863: Credit transfer credit amount maximum

### DIFF
--- a/backend/lcfs/tests/organization/test_organization_validation.py
+++ b/backend/lcfs/tests/organization/test_organization_validation.py
@@ -37,6 +37,23 @@ async def test_create_transfer_success(
     mock_transaction_repo.calculate_available_balance.assert_called_once()
     pass
 
+@pytest.mark.anyio
+async def test_check_available_balance_excess_quantity(organization_validation):
+    organization_validation.transaction_repo.calculate_available_balance.return_value = 500
+    
+    result = await organization_validation.check_available_balance(1, 1000)
+    
+    assert result["adjusted"] is True
+    assert result["adjusted_quantity"] == 500
+
+@pytest.mark.anyio
+async def test_check_available_balance_valid_quantity(organization_validation):
+    organization_validation.transaction_repo.calculate_available_balance.return_value = 1000
+    
+    result = await organization_validation.check_available_balance(1, 500)
+    
+    assert result["adjusted"] is False
+    assert result["adjusted_quantity"] == 500
 
 @pytest.mark.anyio
 async def test_update_transfer_success(organization_validation, mock_transaction_repo):

--- a/frontend/src/assets/locales/en/transfer.json
+++ b/frontend/src/assets/locales/en/transfer.json
@@ -83,5 +83,6 @@
   },
   "zeroDollarInstructionText": "If proposing a zero-dollar transfer, use the comment box below to provide an explanation for this value.",
   "categoryCheckbox": "Select the checkbox to set the transfer as <strong>Category D</strong> if the price is significantly less than fair market value. This will override the default category determined by the agreement and approval dates indicated above.",
-  "director": "Director"
+  "director": "Director",
+  "quantityAdjusted": "Quantity adjusted to maximum available balance"
 }

--- a/frontend/src/views/Transfers/components/TransferDetails.jsx
+++ b/frontend/src/views/Transfers/components/TransferDetails.jsx
@@ -1,6 +1,8 @@
 import BCBox from '@/components/BCBox'
+import BCAlert from '@/components/BCAlert'
 import BCTypography from '@/components/BCTypography'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { useCurrentOrgBalance } from '@/hooks/useOrganization'
 import { useRegExtOrgs } from '@/hooks/useOrganizations'
 import {
   FormControl,
@@ -9,7 +11,7 @@ import {
   TextField,
   InputAdornment
 } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { LabelBox } from './LabelBox'
@@ -19,6 +21,8 @@ import { NumericFormat } from 'react-number-format'
 export const TransferDetails = () => {
   const { t } = useTranslation(['common', 'transfer', 'organization'])
   const [totalValue, setTotalValue] = useState(0.0)
+  const [showAdjustmentAlert, setShowAdjustmentAlert] = useState(false)
+  const { data: balanceData } = useCurrentOrgBalance()
   const {
     register,
     control,
@@ -27,6 +31,12 @@ export const TransferDetails = () => {
   } = useFormContext()
   const { data: currentUser } = useCurrentUser()
   const { data: orgData } = useRegExtOrgs()
+
+  const availableBalance = useMemo(() => {
+    if (!balanceData) return 0
+    // Maximum Allowed = Total Balance - Reserved Balance
+    return balanceData.totalBalance - balanceData.reservedBalance
+  }, [balanceData])
 
   const organizations =
     orgData?.map((org) => ({
@@ -71,6 +81,15 @@ export const TransferDetails = () => {
   return (
     <BCBox data-test="transfer-details">
       <LabelBox label={t('transfer:detailsLabel')}>
+      {showAdjustmentAlert && (
+        <BCAlert
+          severity="warning"
+          sx={{ mb: 2 }}
+          onClose={() => setShowAdjustmentAlert(false)}
+        >
+          {t('transfer:quantityAdjusted')}: {availableBalance.toLocaleString()}
+        </BCAlert>
+      )}
         <BCTypography variant="body4" component="div">
           <BCTypography fontWeight="bold" variant="body4" component="span">
             {currentUser?.organization?.name}
@@ -85,7 +104,15 @@ export const TransferDetails = () => {
                 customInput={TextField}
                 thousandSeparator
                 value={value}
-                onValueChange={(vals) => onChange(vals.floatValue)}
+                onValueChange={(values) => {
+                  const newValue = values.floatValue > availableBalance
+                    ? availableBalance
+                    : values.floatValue
+                  onChange(newValue)
+                  if (values.floatValue > availableBalance) {
+                    setShowAdjustmentAlert(true)
+                  }
+                }}
                 onBlur={onBlur}
                 name={name}
                 inputRef={ref}


### PR DESCRIPTION
- When a BCeID user enters a credit amount exceeding their available balance, instead of triggering a 403 error, the system now automatically adjusts the amount to the maximum allowed and notifies the user of the change in the UI.
- This enhancement has been implemented on both the frontend and backend as requested.


![image](https://github.com/user-attachments/assets/c4d10b27-a4d3-41db-bfec-9e03f884682d)

[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=95751541&issue=bcgov%7Clcfs%7C1863)