### PR TITLE
Fix: Ensure all transactions are included in the export - 2068

### DIFF
--- a/backend/lcfs/utils/constants.py
+++ b/backend/lcfs/utils/constants.py
@@ -78,12 +78,14 @@ transaction_type_to_id_prefix_map = {
     "Transfer": "CT",
     "AdminAdjustment": "AA",
     "InitiativeAgreement": "IA",
+    "ComplianceReport": "CR",
 }
 
 id_prefix_to_transaction_type_map = {
     "CT": "Transfer",
     "AA": "AdminAdjustment",
     "IA": "InitiativeAgreement",
+    "CR": "ComplianceReport",
 }
 
 default_ci = {"Gasoline": 93.67, "Diesel": 100.21, "Jet fuel": 88.83}

--- a/backend/lcfs/web/api/transaction/services.py
+++ b/backend/lcfs/web/api/transaction/services.py
@@ -88,15 +88,15 @@ class TransactionsService:
                 # check if the date string is selected for filter
                 if filter.filter is None:
                     filter_value = [
-                        datetime.strptime(filter.date_from, "%Y-%m-%d %H:%M:%S").strftime(
-                            "%Y-%m-%d"
-                        )
+                        datetime.strptime(
+                            filter.date_from, "%Y-%m-%d %H:%M:%S"
+                        ).strftime("%Y-%m-%d")
                     ]
                     if filter.date_to:
                         filter_value.append(
-                            datetime.strptime(filter.date_to, "%Y-%m-%d %H:%M:%S").strftime(
-                                "%Y-%m-%d"
-                            )
+                            datetime.strptime(
+                                filter.date_to, "%Y-%m-%d %H:%M:%S"
+                            ).strftime("%Y-%m-%d")
                         )
                 if filter.field == "status":
                     field = cast(
@@ -189,12 +189,7 @@ class TransactionsService:
         results = await self.repo.get_transactions_paginated(
             0,
             None,
-            [
-                or_(
-                    TransactionView.status == "Approved",
-                    TransactionView.status == "Recorded",
-                )
-            ],
+            [TransactionView.status != "Deleted"],
             [],
             organization_id,
         )


### PR DESCRIPTION
This PR includes the following fixes:  
- Ensures that all transactions displayed in the UI are included in the exported file.
- Adds support for Compliance Report transaction type in the download.

Closes #2068