### PR TITLE
Fix: Hide Draft Status from IDIR Users in Compliance Report History - 2074

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
@@ -253,7 +253,7 @@ async def test_get_compliance_report_by_id_success(
 
         assert response.json() == expected_response
         mock_get_compliance_report_by_id.assert_called_once_with(
-            1, False, get_chain=True
+            1, False, True, get_chain=True
         )
         mock_validate_organization_access.assert_called_once_with(1)
 

--- a/backend/lcfs/web/api/compliance_report/services.py
+++ b/backend/lcfs/web/api/compliance_report/services.py
@@ -236,14 +236,25 @@ class ComplianceReportServices:
 
     @service_handler
     async def get_compliance_report_by_id(
-        self, report_id: int, apply_masking: bool = False, get_chain: bool = False
+        self,
+        report_id: int,
+        apply_masking: bool = False,
+        is_gov: bool = False,
+        get_chain: bool = False,
     ):
-        """Fetches a specific compliance report by ID."""
+        """
+        Fetches a specific compliance report by ID.
+        """
         report = await self.repo.get_compliance_report_by_id(report_id)
         if report is None:
             raise DataNotFoundException("Compliance report not found.")
 
         validated_report = ComplianceReportBaseSchema.model_validate(report)
+
+        # Remove 'Draft' entries from the report history
+        if is_gov:
+            validated_report = self._remove_draft_entries(validated_report)
+
         masked_report = (
             self._mask_report_status([validated_report])[0]
             if apply_masking
@@ -259,9 +270,21 @@ class ComplianceReportServices:
                 report.compliance_report_group_uuid
             )
 
+            # Remove 'Draft' reports from the chain
+            compliance_report_chain = self._remove_draft_reports(
+                compliance_report_chain
+            )
+
+            # Remove 'Draft' entries from the report history
+            draft_cleaned_chain = []
+            for item in compliance_report_chain:
+                cleaned_item = self._remove_draft_entries(item)
+                if cleaned_item:
+                    draft_cleaned_chain.append(cleaned_item)
+
             if apply_masking:
                 # Apply masking to each report in the chain
-                masked_chain = self._mask_report_status(compliance_report_chain)
+                masked_chain = self._mask_report_status(draft_cleaned_chain)
                 # Apply history masking to each report in the chain
                 masked_chain = [
                     self._mask_report_status_for_history(report, apply_masking)
@@ -327,7 +350,11 @@ class ComplianceReportServices:
         self,
         pagination: PaginationResponseSchema,
         compliance_report_id: int,
-        selection: Type[Union[FuelSupply, OtherUses, NotionalTransfer, FuelExport, AllocationAgreement]],
+        selection: Type[
+            Union[
+                FuelSupply, OtherUses, NotionalTransfer, FuelExport, AllocationAgreement
+            ]
+        ],
     ):
         changelog, total_count = await self.repo.get_changelog_data(
             pagination, compliance_report_id, selection
@@ -367,3 +394,32 @@ class ComplianceReportServices:
             ),
             "changelog": changelog,
         }
+
+    def _remove_draft_entries(
+        self, report: ComplianceReportBaseSchema
+    ) -> Union[ComplianceReportBaseSchema, None]:
+        """
+        Removes 'Draft' entries from the report history.
+        """
+        # Filter out 'Draft' from the history
+        new_history = [
+            h
+            for h in report.history
+            if h.status.status != ComplianceReportStatusEnum.Draft.value
+        ]
+        report.history = new_history
+
+        return report
+
+    def _remove_draft_reports(
+        self, reports: List[ComplianceReportBaseSchema]
+    ) -> List[ComplianceReportBaseSchema]:
+        """
+        Removes 'Draft' reports from the compliance report chain.
+        """
+        filtered = []
+        for r in reports:
+            if r.current_status.status == ComplianceReportStatusEnum.Draft.value:
+                continue
+            filtered.append(r)
+        return filtered

--- a/frontend/src/views/ComplianceReports/__tests__/HistoryCard.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/HistoryCard.test.jsx
@@ -87,12 +87,6 @@ describe('HistoryCard', () => {
   it('sorts history in descending order by createDate and filters out DRAFT', async () => {
     const history = [
       {
-        status: { status: COMPLIANCE_REPORT_STATUSES.DRAFT },
-        createDate: '2024-10-02',
-        userProfile: { firstName: 'Draft', lastName: 'User' },
-        displayName: 'Draft User'
-      },
-      {
         status: { status: COMPLIANCE_REPORT_STATUSES.SUBMITTED },
         createDate: '2024-10-01T10:00:00Z',
         userProfile: { firstName: 'John', lastName: 'Doe' },
@@ -113,7 +107,6 @@ describe('HistoryCard', () => {
     // SUBMITTED first because 2024-10-03 is later than 2024-10-01
     await waitFor(() => {
       const items = screen.getAllByTestId('list-item')
-      expect(items.length).toBe(2) // DRAFT is filtered out
       // The first item should be RECOMMENDED_BY_ANALYST (2024-10-03)
       expect(items[0].textContent).toContain(
         'report:complianceReportHistory.Recommended by analyst: Jane Smith'

--- a/frontend/src/views/ComplianceReports/components/HistoryCard.jsx
+++ b/frontend/src/views/ComplianceReports/components/HistoryCard.jsx
@@ -67,7 +67,6 @@ export const HistoryCard = ({ report }) => {
         }
         return item
       })
-      .filter((item) => item.status.status !== COMPLIANCE_REPORT_STATUSES.DRAFT)
   }, [isGovernmentUser, report.history])
 
   return (


### PR DESCRIPTION
This PR includes the following fixes:

- Hides "Draft" status from IDIR users in Compliance Report history.
- Updates filtering logic to exclude draft statuses.
- Adds tests for components.

Closes #2074