### PR TITLE
hotfix: Fix selection of organization in Allocation Agreement

### DIFF
--- a/frontend/src/components/BCDataGrid/components/Editors/AsyncSuggestionEditor.jsx
+++ b/frontend/src/components/BCDataGrid/components/Editors/AsyncSuggestionEditor.jsx
@@ -61,7 +61,7 @@ export const AsyncSuggestionEditor = ({
       onValueChange(newValue)
     } else if (newValue && typeof newValue === 'object') {
       debouncedSetInputValue(newValue[optionLabel])
-      onValueChange(newValue) // Set full object if option is an object
+      onValueChange(newValue[optionLabel])
     } else {
       onValueChange('')
     }


### PR DESCRIPTION
On Dev, the user cannot select  a value in the column Legal name of transaction partner. The schema is expecting the label and not all the object, so the setter is not triggered. As a result, we are not able to show organization details in the grid:

<img width="794" alt="image" src="https://github.com/user-attachments/assets/17b30174-5be6-4572-aa96-8098a22fcc59" />

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/f07cb129-7733-4010-8e9e-b642c8efe452" />
