### PR TITLE
Fix: Hide Assessment Recommendation Section for BCeID Users - 2701

### DIFF
--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -496,87 +496,87 @@ export const EditViewComplianceReport = ({ reportData, isError, error }) => {
             />
           )}
 
-          <BCTypography
-            color="primary"
-            variant="h5"
-            mb={2}
-            mt={2}
-            component="div"
-          >
-            {t('report:assessmentRecommendation')}
-          </BCTypography>
+          {isGovernmentUser && (
+            <>
+              <BCTypography
+                color="primary"
+                variant="h5"
+                mb={2}
+                mt={2}
+                component="div"
+              >
+                {t('report:assessmentRecommendation')}
+              </BCTypography>
 
-          <BCBox
-            sx={{
-              border: '1px solid rgba(0, 0, 0, 0.28)',
-              padding: '20px',
-              boxShadow: '0 1px 2px rgba(0,0,0,0.28)'
-            }}
-          >
-            {isGovernmentUser && !qReport?.isQuarterly && (
-              <AssessmentStatement />
-            )}
-            {hasRoles(roles.analyst) && !qReport?.isQuarterly && (
-              <AssessmentRecommendation
-                reportData={reportData}
-                complianceReportId={complianceReportId}
-                currentStatus={currentStatus}
-              />
-            )}
-            {/* Internal Comments */}
-            {isGovernmentUser && (
-              <BCBox mt={4}>
-                <BCTypography variant="h6" color="primary">
-                  {t(`report:internalComments`)}
-                </BCTypography>
-                <BCBox>
-                  <Role roles={govRoles}>
-                    <InternalComments
-                      entityType="complianceReport"
-                      entityId={parseInt(complianceReportId)}
-                    />
-                  </Role>
+              <BCBox
+                sx={{
+                  border: '1px solid rgba(0, 0, 0, 0.28)',
+                  padding: '20px',
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.28)'
+                }}
+              >
+                {!qReport?.isQuarterly && <AssessmentStatement />}
+                {hasRoles(roles.analyst) && !qReport?.isQuarterly && (
+                  <AssessmentRecommendation
+                    reportData={reportData}
+                    complianceReportId={complianceReportId}
+                    currentStatus={currentStatus}
+                  />
+                )}
+                {/* Internal Comments */}
+                <BCBox mt={4}>
+                  <BCTypography variant="h6" color="primary">
+                    {t(`report:internalComments`)}
+                  </BCTypography>
+                  <BCBox>
+                    <Role roles={govRoles}>
+                      <InternalComments
+                        entityType="complianceReport"
+                        entityId={parseInt(complianceReportId)}
+                      />
+                    </Role>
+                  </BCBox>
+                  <Stack
+                    direction="row"
+                    justifyContent="flex-start"
+                    mt={2}
+                    gap={2}
+                  >
+                    {buttonClusterConfig[currentStatus]?.map(
+                      (config) =>
+                        config && (
+                          <BCButton
+                            key={config.id}
+                            data-test={config.id}
+                            id={config.id}
+                            size="small"
+                            variant={config.variant}
+                            color={config.color}
+                            onClick={methods.handleSubmit(() =>
+                              config.handler({
+                                assessmentStatement:
+                                  reportData?.report.assessmentStatement
+                              })
+                            )}
+                            startIcon={
+                              config.startIcon && (
+                                <FontAwesomeIcon
+                                  icon={config.startIcon}
+                                  className="small-icon"
+                                />
+                              )
+                            }
+                            disabled={config.disabled}
+                          >
+                            {config.label}
+                          </BCButton>
+                        )
+                    )}
+                  </Stack>
                 </BCBox>
-                <Stack
-                  direction="row"
-                  justifyContent="flex-start"
-                  mt={2}
-                  gap={2}
-                >
-                  {buttonClusterConfig[currentStatus]?.map(
-                    (config) =>
-                      config && (
-                        <BCButton
-                          key={config.id}
-                          data-test={config.id}
-                          id={config.id}
-                          size="small"
-                          variant={config.variant}
-                          color={config.color}
-                          onClick={methods.handleSubmit(() =>
-                            config.handler({
-                              assessmentStatement:
-                                reportData?.report.assessmentStatement
-                            })
-                          )}
-                          startIcon={
-                            config.startIcon && (
-                              <FontAwesomeIcon
-                                icon={config.startIcon}
-                                className="small-icon"
-                              />
-                            )
-                          }
-                          disabled={config.disabled}
-                        >
-                          {config.label}
-                        </BCButton>
-                      )
-                  )}
-                </Stack>
               </BCBox>
-            )}
-          </BCBox>
+            </>
+          )}
 
           {/* 30-Day Submission Notice for BCeID on Draft Supplementals */}
           {!isGovernmentUser && isDraftSupplemental && submissionDeadline && (

--- a/frontend/src/views/ComplianceReports/__tests__/EditViewComplianceReports.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/EditViewComplianceReports.test.jsx
@@ -635,4 +635,68 @@ describe('EditViewComplianceReport', () => {
       expect(screen.getByLabelText('scroll to bottom')).toBeInTheDocument()
     })
   })
+
+  it('should show Assessment Recommendation section for government users (IDIR)', async () => {
+    const mocks = setupMocks({
+      currentUser: {
+        data: {
+          organization: { organizationId: '123' },
+          isGovernmentUser: true, // Government user (IDIR)
+          roles: ['analyst'] // Government role
+        },
+        isLoading: false,
+        hasRoles: (roles) => roles.includes('analyst'),
+        hasAnyRole: () => true
+      }
+    })
+
+    render(
+      <EditViewComplianceReport
+        reportData={mocks.reportData}
+        isError={mocks.isError}
+        error={mocks.error}
+      />,
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      // Check for Assessment Recommendation heading
+      expect(screen.getByText(/assessmentRecommendation/i)).toBeInTheDocument()
+      // Check for Internal Comments section (also within the government-only section)
+      expect(screen.getByText(/internalComments/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should hide Assessment Recommendation section for non-government users (BCeID)', async () => {
+    const mocks = setupMocks({
+      currentUser: {
+        data: {
+          organization: { organizationId: '123' },
+          isGovernmentUser: false, // Non-government user (BCeID)
+          roles: ['supplier'] // Non-government role
+        },
+        isLoading: false,
+        hasRoles: (roles) => roles.includes('supplier'),
+        hasAnyRole: () => false
+      }
+    })
+
+    render(
+      <EditViewComplianceReport
+        reportData={mocks.reportData}
+        isError={mocks.isError}
+        error={mocks.error}
+      />,
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      // Assessment Recommendation heading should NOT be present
+      expect(
+        screen.queryByText(/assessmentRecommendation/i)
+      ).not.toBeInTheDocument()
+      // Internal Comments section should NOT be present
+      expect(screen.queryByText(/internalComments/i)).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
This PR includes the following:
- Updated frontend logic to conditionally hide the "Assessment Recommendation" section for BCeID users.
- Added frontend tests to verify visibility behavior for IDIR and BCeID users.

Closes #2701