### PR TITLE
LCFS-1925: Allow Expand/Collapse for Supporting Documents

### DIFF
--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -263,12 +263,11 @@ const ReportDetails = ({ currentStatus = 'Draft', userRoles }) => {
       </BCTypography>
       {activityList.map((activity, index) => {
         const { data, error, isLoading } = activity.useFetch(complianceReportId)
-        const isSupportingDocs = activity.name === t('report:supportingDocs')
         return (
           ((data && !isArrayEmpty(data)) && (
             <Accordion
               key={index}
-              expanded={isSupportingDocs || expanded.includes(`panel${index}`)}
+              expanded={expanded.includes(`panel${index}`)}
               onChange={onExpand(`panel${index}`)}
             >
               <AccordionSummary


### PR DESCRIPTION
Allow Expand/Collapse for Supporting Documents:

<img width="819" alt="image" src="https://github.com/user-attachments/assets/56260b2e-2355-4b4c-8e94-f160d5bd6855" />

<img width="809" alt="image" src="https://github.com/user-attachments/assets/1e221b68-4b54-435a-845c-9c34078b4c9c" />
