### PR TITLE
Fix: Ensure correct column ordering in Compare mode - 2629

### DIFF
--- a/frontend/src/views/CompareReports/CompareReports.jsx
+++ b/frontend/src/views/CompareReports/CompareReports.jsx
@@ -47,12 +47,13 @@ export const CompareReports = () => {
       setReportChain(chain)
 
       // Set default selections to the two most recent reports
+      // with the oldest on the left (report1) and newest on the right (report2)
       if (chain.length >= 2) {
         const sortedChain = [...chain].sort(
           (a, b) => new Date(b.timestamp) - new Date(a.timestamp)
         )
-        setReport1ID(sortedChain[0].complianceReportId)
-        setReport2ID(sortedChain[1].complianceReportId)
+        setReport1ID(sortedChain[1].complianceReportId)
+        setReport2ID(sortedChain[0].complianceReportId)
       }
 
       setIsLoading(false)

--- a/frontend/src/views/CompareReports/__tests__/CompareReports.test.jsx
+++ b/frontend/src/views/CompareReports/__tests__/CompareReports.test.jsx
@@ -150,15 +150,36 @@ describe('CompareReports Component', () => {
     })
   })
 
-  it('initializes with default report selections', () => {
+  it('initializes with default report selections in correct order', () => {
     render(<CompareReports />, { wrapper })
 
     const report1Select = screen.getAllByRole('combobox')[0]
     const report2Select = screen.getAllByRole('combobox')[1]
 
-    // Since the component sorts by timestamp and selects the two most recent reports
+    // Earliest report should be on the left (report1), most recent on the right (report2)
+    expect(report1Select).toHaveTextContent('Supplemental Report 1')
+    expect(report2Select).toHaveTextContent('Government Adjustment 2')
+  })
+
+  it('ensures column ordering follows chronological order (earliest left, latest right)', () => {
+    render(<CompareReports />, { wrapper })
+
+    const report1Select = screen.getAllByRole('combobox')[0]
+    const report2Select = screen.getAllByRole('combobox')[1]
+
+    expect(report1Select).toHaveTextContent('Supplemental Report 1')
+    expect(report2Select).toHaveTextContent('Government Adjustment 2')
+
+    fireEvent.mouseDown(report1Select)
+    fireEvent.click(
+      screen.getByRole('option', { name: 'Government Adjustment 2' })
+    )
+
+    fireEvent.mouseDown(report2Select)
+    fireEvent.click(screen.getByRole('option', { name: 'Original Report' }))
+
     expect(report1Select).toHaveTextContent('Government Adjustment 2')
-    expect(report2Select).toHaveTextContent('Supplemental Report 1')
+    expect(report2Select).toHaveTextContent('Original Report')
   })
 
   it('allows selecting different reports', async () => {
@@ -173,17 +194,17 @@ describe('CompareReports Component', () => {
 
     // Verify selection was made
     expect(report1Select).toHaveTextContent('Original Report')
-    expect(report2Select).toHaveTextContent('Supplemental Report 1')
+    expect(report2Select).toHaveTextContent('Government Adjustment 2')
 
     // Open second dropdown and select a different option
     fireEvent.mouseDown(report2Select)
     fireEvent.click(
-      screen.getByRole('option', { name: 'Government Adjustment 2' })
+      screen.getByRole('option', { name: 'Supplemental Report 1' })
     )
 
     // Verify both selections
     expect(report1Select).toHaveTextContent('Original Report')
-    expect(report2Select).toHaveTextContent('Government Adjustment 2')
+    expect(report2Select).toHaveTextContent('Supplemental Report 1')
   })
 
   it('should not allow selecting the same report in both dropdowns', async () => {
@@ -192,7 +213,7 @@ describe('CompareReports Component', () => {
     const report1Select = screen.getAllByRole('combobox')[0]
     const report2Select = screen.getAllByRole('combobox')[1]
 
-    // Initially Government Adjustment 2 and Supplemental Report 1 are selected
+    // Initially Supplemental Report 1 (left) and Government Adjustment 2 (right) are selected
 
     // Select Original Report in first dropdown
     fireEvent.mouseDown(report1Select)
@@ -243,7 +264,7 @@ describe('CompareReports Component', () => {
 
     fireEvent.mouseDown(report2Select)
     fireEvent.click(
-      screen.getByRole('option', { name: 'Government Adjustment 2' })
+      screen.getByRole('option', { name: 'Supplemental Report 1' })
     )
 
     // Check if the data rows are rendered correctly after selection

--- a/frontend/src/views/CompareReports/__tests__/CompareReports.test.jsx
+++ b/frontend/src/views/CompareReports/__tests__/CompareReports.test.jsx
@@ -170,13 +170,13 @@ describe('CompareReports Component', () => {
     expect(report1Select).toHaveTextContent('Supplemental Report 1')
     expect(report2Select).toHaveTextContent('Government Adjustment 2')
 
+    fireEvent.mouseDown(report2Select)
+    fireEvent.click(screen.getByRole('option', { name: 'Original Report' }))
+
     fireEvent.mouseDown(report1Select)
     fireEvent.click(
       screen.getByRole('option', { name: 'Government Adjustment 2' })
     )
-
-    fireEvent.mouseDown(report2Select)
-    fireEvent.click(screen.getByRole('option', { name: 'Original Report' }))
 
     expect(report1Select).toHaveTextContent('Government Adjustment 2')
     expect(report2Select).toHaveTextContent('Original Report')


### PR DESCRIPTION
This PR includes the following:
- Fixed the column ordering logic in CompareReports to ensure the earliest report is displayed on the left and the most recent on the right.

Closes #2629