### PR TITLE
Fix: Enable director to issue assessment from analyst recommendation - 2607

### DIFF
--- a/frontend/src/views/ComplianceReports/__tests__/buttonConfigs.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/buttonConfigs.test.jsx
@@ -201,4 +201,27 @@ describe('buttonClusterConfigFn', () => {
     )
     expect(returnButton).toBeUndefined()
   })
+
+  it('should display assessment button for Director in Recommended by analyst status', () => {
+    const props = {
+      ...baseProps,
+      isGovernmentUser: true,
+      hasRoles: (role) => role === roles.director,
+      hasDraftSupplemental: false
+    }
+
+    // Test Recommended by Analyst status with Director role
+    const config = buttonClusterConfigFn(props)
+    const buttons = config[COMPLIANCE_REPORT_STATUSES.RECOMMENDED_BY_ANALYST]
+
+    // We should see the Director buttons (after the Manager buttons)
+    expect(buttons.length).toBe(2)
+    expect(buttons[0].id).toBe('assess-report-btn')
+    expect(buttons[0].label).toBe('report:actionBtns.assessReportBtn')
+    expect(buttons[0].disabled).toBe(false)
+
+    expect(buttons[1].id).toBe('return-report-manager-btn')
+    expect(buttons[1].label).toBe('report:actionBtns.returnToAnalyst')
+    expect(buttons[1].disabled).toBe(false)
+  })
 })

--- a/frontend/src/views/ComplianceReports/buttonConfigs.jsx
+++ b/frontend/src/views/ComplianceReports/buttonConfigs.jsx
@@ -303,6 +303,12 @@ export const buttonClusterConfigFn = ({
             },
             { ...reportButtons.returnToAnalyst, disabled: hasDraftSupplemental }
           ]
+        : []),
+      ...(isGovernmentUser && hasRoles('Director')
+        ? [
+            { ...reportButtons.assessReport, disabled: hasDraftSupplemental },
+            { ...reportButtons.returnToAnalyst, disabled: hasDraftSupplemental }
+          ]
         : [])
     ],
     [COMPLIANCE_REPORT_STATUSES.RECOMMENDED_BY_MANAGER]: [


### PR DESCRIPTION
This PR includes the following:
- Shows the "Issue assessment" button to IDIR Directors when a report is in "Recommended by analyst" status
- Ensures report history shows one or two recommendation entries as expected

Since Directors can now bypass the Compliance Manager, I believe there should also be a "Return to analyst" option available at this stage. I've informed the Product Owner about this suggestion.

Closes #2607