### PR TITLE
Fix: Clean up transaction history by removing draft entries - 1855

### DIFF
--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -62,7 +62,7 @@ export const AddEditViewTransfer = () => {
   const { transferId } = useParams()
   const [alertMessage, setAlertMessage] = useState('')
   const [alertSeverity, setAlertSeverity] = useState('info')
-  const [steps, setSteps] = useState(['Draft', 'Sent', 'Submitted', 'Recorded'])
+  const [steps, setSteps] = useState(['Sent', 'Submitted', 'Recorded'])
   const { data: currentUser, hasRoles, hasAnyRole } = useCurrentUser()
   const { data: toOrgData } = useRegExtOrgs()
   const isGovernmentUser = !!currentUser?.isGovernmentUser
@@ -248,8 +248,10 @@ export const AddEditViewTransfer = () => {
       statusSet.add(item.transferStatus.status)
     })
     if (statusSet.length === 0) {
-      setSteps(['Draft', 'Sent', 'Submitted', 'Recorded'])
+      setSteps(['Sent', 'Submitted', 'Recorded'])
     } else {
+       statusSet.delete(TRANSFER_STATUSES.DRAFT)
+       
       if (!statusSet.has(TRANSFER_STATUSES.SENT))
         statusSet.add(TRANSFER_STATUSES.SENT)
       if (

--- a/frontend/src/views/Transfers/__tests__/AddEditViewTransfer.test.jsx
+++ b/frontend/src/views/Transfers/__tests__/AddEditViewTransfer.test.jsx
@@ -422,12 +422,13 @@ describe.skip('AddEditViewTransfer Component Tests', () => {
       const buttonClusterSignButton = await screen.findByTestId(
         'sign-and-submit-btn'
       )
-      const buttonClusterRecindButton = await screen.findByTestId('rescind-btn')
+      const buttonClusterRescindButton =
+        await screen.findByTestId('rescind-btn')
 
       expect(buttonClusterBackButton).toBeInTheDocument()
       expect(buttonClusterDeclineButton).toBeInTheDocument()
       expect(buttonClusterSignButton).toBeInTheDocument()
-      expect(buttonClusterRecindButton).toBeInTheDocument()
+      expect(buttonClusterRescindButton).toBeInTheDocument()
     })
     it('renders the correct button components (Submitted status & signing auth)', async () => {
       useTransfer.mockReturnValue({
@@ -445,10 +446,11 @@ describe.skip('AddEditViewTransfer Component Tests', () => {
       const buttonClusterBackButton = await screen.findByTestId(
         'button-cluster-back'
       )
-      const buttonClusterRecindButton = await screen.findByTestId('rescind-btn')
+      const buttonClusterRescindButton =
+        await screen.findByTestId('rescind-btn')
 
       expect(buttonClusterBackButton).toBeInTheDocument()
-      expect(buttonClusterRecindButton).toBeInTheDocument()
+      expect(buttonClusterRescindButton).toBeInTheDocument()
     })
     it('renders the correct button components (Recommended status & director)', async () => {
       useTransfer.mockReturnValue({
@@ -478,10 +480,11 @@ describe.skip('AddEditViewTransfer Component Tests', () => {
       const buttonClusterBackButton = await screen.findByTestId(
         'button-cluster-back'
       )
-      const buttonClusterRecindButton = await screen.findByTestId('rescind-btn')
+      const buttonClusterRescindButton =
+        await screen.findByTestId('rescind-btn')
 
       expect(buttonClusterBackButton).toBeInTheDocument()
-      expect(buttonClusterRecindButton).toBeInTheDocument()
+      expect(buttonClusterRescindButton).toBeInTheDocument()
     })
     it('renders the alert box when alert severity state is present', async () => {
       useLocation.mockReturnValue({

--- a/frontend/src/views/Transfers/components/TransferHistory.jsx
+++ b/frontend/src/views/Transfers/components/TransferHistory.jsx
@@ -66,6 +66,11 @@ function TransferHistory({ transferHistory }) {
     category = 'C'
   }
 
+  // Filter out any DRAFT records, so “Created draft” never shows up
+  const filteredHistory = transferHistory?.filter(
+    (item) => item.transferStatus?.status !== TRANSFER_STATUSES.DRAFT
+  )
+
   return (
     <BCBox mt={2} data-test="transfer-history">
       <BCTypography variant="h6" color="primary">
@@ -107,11 +112,14 @@ function TransferHistory({ transferHistory }) {
                 </BCTypography>
               </li>
             )}
-          {transferHistory?.map((item, index) => {
-            const isRecordedStatus = item.transferStatus?.status === TRANSFER_STATUSES.RECORDED;
-            const isBCeIDUser = !currentUser?.isGovernmentUser;
+          {filteredHistory?.map((item, index) => {
+            const isRecordedStatus =
+              item.transferStatus?.status === TRANSFER_STATUSES.RECORDED
+            const isBCeIDUser = !currentUser?.isGovernmentUser
             return (
-              <li key={(item.transferStatus?.transferStatusId || index) + index}>
+              <li
+                key={(item.transferStatus?.transferStatusId || index) + index}
+              >
                 <BCTypography variant="body2" component="div">
                   <b>{getTransferStatusLabel(item.transferStatus?.status)}</b>
                   <span> on </span>
@@ -119,7 +127,8 @@ function TransferHistory({ transferHistory }) {
                   <span> by </span>
                   {isRecordedStatus && isBCeIDUser ? (
                     <>
-                      the <strong>{t('transfer:director')}</strong> under the <i>{t('underAct')}</i>
+                      the <strong>{t('transfer:director')}</strong> under the{' '}
+                      <i>{t('underAct')}</i>
                     </>
                   ) : (
                     <>
@@ -137,8 +146,8 @@ function TransferHistory({ transferHistory }) {
                   )}
                 </BCTypography>
               </li>
-            )}
-          )}
+            )
+          })}
         </ul>
       </BCBox>
     </BCBox>


### PR DESCRIPTION
This PR removes the "Created draft" entry from transaction history and the "Draft" stage from the progress bar for a clearer, more accurate user experience.

Closes #1855