### PR TITLE
LCFS-1863: Fix calculation for available balance

### DIFF
--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -269,7 +269,7 @@ class TransactionRepository:
                             (
                                 Transaction.transaction_action
                                 == TransactionActionEnum.Reserved,
-                                Transaction.compliance_units,
+                                func.abs(Transaction.compliance_units),
                             ),
                             else_=0,
                         )

--- a/frontend/src/views/Transfers/components/TransferDetails.jsx
+++ b/frontend/src/views/Transfers/components/TransferDetails.jsx
@@ -35,7 +35,7 @@ export const TransferDetails = () => {
   const availableBalance = useMemo(() => {
     if (!balanceData) return 0
     // Maximum Allowed = Total Balance - Reserved Balance
-    return balanceData.totalBalance - balanceData.reservedBalance
+    return balanceData.totalBalance - Math.abs(balanceData.reservedBalance)
   }, [balanceData])
 
   const organizations =


### PR DESCRIPTION
When the user exhausts their available balance, they cannot create another transfer.

The balance is set to 50,000 and the user creates a transfer for the same amount:
<img width="811" alt="image" src="https://github.com/user-attachments/assets/47f91bca-9422-4db8-a408-870d57df4d2f" />


Then, the user cannot create another transfer:
<img width="817" alt="image" src="https://github.com/user-attachments/assets/5108a11c-69d9-4c3e-9a52-ddd042d5deb6" />


