### PR TITLE
fix: Return same response schema all the time

### DIFF
--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -408,8 +408,7 @@ class FuelSupplyRepository:
         self, group_uuid: str, version: int
     ) -> Optional[FuelSupply]:
         """
-        Retrieve a specific FuelSupply record by group UUID, version, and user_type.
-        This method explicitly requires user_type to avoid ambiguity.
+        Retrieve a specific FuelSupply record by group UUID, version.
         """
         query = select(FuelSupply).where(
             FuelSupply.group_uuid == group_uuid,
@@ -429,6 +428,13 @@ class FuelSupplyRepository:
         """
         query = (
             select(FuelSupply)
+            .options(
+                joinedload(FuelSupply.fuel_code),
+                joinedload(FuelSupply.fuel_category),
+                joinedload(FuelSupply.fuel_type),
+                joinedload(FuelSupply.provision_of_the_act),
+                joinedload(FuelSupply.end_use_type),
+            )
             .where(FuelSupply.group_uuid == group_uuid)
             .order_by(
                 FuelSupply.version.desc(),

--- a/backend/lcfs/web/api/fuel_supply/schema.py
+++ b/backend/lcfs/web/api/fuel_supply/schema.py
@@ -181,11 +181,6 @@ class FuelSupplyResponseSchema(FuelSupplyCreateUpdateSchema):
         return value
 
 
-class DeleteFuelSupplyResponseSchema(BaseSchema):
-    success: bool
-    message: str
-
-
 class FuelSuppliesSchema(BaseSchema):
     fuel_supplies: Optional[List[FuelSupplyResponseSchema]] = []
     pagination: Optional[PaginationResponseSchema] = {}

--- a/backend/lcfs/web/api/fuel_supply/services.py
+++ b/backend/lcfs/web/api/fuel_supply/services.py
@@ -70,7 +70,9 @@ class FuelSupplyServices:
         )
         eer = EnergyEffectivenessRatioSchema(
             eer_id=row_data["eer_id"],
-            energy_effectiveness_ratio=round(row_data["energy_effectiveness_ratio"]  or 1, 2),
+            energy_effectiveness_ratio=round(
+                row_data["energy_effectiveness_ratio"] or 1, 2
+            ),
             fuel_category=fuel_category,
             end_use_type=end_use_type,
         )

--- a/backend/lcfs/web/api/fuel_supply/views.py
+++ b/backend/lcfs/web/api/fuel_supply/views.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import structlog
 from fastapi import APIRouter, Body, Depends, Request, Response, status, HTTPException
 from starlette.responses import JSONResponse
@@ -9,7 +7,6 @@ from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.compliance_report.validation import ComplianceReportValidation
 from lcfs.web.api.fuel_supply.actions_service import FuelSupplyActionService
 from lcfs.web.api.fuel_supply.schema import (
-    DeleteFuelSupplyResponseSchema,
     FuelSuppliesSchema,
     FuelSupplyCreateUpdateSchema,
     FuelSupplyResponseSchema,
@@ -95,7 +92,7 @@ async def get_fuel_supply(
 
 @router.post(
     "/save",
-    response_model=Union[FuelSupplyResponseSchema, DeleteFuelSupplyResponseSchema],
+    response_model=FuelSupplyResponseSchema,
     status_code=status.HTTP_201_CREATED,
 )
 @view_handler(

--- a/frontend/src/hooks/useFuelSupply.js
+++ b/frontend/src/hooks/useFuelSupply.js
@@ -1,6 +1,6 @@
 import { apiRoutes } from '@/constants/routes'
 import { useApiService } from '@/services/useApiService'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 export const useFuelSupplyOptions = (params, options) => {
   const client = useApiService()
@@ -31,7 +31,7 @@ export const useGetFuelSupplies = (complianceReportId, pagination, options) => {
 export const useGetFuelSuppliesList = (
   { complianceReportId, changelog = false },
   pagination,
-  options
+  options = {}
 ) => {
   const client = useApiService()
   return useQuery({
@@ -50,6 +50,8 @@ export const useGetFuelSuppliesList = (
 
 export const useSaveFuelSupply = (params, options) => {
   const client = useApiService()
+  const queryClient = useQueryClient()
+
   return useMutation({
     ...options,
     mutationFn: async (data) => {
@@ -59,6 +61,16 @@ export const useSaveFuelSupply = (params, options) => {
       }
 
       return await client.post(apiRoutes.saveFuelSupplies, modifedData)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries([
+        'fuel-supplies',
+        params.complianceReportId
+      ])
+      queryClient.invalidateQueries([
+        'compliance-report-summary',
+        params.complianceReportId
+      ])
     }
   })
 }

--- a/frontend/src/views/AllocationAgreements/_schema.jsx
+++ b/frontend/src/views/AllocationAgreements/_schema.jsx
@@ -276,6 +276,7 @@ export const allocationAgreementColDefs = (
       openOnFocus: true
     }),
     suppressKeyboardEvent,
+    cellRenderer: SelectRenderer,
     cellStyle: (params) =>
       StandardCellWarningAndErrors(params, errors, warnings, isSupplemental),
     minWidth: 150,
@@ -315,9 +316,7 @@ export const allocationAgreementColDefs = (
       freeSolo: false,
       openOnFocus: true
     }),
-    cellRenderer: (params) =>
-      params.value ||
-      (!params.value && <BCTypography variant="body4">Select</BCTypography>),
+    cellRenderer: SelectRenderer,
     cellStyle: (params) =>
       StandardCellWarningAndErrors(params, errors, warnings, isSupplemental),
     suppressKeyboardEvent,
@@ -357,6 +356,7 @@ export const allocationAgreementColDefs = (
         openOnFocus: true
       }
     },
+    cellRenderer: SelectRenderer,
     cellStyle: (params) =>
       StandardCellWarningAndErrors(params, errors, warnings, isSupplemental),
     suppressKeyboardEvent,


### PR DESCRIPTION
* Union types cause issues with Schema validators, it will run the wrong validators
* Update update to always return the standard response
* Add SelectRenderers where missing
* Add onSettled back to GetFuelSuppliesList