### PR TITLE
fix: fuel export date accessibility

### DIFF
--- a/frontend/src/views/FuelExports/AddEditFuelExports.jsx
+++ b/frontend/src/views/FuelExports/AddEditFuelExports.jsx
@@ -307,7 +307,6 @@ export const AddEditFuelExports = () => {
             showAddRowsButton={true}
             context={{ errors }}
             onAction={onAction}
-            stopEditingWhenCellsLoseFocus
             saveButtonProps={{
               enabled: true,
               text: t('report:saveReturn'),

--- a/frontend/src/views/FuelExports/_schema.jsx
+++ b/frontend/src/views/FuelExports/_schema.jsx
@@ -102,7 +102,6 @@ export const fuelExportColDefs = (
 
     suppressKeyboardEvent,
     cellEditor: DateEditor,
-    cellEditorPopup: true,
     cellEditorParams: {
       autoOpenLastRow: !gridReady
     }


### PR DESCRIPTION
- fix: not being able to tab open the date picker, closes #2138 

the date range picker in FSE uses a package that does not look like we'll be able to customize to add the ability to use arrow keys to select the date range. may need to explore other alternative packages that offer this feature or at least be able to customize to add this feature. spike ticket created: https://github.com/bcgov/lcfs/issues/2184