### PR TITLE
Feat: Idir Uploads - 2543

### DIFF
--- a/backend/lcfs/services/s3/schema.py
+++ b/backend/lcfs/services/s3/schema.py
@@ -1,10 +1,16 @@
 from lcfs.web.api.base import BaseSchema
+from datetime import datetime
 
 
 class FileResponseSchema(BaseSchema):
     document_id: int
     file_name: str
     file_size: int
+    create_date: datetime | None = None
+    create_user: str | None = None
+
+    class Config:
+        from_attributes = True
 
 
 class UrlResponseSchema(BaseSchema):

--- a/backend/lcfs/tests/document/test_document_view.py
+++ b/backend/lcfs/tests/document/test_document_view.py
@@ -17,6 +17,8 @@ class DummyDocument:
         self.file_name = file_name
         self.document_id = document_id
         self.file_size = file_size
+        self.create_date = "2024-01-01T00:00:00Z"
+        self.create_user = "tester"
 
 
 class FakeDocumentService:
@@ -26,6 +28,8 @@ class FakeDocumentService:
                 "document_id": 1,
                 "file_name": "test.pdf",
                 "file_size": 123,
+                "create_date": "2024-01-01T00:00:00Z",
+                "create_user": "tester",
             }
         ]
 
@@ -36,6 +40,8 @@ class FakeDocumentService:
             "document_id": 2,
             "file_name": "uploaded.pdf",
             "file_size": 456,
+            "create_date": "2024-01-01T00:00:00Z",
+            "create_user": "tester",
         }
 
     async def get_object(self, document_id: int):
@@ -105,6 +111,8 @@ async def test_get_all_documents(fastapi_app, client):
     assert doc["documentId"] == 1
     assert doc["fileName"] == "test.pdf"
     assert doc["fileSize"] == 123
+    assert doc["createDate"] == "2024-01-01T00:00:00Z"
+    assert doc["createUser"] == "tester"
 
 
 @pytest.mark.anyio
@@ -121,6 +129,8 @@ async def test_upload_file_success(fastapi_app, client):
     assert data["documentId"] == 2
     assert data["fileName"] == "uploaded.pdf"
     assert data["fileSize"] == 456
+    assert data["createDate"] == "2024-01-01T00:00:00Z"
+    assert data["createUser"] == "tester"
 
 
 @pytest.mark.anyio

--- a/frontend/src/components/Documents/DocumentTable.jsx
+++ b/frontend/src/components/Documents/DocumentTable.jsx
@@ -20,6 +20,8 @@ import {
   useUploadDocument,
   useDownloadDocument
 } from '@/hooks/useDocuments'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { timezoneFormatter } from '@/utils/formatters'
 import { MAX_FILE_SIZE_BYTES } from '@/constants/common.js'
 
 const StyledCard = styled(Card)(({ theme, isDragActive = false }) => ({
@@ -40,7 +42,7 @@ const StyledCard = styled(Card)(({ theme, isDragActive = false }) => ({
 const FileTable = styled(Box)(({ theme }) => ({
   width: '100%',
   display: 'grid',
-  gridTemplateColumns: '1fr max-content max-content max-content',
+  gridTemplateColumns: '1fr 220px max-content max-content max-content',
   gridColumnGap: '8px'
 }))
 
@@ -54,6 +56,7 @@ function DocumentTable({ parentType, parentID }) {
   const [isDragActive, setIsDragActive] = useState(false)
   const fileInputRef = useRef(null)
   const [files, setFiles] = useState([])
+  const { data: currentUser, hasRoles } = useCurrentUser()
 
   const { data: loadedFiles } = useDocuments(parentType, parentID)
   useEffect(() => {
@@ -205,6 +208,11 @@ function DocumentTable({ parentType, parentID }) {
         </TableCell>
         <TableCell>
           <BCTypography color="primary" variant="subtitle1">
+            Uploaded
+          </BCTypography>
+        </TableCell>
+        <TableCell>
+          <BCTypography color="primary" variant="subtitle1">
             Size
           </BCTypography>
         </TableCell>
@@ -238,6 +246,12 @@ function DocumentTable({ parentType, parentID }) {
               )}
             </TableCell>
             <TableCell>
+              {timezoneFormatter({ value: file.createDate })}
+              {file.createUser && !hasRoles('Supplier')
+                ? ` - ${file.createUser}`
+                : ''}
+            </TableCell>
+            <TableCell>
               {file.oversize && (
                 <Icon style={{ color: colors.error.main }}>close</Icon>
               )}
@@ -257,7 +271,8 @@ function DocumentTable({ parentType, parentID }) {
                 {!file.deleting &&
                   !file.virus &&
                   !file.scanning &&
-                  !file.oversize && (
+                  !file.oversize &&
+                  file.createUser === currentUser?.keycloakUsername && (
                     <IconButton
                       onClick={() => {
                         handleDeleteFile(file.documentId)

--- a/frontend/src/components/Documents/__test__/DocumentUploadDialog.test.jsx
+++ b/frontend/src/components/Documents/__test__/DocumentUploadDialog.test.jsx
@@ -8,6 +8,7 @@ import {
   useUploadDocument,
   useDocuments
 } from '@/hooks/useDocuments'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 
 // Mock hooks
 vi.mock('@/hooks/useDocuments', () => ({
@@ -16,6 +17,7 @@ vi.mock('@/hooks/useDocuments', () => ({
   useUploadDocument: vi.fn(),
   useDownloadDocument: vi.fn()
 }))
+vi.mock('@/hooks/useCurrentUser')
 
 describe('DocumentUploadDialog', () => {
   const parentID = '123'
@@ -32,6 +34,9 @@ describe('DocumentUploadDialog', () => {
     })
     useDeleteDocument.mockReturnValue({
       mutate: vi.fn()
+    })
+    useCurrentUser.mockReturnValue({
+      data: { keycloakUsername: 'tester' }
     })
   })
 
@@ -108,7 +113,9 @@ describe('DocumentUploadDialog', () => {
         {
           documentId: '1',
           fileName: 'example.txt',
-          fileSize: 1024
+          fileSize: 1024,
+          createUser: 'tester',
+          createDate: '2024-01-01T00:00:00Z'
         }
       ],
       isLoading: false

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -100,8 +100,9 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', userRoles }) => {
     if (hasAnalystRole) {
       const editableAnalystStatuses = [
         COMPLIANCE_REPORT_STATUSES.SUBMITTED,
-        COMPLIANCE_REPORT_STATUSES.ASSESSED,
-        COMPLIANCE_REPORT_STATUSES.ANALYST_ADJUSTMENT
+        COMPLIANCE_REPORT_STATUSES.RECOMMENDED_BY_ANALYST,
+        COMPLIANCE_REPORT_STATUSES.RECOMMENDED_BY_MANAGER,
+        COMPLIANCE_REPORT_STATUSES.ASSESSED
       ]
 
       return editableAnalystStatuses.includes(currentStatus)
@@ -117,19 +118,13 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', userRoles }) => {
     return canEdit
   }
 
-  const crMap = useMemo(() => {
-    const mapSet = {}
-    complianceReportData.chain.forEach((complianceReport) => {
-      mapSet[complianceReport.complianceReportId] = complianceReport.version
-    })
-    return mapSet
-  }, [complianceReportData])
-
   const wasEdited = (data) => {
-    return data?.some(
-      (row) =>
-        crMap[row.complianceReportId] !== 0 && Object.prototype.hasOwnProperty.call(row, 'version')
-    )
+    const crMap = {}
+    complianceReportData.chain.forEach((complianceReport) => {
+      crMap[complianceReport.complianceReportId] = complianceReport.version
+    })
+
+    return data?.some((row) => crMap[row.complianceReportId] !== 0)
   }
 
   const activityList = useMemo(
@@ -391,18 +386,13 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', userRoles }) => {
           scheduleData.length > 0 &&
           scheduleData.every((item) => item.actionType === 'DELETE')
 
-        // Determine if this accordion should be displayed
-        const shouldShowAccordion =
-          // Always show if it has data
-          (scheduleData && !isArrayEmpty(scheduleData)) ||
-          // Or if it's Supporting Docs and user has analyst role (always show this section regardless of content)
+        const shouldRender =
           activity.name === t('report:supportingDocs') ||
-          // For non-supplemental reports, always show all sections even if they're empty
-          // For supplemental reports (version > 0), hide empty accordions
-          !isSupplemental
+          (scheduleData && !isArrayEmpty(scheduleData)) ||
+          hasVersions
 
         return (
-          shouldShowAccordion && (
+          shouldRender && (
             <Accordion
               sx={{
                 '& .Mui-disabled': {
@@ -483,7 +473,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', userRoles }) => {
                     sx={{ ...chipStyles }}
                   />
                 )}
-                {hasNoData && (
+                {isDisabled && (
                   <Chip
                     aria-label="no records"
                     icon={<InfoOutlined fontSize="small" />}
@@ -491,11 +481,11 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', userRoles }) => {
                     size="small"
                     sx={{
                       ...chipStyles,
-                      color: colors.alerts.info.color,
+                      color: colors.alerts.error.color,
                       '& .MuiChip-icon': {
-                        color: colors.alerts.info.color
+                        color: colors.alerts.error.color
                       },
-                      backgroundImage: `linear-gradient(195deg, ${colors.alerts.info.border},${colors.alerts.info.background})`
+                      backgroundImage: `linear-gradient(195deg, ${colors.alerts.error.border},${colors.alerts.error.background})`
                     }}
                   />
                 )}

--- a/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
+++ b/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
@@ -2,9 +2,12 @@ import Box from '@mui/material/Box'
 import { List, ListItemButton } from '@mui/material'
 import BCTypography from '@/components/BCTypography'
 import { useDownloadDocument } from '@/hooks/useDocuments.js'
+import { timezoneFormatter } from '@/utils/formatters'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 
 export const SupportingDocumentSummary = ({ parentID, parentType, data }) => {
   const downloadDocument = useDownloadDocument(parentType, parentID)
+  const { hasRoles } = useCurrentUser()
 
   return (
     <Box>
@@ -26,7 +29,10 @@ export const SupportingDocumentSummary = ({ parentID, parentType, data }) => {
               variant="subtitle2"
               color="link"
             >
-              {file.fileName}
+              {file.fileName} - {timezoneFormatter({ value: file.createDate })}
+              {file.createUser && !hasRoles('Supplier')
+                ? ` - ${file.createUser}`
+                : ''}
             </BCTypography>
           </ListItemButton>
         ))}


### PR DESCRIPTION
allow analysts to upload documents in more compliance report states
return uploader and timestamp information from document API
show username and PST timestamp for uploaded documents
restrict delete button to the document uploader only
display supporting-documents accordion even when no documents exist