### PR TITLE
LCFS-2219: PROD Page not loading for viewing a rescinded transaction

### DIFF
--- a/backend/lcfs/web/api/transfer/services.py
+++ b/backend/lcfs/web/api/transfer/services.py
@@ -99,8 +99,16 @@ class TransferServices:
             in [
                 TransferStatusEnum.Draft,
                 TransferStatusEnum.Sent,
-                TransferStatusEnum.Rescinded,
             ]
+            or
+            (
+                transfer.current_status.status == TransferStatusEnum.Rescinded and
+                not any(
+                    history.transfer_status.status == TransferStatusEnum.Submitted
+                    and history.create_date < transfer.update_date
+                    for history in transfer.transfer_history
+                )
+            )
         ):
             raise DataNotFoundException(f"Transfer with ID {transfer_id} not found")
 


### PR DESCRIPTION
When retriving an individual transaction check if it was `Submitted` before being `Rescinded`