### PR TITLE
Hotfix: audit text update - 2552

### DIFF
--- a/backend/lcfs/web/api/transfer/services.py
+++ b/backend/lcfs/web/api/transfer/services.py
@@ -453,7 +453,9 @@ class TransferServices:
 
         await self.repo.refresh_transfer(transfer)
 
-        if not hasattr(transfer.transfer_category, "category"):
+        if transfer.transfer_category is None or not hasattr(
+            transfer.transfer_category, "category"
+        ):
             today = datetime.now()
             diff_seconds = today.timestamp() - transfer.agreement_date.timestamp()
             # Define approximate thresholds in seconds

--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -128,7 +128,7 @@
     {
       "header": "Audits of reports",
       "content": [
-        "<p>Responsible parties must keep sufficient records to verify and evaluate any reports and information submitted to the director. Under section 34 of the Low Carbon Fuels Act, the director can require an organization that submits a report to have the report audited by a designated inspector to verify compliance with the legislation. Any inconsistencies noted during the audit are deemed contraventions under the Low Carbon Fuels Act and may be subject to penalty after substantiation.</p>"
+        "<p>Responsible parties must keep sufficient records to verify and evaluate any reports and information submitted to the director. Under section 34 of the Low Carbon Fuels Act, the director can require an organization that submits a report to have the report audited to verify compliance with the legislation. Any inconsistencies noted during the audit may be contraventions under the Low Carbon Fuels Act and may be subject to penalty after substantiation.</p>"
       ]
     },
     {


### PR DESCRIPTION
- updated audit text
- transfer category null check added