### PR TITLE
LCFS-1925: Supporting Documents Accordion Displays Even When No Documents Are Uploaded

### DIFF
--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -263,16 +263,12 @@ const ReportDetails = ({ currentStatus = 'Draft', userRoles }) => {
       </BCTypography>
       {activityList.map((activity, index) => {
         const { data, error, isLoading } = activity.useFetch(complianceReportId)
+        const isSupportingDocs = activity.name === t('report:supportingDocs')
         return (
-          ((data && !isArrayEmpty(data)) ||
-            activity.name === t('report:supportingDocs')) && (
+          ((data && !isArrayEmpty(data)) && (
             <Accordion
               key={index}
-              expanded={
-                activity.name === t('report:supportingDocs')
-                  ? expanded.includes(`panel${index}`) && !isArrayEmpty(data)
-                  : expanded.includes(`panel${index}`)
-              }
+              expanded={isSupportingDocs || expanded.includes(`panel${index}`)}
               onChange={onExpand(`panel${index}`)}
             >
               <AccordionSummary
@@ -327,6 +323,7 @@ const ReportDetails = ({ currentStatus = 'Draft', userRoles }) => {
                 )}
               </AccordionDetails>
             </Accordion>
+            )
           )
         )
       })}


### PR DESCRIPTION
When there is no documents, `Supporting Documents` section should not appear. If there is at least one doc, then show the accordion opened:

<img width="797" alt="image" src="https://github.com/user-attachments/assets/b7783be0-74da-4294-8f16-4d8a0bf67efd" />


<img width="803" alt="image" src="https://github.com/user-attachments/assets/da3ecfc0-52b3-4f6b-b551-f34841ee21a4" />
