### PR TITLE
Fix: Dashboard Summary Widget missing unregistered organizations - 1789

### DIFF
--- a/backend/lcfs/tests/organizations/test_organizations_service.py
+++ b/backend/lcfs/tests/organizations/test_organizations_service.py
@@ -1,0 +1,172 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from lcfs.web.api.organizations.services import OrganizationsService
+from lcfs.web.api.organizations.schema import OrganizationSummaryResponseSchema
+
+
+@pytest.fixture
+def mock_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_redis_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_transaction_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def organizations_service(mock_repo, mock_redis_service, mock_transaction_repo):
+    service = OrganizationsService()
+    service.repo = mock_repo
+    service.redis_balance_service = mock_redis_service
+    service.transaction_repo = mock_transaction_repo
+    return service
+
+
+@pytest.mark.anyio
+async def test_get_organization_names_with_statuses(organizations_service, mock_repo):
+    """Test get_organization_names with specific statuses parameter"""
+
+    # Mock data that would be returned from the repository
+    mock_org_data = [
+        {
+            "organization_id": 1,
+            "name": "Test Org 1",
+            "operating_name": "Test Operating 1",
+            "total_balance": 1000,
+            "reserved_balance": 100,
+        },
+        {
+            "organization_id": 2,
+            "name": "Test Org 2",
+            "operating_name": "Test Operating 2",
+            "total_balance": 2000,
+            "reserved_balance": 200,
+        },
+    ]
+
+    # Mock the repository method
+    mock_repo.get_organization_names = AsyncMock(return_value=mock_org_data)
+
+    # Test with specific statuses
+    statuses = ["Registered", "Unregistered"]
+    result = await organizations_service.get_organization_names(
+        order_by=("name", "asc"), statuses=statuses
+    )
+
+    # Verify the repository was called with the right conditions
+    mock_repo.get_organization_names.assert_called_once()
+    call_args = mock_repo.get_organization_names.call_args
+    conditions = call_args[0][0]  # First positional argument
+    order_by = call_args[0][1]  # Second positional argument
+
+    # Verify that status filtering conditions were created
+    assert len(conditions) == 1
+    assert order_by == ("name", "asc")
+
+    # Verify the result structure
+    assert len(result) == 2
+    assert all(isinstance(org, OrganizationSummaryResponseSchema) for org in result)
+    assert result[0].organization_id == 1
+    assert result[0].name == "Test Org 1"
+    assert result[1].organization_id == 2
+    assert result[1].name == "Test Org 2"
+
+
+@pytest.mark.anyio
+async def test_get_organization_names_registered_status(
+    organizations_service, mock_repo
+):
+    """Test get_organization_names with registered status"""
+
+    mock_org_data = [
+        {
+            "organization_id": 1,
+            "name": "Registered Org",
+            "operating_name": "Registered Operating",
+            "total_balance": 1000,
+            "reserved_balance": 100,
+        }
+    ]
+
+    mock_repo.get_organization_names = AsyncMock(return_value=mock_org_data)
+
+    # Test with registered status
+    result = await organizations_service.get_organization_names(
+        order_by=("name", "asc"), statuses=["Registered"]
+    )
+
+    # Verify the repository was called
+    mock_repo.get_organization_names.assert_called_once()
+    call_args = mock_repo.get_organization_names.call_args
+    conditions = call_args[0][0]
+
+    # Should have one condition for registered status
+    assert len(conditions) == 1
+
+    # Verify result
+    assert len(result) == 1
+    assert result[0].name == "Registered Org"
+
+
+@pytest.mark.anyio
+async def test_get_organization_names_no_statuses_filter(
+    organizations_service, mock_repo
+):
+    """Test get_organization_names with no statuses (all organizations)"""
+
+    mock_org_data = [
+        {
+            "organization_id": 1,
+            "name": "Any Status Org",
+            "operating_name": "Any Operating",
+            "total_balance": 1000,
+            "reserved_balance": 100,
+        }
+    ]
+
+    mock_repo.get_organization_names = AsyncMock(return_value=mock_org_data)
+
+    # Test with no filtering
+    result = await organizations_service.get_organization_names(
+        order_by=("name", "asc"), statuses=None
+    )
+
+    # Verify the repository was called
+    mock_repo.get_organization_names.assert_called_once()
+    call_args = mock_repo.get_organization_names.call_args
+    conditions = call_args[0][0]
+
+    # Should have no conditions (empty list)
+    assert len(conditions) == 0
+
+    # Verify result
+    assert len(result) == 1
+    assert result[0].name == "Any Status Org"
+
+
+@pytest.mark.anyio
+async def test_get_organization_names_invalid_statuses(
+    organizations_service, mock_repo
+):
+    """Test get_organization_names filters out invalid statuses"""
+
+    mock_org_data = []
+    mock_repo.get_organization_names = AsyncMock(return_value=mock_org_data)
+
+    # Test with invalid statuses mixed with valid ones
+    statuses = ["Registered", "InvalidStatus", "Unregistered", "AnotherInvalid"]
+    result = await organizations_service.get_organization_names(
+        order_by=("name", "asc"), statuses=statuses
+    )
+
+    # Should still call the repo (invalid statuses are filtered out in the service)
+    mock_repo.get_organization_names.assert_called_once()
+
+    # Result should be valid even with invalid statuses passed
+    assert isinstance(result, list)

--- a/backend/lcfs/tests/test_organization.py
+++ b/backend/lcfs/tests/test_organization.py
@@ -232,12 +232,27 @@ async def test_get_organization_names(
 ) -> None:
     set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
     url = fastapi_app.url_path_for("get_organization_names")
+
+    # Test without any filters
     response = await client.get(url)
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
     assert isinstance(data, list)
     assert len(data) > 0
     assert all("name" in org for org in data)
+
+    # Test with specific statuses
+    response = await client.get(url + "?statuses=Registered&statuses=Unregistered")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert isinstance(data, list)
+    assert all("name" in org for org in data)
+
+    # Test with single status
+    response = await client.get(url + "?statuses=Registered")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert isinstance(data, list)
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/organizations/services.py
+++ b/backend/lcfs/web/api/organizations/services.py
@@ -282,21 +282,31 @@ class OrganizationsService:
 
     @service_handler
     async def get_organization_names(
-        self, only_registered: bool = False, order_by=("name", "asc")
+        self,
+        order_by=("name", "asc"),
+        statuses: List[str] = None,
     ) -> List[OrganizationSummaryResponseSchema]:
         """
         Fetches all organization names and their detailed information, formatted as per OrganizationSummaryResponseSchema.
 
         Parameters:
-            only_registered (bool): If true, fetches only registered organizations.
             order_by (tuple): Tuple containing the field name to sort by and the direction ('asc' or 'desc').
+            statuses (List[str]): List of statuses to filter by. If None, returns all organizations.
 
         Returns:
             List[OrganizationSummaryResponseSchema]: List of organizations with their summary information.
         """
         conditions = []
-        if only_registered:
-            conditions.append(OrganizationStatus.status == OrgStatusEnum.Registered)
+
+        if statuses:
+            # If specific statuses are provided, filter by those
+            status_enums = [
+                OrgStatusEnum(status)
+                for status in statuses
+                if status in [e.value for e in OrgStatusEnum]
+            ]
+            if status_enums:
+                conditions.append(OrganizationStatus.status.in_(status_enums))
 
         # The order_by tuple directly specifies both the sort field and direction
         organization_data = await self.repo.get_organization_names(conditions, order_by)

--- a/backend/lcfs/web/api/organizations/views.py
+++ b/backend/lcfs/web/api/organizations/views.py
@@ -172,12 +172,12 @@ async def get_organization_types(
 )  # Ensure only government can access this endpoint because it returns balances
 async def get_organization_names(
     request: Request,
-    only_registered: bool = Query(True),
+    statuses: Optional[List[str]] = Query(None),
     service: OrganizationsService = Depends(),
 ):
     """Fetch all organization names."""
     order_by = ("name", "asc")
-    return await service.get_organization_names(only_registered, order_by)
+    return await service.get_organization_names(order_by, statuses)
 
 
 @router.get(

--- a/frontend/src/hooks/useOrganizations.js
+++ b/frontend/src/hooks/useOrganizations.js
@@ -11,16 +11,23 @@ export const useOrganizationStatuses = (options) => {
   })
 }
 
-export const useOrganizationNames = (onlyRegistered = true, options) => {
+export const useOrganizationNames = (statuses = null, options) => {
   const client = useApiService()
 
   return useQuery({
-    queryKey: ['organization-names', onlyRegistered],
+    queryKey: ['organization-names', statuses],
     queryFn: async () => {
-      const response = await client.get(`/organizations/names/?only_registered=${onlyRegistered}`)
+      let url = `/organizations/names/`
+      if (statuses && Array.isArray(statuses)) {
+        const statusParams = statuses
+          .map((status) => `statuses=${status}`)
+          .join('&')
+        url += `?${statusParams}`
+      }
+      const response = await client.get(url)
       return response.data
     },
-    ...options,
+    ...options
   })
 }
 

--- a/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
@@ -7,7 +7,10 @@ import { numberFormatter } from '@/utils/formatters.js'
 import { useTranslation } from 'react-i18next'
 
 const OrganizationsSummaryCard = () => {
-  const { data: organizations, isLoading } = useOrganizationNames()
+  const { data: organizations, isLoading } = useOrganizationNames([
+    'Registered',
+    'Unregistered'
+  ])
   const { t } = useTranslation(['common', 'transaction'])
 
   const [formattedOrgs, setFormattedOrgs] = useState([])

--- a/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
@@ -25,6 +25,15 @@ describe('OrganizationsSummaryCards', () => {
     })
   })
 
+  it('calls useOrganizationNames with correct statuses for dashboard', () => {
+    render(<OrganizationsSummaryCard />, { wrapper })
+
+    expect(useOrganizationNames).toHaveBeenCalledWith([
+      'Registered',
+      'Unregistered'
+    ])
+  })
+
   it('renders correctly with default values', () => {
     render(<OrganizationsSummaryCard />, { wrapper })
 

--- a/frontend/src/views/Transactions/components/OrganizationList.jsx
+++ b/frontend/src/views/Transactions/components/OrganizationList.jsx
@@ -12,7 +12,8 @@ const OrganizationList = ({
   onlyRegistered = true
 }) => {
   const { t } = useTranslation(['transaction'])
-  const { data, isLoading } = useOrganizationNames(onlyRegistered)
+  const statuses = onlyRegistered ? ['Registered'] : null
+  const { data, isLoading } = useOrganizationNames(statuses)
   const [optionsList, setOptionsList] = useState([])
 
   useEffect(() => {
@@ -82,8 +83,7 @@ const OrganizationList = ({
               aria-label={t('txn:selectOrganizationName')}
               value={
                 optionsList.find(
-                  (option) =>
-                    option.organizationId === selectedOrg?.id
+                  (option) => option.organizationId === selectedOrg?.id
                 ) || null
               }
               slotProps={{

--- a/frontend/src/views/Transactions/components/TransactionDetails.jsx
+++ b/frontend/src/views/Transactions/components/TransactionDetails.jsx
@@ -34,7 +34,7 @@ export const TransactionDetails = ({ transactionId, isEditable }) => {
     control
   } = useFormContext()
 
-  const { data: orgData } = useOrganizationNames(false)
+  const { data: orgData } = useOrganizationNames(null)
   const organizations =
     orgData?.map((org) => ({
       value: parseInt(org.organizationId),

--- a/frontend/src/views/Transactions/components/__tests__/TransactionDetails.test.jsx
+++ b/frontend/src/views/Transactions/components/__tests__/TransactionDetails.test.jsx
@@ -76,6 +76,29 @@ describe('TransactionDetails Component', () => {
     })
   })
 
+  it('calls useOrganizationNames with null to get all organizations', () => {
+    const TestComponent = () => {
+      const methods = useForm()
+      return (
+        <FormProvider {...methods}>
+          <TransactionDetails transactionId={null} isEditable={true} />
+        </FormProvider>
+      )
+    }
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <ThemeProvider theme={theme}>
+          <MemoryRouter>
+            <TestComponent />
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    )
+
+    expect(useOrganizationNames).toHaveBeenCalledWith(null)
+  })
+
   afterEach(() => {
     vi.resetModules()
   })


### PR DESCRIPTION
Fixes bug #1789 where unregistered organizations were missing from the Dashboard Summary Widget. Now shows both Registered and Unregistered orgs, excluding Suspended and Canceled.