### PR TITLE
fix: Add timezone to available balance check

### DIFF
--- a/backend/lcfs/tests/transaction/transaction_payloads.py
+++ b/backend/lcfs/tests/transaction/transaction_payloads.py
@@ -1,3 +1,5 @@
+import zoneinfo
+
 from datetime import datetime
 
 from lcfs.db.models import (
@@ -123,6 +125,18 @@ recorded_transfer_orm = Transfer(
     recommendation=TransferRecommendationEnum.Record,
 )
 
+edge_case_transfer_orm = Transfer(
+    from_organization_id=test_org_id,
+    to_organization_id=test_org_2_id,
+    agreement_date=formatted_date(),
+    transaction_effective_date=formatted_date(),
+    price_per_unit=2.0,
+    quantity=20,
+    transfer_category_id=1,
+    current_status_id=6,
+    recommendation=TransferRecommendationEnum.Record,
+)
+
 refused_transfer_orm = Transfer(
     from_organization_id=test_org_id,
     to_organization_id=test_org_2_id,
@@ -194,4 +208,17 @@ adjustment_transaction_orm = Transaction(
     compliance_units=100,
     organization_id=test_org_id,
     create_date=datetime.now(),
+)
+
+edge_case_transaction_orm = Transaction(
+    transaction_id=6,
+    transaction_action=TransactionActionEnum.Adjustment,
+    compliance_units=133,
+    organization_id=test_org_id,
+    create_date=datetime.strptime(f"2023-03-31", "%Y-%m-%d").replace(
+        hour=23,
+        minute=59,
+        second=0,
+        tzinfo=zoneinfo.ZoneInfo("America/Vancouver"),
+    ),
 )

--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -1,5 +1,7 @@
 # transactions/repo.py
+import zoneinfo
 
+import structlog
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional
@@ -34,6 +36,9 @@ class EntityType(Enum):
     Government = "Government"
     Transferor = "Transferor"
     Transferee = "Transferee"
+
+
+logger = structlog.get_logger(__name__)
 
 
 class TransactionRepository:
@@ -317,8 +322,12 @@ class TransactionRepository:
         Returns:
             int: The available balance of compliance units for the specified organization and period. Returns 0 if no balance is calculated.
         """
+        vancouver_timezone = zoneinfo.ZoneInfo("America/Vancouver")
         compliance_period_end = datetime.strptime(
             f"{str(compliance_period + 1)}-03-31", "%Y-%m-%d"
+        )
+        compliance_period_end_local = compliance_period_end.replace(
+            hour=23, minute=59, second=59, microsecond=999999, tzinfo=vancouver_timezone
         )
         async with self.db.begin_nested():
             # Calculate the sum of all transactions up to the specified date
@@ -326,7 +335,7 @@ class TransactionRepository:
                 select(func.coalesce(func.sum(Transaction.compliance_units), 0)).where(
                     and_(
                         Transaction.organization_id == organization_id,
-                        Transaction.create_date <= compliance_period_end,
+                        Transaction.create_date <= compliance_period_end_local,
                         Transaction.transaction_action
                         != TransactionActionEnum.Released,
                     )
@@ -338,7 +347,7 @@ class TransactionRepository:
                 select(func.coalesce(func.sum(Transaction.compliance_units), 0)).where(
                     and_(
                         Transaction.organization_id == organization_id,
-                        Transaction.create_date > compliance_period_end,
+                        Transaction.create_date > compliance_period_end_local,
                         Transaction.compliance_units < 0,
                         Transaction.transaction_action
                         != TransactionActionEnum.Released,

--- a/backend/lcfs/web/api/transfer/services.py
+++ b/backend/lcfs/web/api/transfer/services.py
@@ -471,9 +471,6 @@ class TransferServices:
                 transfer.transfer_id, category
             )
             updated_transfer.transaction_effective_date = datetime.now()
-            await self.repo.update_transfer(transfer)
-
-        await self.repo.refresh_transfer(transfer)
 
         # Create new transaction for receiving organization
         to_transaction = await self.org_service.adjust_balance(
@@ -483,6 +480,7 @@ class TransferServices:
         )
         transfer.to_transaction = to_transaction
 
+        await self.repo.update_transfer(transfer)
         await self.repo.refresh_transfer(transfer)
 
     async def cancel_transfer(self, transfer):


### PR DESCRIPTION
* Was only checking the day, did not include transactions up until the end of March 31st in Vancouver time.