### PR TITLE
Fix: Update RCI and Compliance Units in Export Fuel Schedule - 2215

### DIFF
--- a/frontend/src/views/FuelExports/AddEditFuelExports.jsx
+++ b/frontend/src/views/FuelExports/AddEditFuelExports.jsx
@@ -83,6 +83,7 @@ export const AddEditFuelExports = () => {
       if (!isArrayEmpty(data)) {
         const updatedRowData = data.fuelExports.map((item) => ({
           ...item,
+          ciOfFuel: item.ciOfFuel,
           complianceReportId,
           compliancePeriod,
           fuelCategory: item.fuelCategory?.category,
@@ -206,6 +207,25 @@ export const AddEditFuelExports = () => {
           params.node.setDataValue('endUseType', endUseValue)
           params.node.setDataValue('provisionOfTheAct', provisionValue)
         }
+      }
+
+      const recalcFields = [
+        'fuelTypeId',
+        'fuelCategory',
+        'provisionOfTheAct',
+        'fuelCode',
+        'exportDate'
+      ]
+
+      if (recalcFields.includes(params.column.colId)) {
+        // remove the stored value so the getter recalculates
+        params.node.setDataValue('ciOfFuel', null)
+
+        // refresh the CI columns for immediate feedback
+        params.api.refreshCells({
+          rowNodes: [params.node],
+          columns: ['ciOfFuel', 'targetCi', 'uci', 'complianceUnits']
+        })
       }
     },
     [optionsData]

--- a/frontend/src/views/FuelExports/_schema.jsx
+++ b/frontend/src/views/FuelExports/_schema.jsx
@@ -304,6 +304,9 @@ export const fuelExportColDefs = (
           params.data.fuelCode = null
           params.data.fuelCodeId = null
         }
+
+        // Clear export date whenever CI option changes
+        params.data.exportDate = null
       }
       return true
     },
@@ -490,6 +493,15 @@ export const fuelExportColDefs = (
       StandardCellWarningAndErrors(params, errors, warnings, isSupplemental),
 
     valueGetter: (params) => {
+      // Show the value we received from the API if it exists
+      if (
+        params.data?.ciOfFuel !== undefined &&
+        params.data?.ciOfFuel !== null
+      ) {
+        return params.data.ciOfFuel
+      }
+
+      // Otherwise fall back to the existing calculation logic
       const provision = params.data.provisionOfTheAct
 
       // 1) If provision is “Unknown”


### PR DESCRIPTION
This PR includes the following changes:
- Ensures RCI and compliance units are recalculated when fuel code is updated in Export fuel schedule.
- Fixes issue where editing a row didn’t reflect the updated CI in the summary.
- Clears export date from display when Determining CI option is changed.

Closes #2215