### PR TITLE
Fix: LCFS BCeID credit calculator 2308

### DIFF
--- a/backend/lcfs/web/api/calculator/views.py
+++ b/backend/lcfs/web/api/calculator/views.py
@@ -10,7 +10,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/compliance-periods/",
+    "/compliance-periods",
     tags=["public"],
     response_model=List[CompliancePeriodBaseSchema],
     status_code=status.HTTP_200_OK,


### PR DESCRIPTION
fix redirect issue that is still persisting for compliance-periods endpoint