### PR TITLE
fix: create assessment report icon size

### DIFF
--- a/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
+++ b/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
@@ -178,7 +178,6 @@ export const AssessmentCard = ({
                           }}
                           startIcon={
                             <Assignment
-                              fontSize="1rem !important"
                               sx={{
                                 width: '1rem',
                                 height: '1rem'

--- a/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
+++ b/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
@@ -176,7 +176,15 @@ export const AssessmentCard = ({
                           onClick={() => {
                             createSupplementalReport()
                           }}
-                          startIcon={<Assignment fontSize="1rem !important" />}
+                          startIcon={
+                            <Assignment
+                              fontSize="1rem !important"
+                              sx={{
+                                width: '1rem',
+                                height: '1rem'
+                              }}
+                            />
+                          }
                           sx={{ mt: 3 }}
                           disabled={isLoading}
                         >


### PR DESCRIPTION
- fix: icon size on the create supplemental report button, closes #2636 