### PR TITLE
Fix: Hide internal statuses and fix submitted status filtering for BCeID users - 2050

### DIFF
--- a/backend/lcfs/db/models/compliance/ComplianceReportStatus.py
+++ b/backend/lcfs/db/models/compliance/ComplianceReportStatus.py
@@ -14,6 +14,12 @@ class ComplianceReportStatusEnum(enum.Enum):
     Reassessed = "Reassessed"
     Rejected = "Rejected"
 
+    def underscore_value(self) -> str:
+        """
+        Return the status as an underscored string.
+        """
+        return self.value.replace(" ", "_")
+
 
 class ComplianceReportStatus(BaseModel, EffectiveDates):
     __tablename__ = "compliance_report_status"


### PR DESCRIPTION
This PR includes the following improvements and fixes:

- Internal statuses are now restricted to IDIR users
- Fixed an issue where filtering for submitted statuses caused a 500 error.
- Formatted Python code for better readability and consistency

Closes #2050
