### PR TITLE
LCFS-2256: BUG - 6, 7, 8, or 9 results in a 500 error

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_views.py
@@ -429,7 +429,7 @@ async def test_update_compliance_report_summary_success(
 
         assert response.json() == expected_response
         mock_update_compliance_report_summary.assert_called_once_with(
-            1, request_schema, mock.ANY
+            1, request_schema
         )
 
         mock_validate_organization_access.assert_called_once_with(1)

--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -137,7 +137,7 @@ async def update_compliance_report_summary(
     """
     await validate.validate_organization_access(report_id)
     return await summary_service.update_compliance_report_summary(
-        report_id, summary_data, request.user
+        report_id, summary_data
     )
 
 


### PR DESCRIPTION
Extra argument in `update_compliance_report_summary` causing the issue.


[Story](https://github.com/orgs/bcgov/projects/137/views/1?pane=issue&itemId=102728397&issue=bcgov%7Clcfs%7C2256)