### PR TITLE
Fix: Show Flash Message Once in Organization View - 2085

### DIFF
--- a/frontend/src/views/Organizations/OrganizationView/OrganizationDetailsCard.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/OrganizationDetailsCard.jsx
@@ -1,9 +1,7 @@
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
-import BCAlert from '@/components/BCAlert'
 import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
 import Loading from '@/components/Loading'
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useParams } from 'react-router-dom'
 import { buildPath, ROUTES } from '@/routes/routes'
@@ -22,9 +20,6 @@ export const OrganizationDetailsCard = () => {
   const { t } = useTranslation(['common', 'org'])
   const location = useLocation()
   const { orgID } = useParams()
-
-  const [alertMessage, setAlertMessage] = useState('')
-  const [alertSeverity, setAlertSeverity] = useState('info')
 
   const {
     data: currentUser,
@@ -46,25 +41,12 @@ export const OrganizationDetailsCard = () => {
       })
     : null
 
-  useEffect(() => {
-    if (location.state?.message) {
-      setAlertMessage(location.state.message)
-      setAlertSeverity(location.state.severity || 'info')
-    }
-  }, [location.state])
-
   if (isLoading) {
     return <Loading />
   }
 
   return (
     <>
-      {alertMessage && (
-        <BCAlert severity={alertSeverity} sx={{ mb: 4 }}>
-          {alertMessage}
-        </BCAlert>
-      )}
-
       <BCBox
         sx={{
           width: {

--- a/frontend/src/views/Organizations/OrganizationView/OrganizationUsers.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/OrganizationUsers.jsx
@@ -3,10 +3,9 @@ import BCTypography from '@/components/BCTypography'
 import BCButton from '@/components/BCButton'
 import BCDataGridServer from '@/components/BCDataGrid/BCDataGridServer'
 import { ClearFiltersButton } from '@/components/ClearFiltersButton'
-import BCAlert from '@/components/BCAlert'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
+import { useState, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LinkRenderer } from '@/utils/grid/cellRenderers'
 import { defaultSortModel, getUserColumnDefs } from './_schema'
@@ -29,18 +28,9 @@ export const OrganizationUsers = () => {
   } = useCurrentUser()
 
   const [gridKey, setGridKey] = useState(`users-grid-${orgID}-active`)
-  const [alertMessage, setAlertMessage] = useState('')
-  const [alertSeverity, setAlertSeverity] = useState('info')
   const [resetGridFn, setResetGridFn] = useState(null)
 
   const gridRef = useRef()
-
-  useEffect(() => {
-    if (location.state?.message) {
-      setAlertMessage(location.state.message)
-      setAlertSeverity(location.state.severity || 'info')
-    }
-  }, [location.state])
 
   const handleGridKey = useCallback(() => {
     setGridKey(`users-grid-${orgID}`)
@@ -103,12 +93,6 @@ export const OrganizationUsers = () => {
 
   return (
     <BCBox mt={3}>
-      {alertMessage && (
-        <BCAlert data-test="alert-box" severity={alertSeverity} sx={{ mb: 2 }}>
-          {alertMessage}
-        </BCAlert>
-      )}
-
       {/* Title + buttons */}
       <BCBox my={2}>
         <BCTypography

--- a/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { AppBar, Tab, Tabs } from '@mui/material'
 import BCBox from '@/components/BCBox'
+import BCAlert from '@/components/BCAlert'
 import { OrganizationDetailsCard } from './OrganizationDetailsCard'
 import { OrganizationUsers } from './OrganizationUsers'
 import { CreditLedger } from './CreditLedger'
@@ -27,8 +29,22 @@ export const OrganizationView = () => {
   const [tabIndex, setTabIndex] = useState(0)
   const [tabsOrientation, setTabsOrientation] = useState('horizontal')
 
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [alert, setAlert] = useState(null)
+
   const { hasRoles } = useCurrentUser()
   const isIdir = hasRoles(roles.government)
+
+  useEffect(() => {
+    if (location.state?.message) {
+      setAlert({
+        message: location.state.message,
+        severity: location.state.severity || 'info'
+      })
+      navigate(location.pathname, { replace: true, state: {} })
+    }
+  }, [location, navigate])
 
   const tabs = [{ label: t('org:usersTab'), content: <OrganizationUsers /> }]
   if (!isIdir) {
@@ -57,12 +73,16 @@ export const OrganizationView = () => {
 
   return (
     <BCBox>
+      {alert && (
+        <BCAlert severity={alert.severity} sx={{ mb: 4 }}>
+          {alert.message}
+        </BCAlert>
+      )}
+
       <OrganizationDetailsCard />
 
       {tabs.length === 1 ? (
-        <BCBox mt={3}>
-          {tabs[0].content}
-        </BCBox>
+        <BCBox mt={3}>{tabs[0].content}</BCBox>
       ) : (
         <BCBox sx={{ mt: 2, bgcolor: 'background.paper' }}>
           <AppBar position="static" sx={{ boxShadow: 'none', border: 'none' }}>


### PR DESCRIPTION
This PR includes the following changes:
- Moved flash message handling from OrganizationUsers and OrganizationDetailsCard into OrganizationView.
- Prevents duplicate success messages when saving or deleting a user.

Closes #2085