### PR TITLE
fix: Properly populate endUseType in Fuel Exports

### DIFF
--- a/backend/lcfs/tests/fuel_export/test_fuel_exports_views.py
+++ b/backend/lcfs/tests/fuel_export/test_fuel_exports_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 import json
 from unittest.mock import patch
@@ -158,6 +160,7 @@ async def test_save_fuel_export_row_forbidden(
         "fuel_type_id": 1,
         "fuel_category": "",
         "fuel_category_id": 1,
+        "end_use_id": 1,
         "provision_of_the_act": "",
         "provision_of_the_act_id": 1,
         "quantity": 1,
@@ -211,16 +214,14 @@ async def test_save_fuel_export_row_delete_success(client, fastapi_app, set_mock
         payload = FuelExportCreateUpdateSchema(
             fuel_export_id=1,
             compliance_report_id=1,
-            fuel_type="Diesel",
             fuel_type_id=1,
-            fuel_category="Diesel",
             fuel_category_id=1,
-            provision_of_the_act="Section 6",
+            end_use_id=1,
             provision_of_the_act_id=1,
             quantity=100,
             units="L",
-            export_date="2024-01-01",
             deleted=True,
+            export_date=datetime.date(2024, 1, 1),
         ).dict(exclude_none=True)
 
         response = await client.post(url, json=jsonable_encoder(payload))
@@ -264,27 +265,29 @@ async def test_save_fuel_export_row_update_success(client, fastapi_app, set_mock
             ),
             quantity=1,
             units="L",
-            export_date="2024-01-01",
+            export_date=datetime.date(2024, 1, 1),
             fuel_category_id=1,
+            end_use_id=1,
             fuel_category=FuelCategoryResponseSchema(category="Diesel"),
-            provisionOfTheActId=1,
-            provisionOfTheAct={"provision_of_the_act_id": 1, "name": "Test Provision"},
             compliance_period="2024",
+            provision_of_the_act_id=1,
+            provision_of_the_act=ProvisionOfTheActSchema(
+                provision_of_the_act_id=1,
+                name="Test Provision",
+            ),
         )
 
         # Create update payload with all required fields
         update_payload = FuelExportCreateUpdateSchema(
             fuel_export_id=1,
             compliance_report_id=1,
-            fuel_type="Diesel",
             fuel_type_id=1,
-            fuel_category="Diesel",
             fuel_category_id=1,
-            provision_of_the_act="Section 6",
+            end_use_id=1,
             provision_of_the_act_id=1,
             quantity=1,
             units="L",
-            export_date="2024-01-01",
+            export_date=datetime.date(2024, 1, 1),
         )
 
         mock_validate_organization_access.return_value = mock_compliance_report
@@ -327,15 +330,13 @@ async def test_save_fuel_export_row_create_success(client, fastapi_app, set_mock
         # Create payload with all required fields
         create_payload = FuelExportCreateUpdateSchema(
             compliance_report_id=1,
-            fuel_type="Diesel",
             fuel_type_id=1,
-            fuel_category="Diesel",
             fuel_category_id=1,
-            provision_of_the_act="Section 6",
+            end_use_id=1,
             provision_of_the_act_id=1,
             quantity=1,
             units="L",
-            export_date="2024-01-01",
+            export_date=datetime.date(2024, 1, 1),
             compliance_period="2024",
         )
 
@@ -350,12 +351,16 @@ async def test_save_fuel_export_row_create_success(client, fastapi_app, set_mock
             ),
             quantity=1,
             units="L",
-            export_date="2024-01-01",
+            export_date=datetime.date(2024, 1, 1),
             fuel_category_id=1,
+            end_use_id=1,
             fuel_category=FuelCategoryResponseSchema(category="Diesel"),
-            provisionOfTheActId=1,
-            provisionOfTheAct={"provision_of_the_act_id": 1, "name": "Section 6"},
             compliance_period="2024",
+            provision_of_the_act_id=1,
+            provision_of_the_act=ProvisionOfTheActSchema(
+                provision_of_the_act_id=1,
+                name="Test Provision",
+            ),
         )
 
         mock_validate_organization_access.return_value = mock_compliance_report

--- a/backend/lcfs/web/api/fuel_export/schema.py
+++ b/backend/lcfs/web/api/fuel_export/schema.py
@@ -193,7 +193,7 @@ class FuelExportCreateUpdateSchema(BaseSchema):
     fuel_type_other: Optional[str] = None
     fuel_type_id: int
     fuel_category_id: int
-    end_use_id: Optional[int] = None
+    end_use_id: int
     provision_of_the_act_id: int
     fuel_code_id: Optional[int] = None
     quantity: int = Field(..., gt=0)

--- a/frontend/src/views/FuelExports/AddEditFuelExports.jsx
+++ b/frontend/src/views/FuelExports/AddEditFuelExports.jsx
@@ -89,7 +89,7 @@ export const AddEditFuelExports = () => {
           fuelType: item.fuelType?.fuelType,
           provisionOfTheAct: item.provisionOfTheAct?.name,
           fuelCode: item.fuelCode?.fuelCode,
-          endUse: item.endUse?.type || 'Any',
+          endUse: item.endUse?.type,
           isNewSupplementalEntry:
             isSupplemental && item.complianceReportId === +complianceReportId,
           id: uuid()
@@ -135,7 +135,7 @@ export const AddEditFuelExports = () => {
         fuelType: item.fuelType?.fuelType,
         provisionOfTheAct: item.provisionOfTheAct?.name,
         fuelCode: item.fuelCode?.fuelCode,
-        endUse: item.endUse?.type || 'Any',
+        endUse: item.endUse?.type,
         isNewSupplementalEntry:
           isSupplemental && item.complianceReportId === +complianceReportId,
         id: uuid()
@@ -163,15 +163,20 @@ export const AddEditFuelExports = () => {
             (item) => item.fuelCategory
           )
 
-          const endUseTypes = selectedFuelType.eerRatios.map(
-            (item) => item.endUseType
+          const uniqueEndUseTypes = Array.from(
+            new Map(
+              selectedFuelType.eerRatios.map((item) => [
+                item.endUseType.endUseTypeId,
+                item.endUseType
+              ])
+            ).values()
           )
 
           // Set to null if multiple options, otherwise use first item
           const category =
             fuelCategoryOptions.length === 1 ? fuelCategoryOptions[0] : null
           const endUseValue =
-            endUseTypes.length === 1 ? endUseTypes[0].type : 'Any'
+            uniqueEndUseTypes.length === 1 ? uniqueEndUseTypes[0].type : null
           const provisionValue =
             selectedFuelType.provisions.length === 1
               ? selectedFuelType.provisions[0].name
@@ -183,22 +188,24 @@ export const AddEditFuelExports = () => {
         }
       }
 
-      if (params.column.colId === 'fuelCategoryId') {
+      if (params.column.colId === 'fuelCategory') {
         const selectedFuelType = optionsData?.fuelTypes?.find(
           (obj) => params.node.data.fuelType === obj.fuelType
         )
 
         if (selectedFuelType) {
-          const endUseTypes = selectedFuelType.eerRatios
-            .filter(
-              (item) =>
-                item.fuelCategory.fuelCategory === params.data.fuelCategory
-            )
-            .map((item) => item.endUseType)
+          const uniqueEndUseTypes = Array.from(
+            new Map(
+              selectedFuelType.eerRatios.map((item) => [
+                item.endUseType.endUseTypeId,
+                item.endUseType
+              ])
+            ).values()
+          )
 
           // Set to null if multiple options, otherwise use first item
           const endUseValue =
-            endUseTypes.length === 1 ? endUseTypes[0].type : 'Any'
+            uniqueEndUseTypes.length === 1 ? uniqueEndUseTypes[0].type : null
           const provisionValue =
             selectedFuelType.provisions.length === 1
               ? selectedFuelType.provisions[0].name

--- a/frontend/src/views/FuelExports/_schema.jsx
+++ b/frontend/src/views/FuelExports/_schema.jsx
@@ -262,7 +262,6 @@ export const fuelExportColDefs = (
     cellRenderer: SelectRenderer,
     cellStyle: (params) =>
       StandardCellWarningAndErrors(params, errors, warnings, isSupplemental),
-
     suppressKeyboardEvent,
     valueGetter: (params) => {
       return params.data.endUseType?.type
@@ -273,16 +272,19 @@ export const fuelExportColDefs = (
     },
     valueSetter: (params) => {
       if (params.newValue) {
-        const eerRatio = optionsData?.fuelTypes
-          ?.find((obj) => params.data.fuelType === obj.fuelType)
-          ?.eerRatios.filter(
-            (item) =>
-              item.fuelCategory.fuelCategory === params.data.fuelCategory
-          )
-          .find((eerRatio) => eerRatio.endUseType.type === params.newValue)
-
-        params.data.endUseType = eerRatio.endUseType
-        params.data.endUseId = eerRatio.endUseType.endUseTypeId
+        const selectedFuel = optionsData?.fuelTypes?.find(
+          (obj) => params.data.fuelType === obj.fuelType
+        )
+        const eerOptions = selectedFuel?.eerRatios.filter(
+          (item) => item.fuelCategory.fuelCategory === params.data.fuelCategory
+        )
+        const selectedRatio = eerOptions.find(
+          (eerRatio) => eerRatio.endUseType.type === params.newValue
+        )
+        if (selectedRatio) {
+          params.data.endUseType = selectedRatio.endUseType
+          params.data.endUseId = selectedRatio.endUseType.endUseTypeId
+        }
       }
       return true
     },
@@ -606,7 +608,7 @@ export const fuelExportSummaryColDefs = [
   },
   {
     headerName: i18n.t('fuelExport:fuelExportColLabels.endUseId'),
-    field: 'endUse',
+    field: 'endUseType',
     valueGetter: (params) => params.data.endUseType?.type || 'Any'
   },
   {
@@ -689,8 +691,8 @@ export const changelogCommonColDefs = [
   },
   {
     headerName: i18n.t('fuelExport:fuelExportColLabels.endUseId'),
-    field: 'endUse',
-    valueGetter: (params) => params.data.endUseType?.type || 'Any',
+    field: 'endUseType',
+    valueGetter: (params) => params.data.endUseType?.type,
     cellStyle: (params) => changelogCellStyle(params, 'endUseId')
   },
   {

--- a/frontend/src/views/FuelSupplies/_schema.jsx
+++ b/frontend/src/views/FuelSupplies/_schema.jsx
@@ -537,8 +537,8 @@ export const fuelSupplySummaryColDef = [
   },
   {
     headerName: i18n.t('fuelSupply:fuelSupplyColLabels.endUseId'),
-    field: 'endUse',
-    valueGetter: (params) => params.data.endUseType?.type || 'Any'
+    field: 'endUseType',
+    valueGetter: (params) => params.data.endUseType?.type
   },
   {
     headerName: i18n.t(
@@ -615,8 +615,8 @@ export const changelogCommonColDefs = [
   },
   {
     headerName: i18n.t('fuelSupply:fuelSupplyColLabels.endUseId'),
-    field: 'endUse',
-    valueGetter: (params) => params.data.endUseType?.type || 'Any',
+    field: 'endUseType',
+    valueGetter: (params) => params.data.endUseType?.type,
     cellStyle: (params) => changelogCellStyle(params, 'endUseId')
   },
   {


### PR DESCRIPTION
* Remove any default, Any is not a valid option for all fuel types (electricity)
* Update logic to look at unique fuel types, with the new code for EER ratios there can be many Anys per fuel type.