### PR TITLE
Fix: Add Missing Report Type Filters to Dropdown - 2443

### DIFF
--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -33,11 +33,16 @@ export const reportsColDefs = (t, isSupplier) => [
     floatingFilterComponentParams: {
       optionsQuery: () => ({
         data: [
-          { id: 1, name: 'Original Report' },
-          { id: 2, name: 'Supplemental Report' },
+          { id: 1, name: 'Early issuance' },
+          { id: 2, name: 'Original report' },
+          { id: 3, name: 'Supplemental report' },
           {
-            id: 3,
+            id: 4,
             name: 'Government adjustment'
+          },
+          {
+            id: 5,
+            name: 'Reassessment'
           }
         ],
         isLoading: false


### PR DESCRIPTION
This PR includes the following changes:
- Added missing report types (e.g. Early Issuance) to the type filter dropdown
- Ensured the dropdown options are complete and aligned with supported report types

Closes #2443