### PR TITLE
Fix: Restrict Pencil Icon Visibility - 1995

### DIFF
--- a/frontend/src/views/Admin/AdminMenu/components/ViewUser.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/ViewUser.jsx
@@ -140,11 +140,15 @@ export const ViewUser = () => {
               id="user-card"
               title={t('admin:userDetails')}
               color="nav"
-              editButton={{
-                text: canEdit ? t('admin:editBtn') : null,
-                route: canEdit ? editButtonRoute : null,
-                id: 'edit-user-button'
-              }}
+              editButton={
+                canEdit
+                  ? {
+                      text: t('admin:editBtn'),
+                      route: editButtonRoute,
+                      id: 'edit-user-button'
+                    }
+                  : null
+              }
               content={
                 <BCBox p={1}>
                   <BCBox


### PR DESCRIPTION
### Changes in this PR:
- Ensures the pencil icon is only visible to users with the "Manage User" and "Administrator" roles.

Closes #1995

