### PR TITLE
Fix: Summary Widget - Exclude Unregistered Orgs from Compliance and Reserve Totals - 1789

### DIFF
--- a/backend/lcfs/web/api/organizations/repo.py
+++ b/backend/lcfs/web/api/organizations/repo.py
@@ -268,6 +268,7 @@ class OrganizationsRepository:
                 "operating_name": org.operating_name,
                 "total_balance": org.total_balance,
                 "reserved_balance": org.reserved_balance,
+                "status": org.org_status,
             }
             for org in organizations
         ]

--- a/backend/lcfs/web/api/organizations/services.py
+++ b/backend/lcfs/web/api/organizations/services.py
@@ -318,6 +318,7 @@ class OrganizationsService:
                 operating_name=org["operating_name"],
                 total_balance=org["total_balance"],
                 reserved_balance=org["reserved_balance"],
+                org_status=org["status"],
             )
             for org in organization_data
         ]

--- a/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
@@ -44,10 +44,15 @@ const OrganizationsSummaryCard = () => {
   }
 
   const setAllOrgSelected = () => {
-    const totalBalance = organizations.reduce((total, org) => {
+    // Only calculate totals from registered organizations
+    const registeredOrgs = organizations.filter(
+      (org) => org.orgStatus?.status === 'Registered'
+    )
+
+    const totalBalance = registeredOrgs.reduce((total, org) => {
       return total + org.totalBalance
     }, 0)
-    const reservedBalance = organizations.reduce((total, org) => {
+    const reservedBalance = registeredOrgs.reduce((total, org) => {
       return total + Math.abs(org.reservedBalance)
     }, 0)
 

--- a/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import OrganizationsSummaryCard from '../OrganizationsSummaryCard'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
@@ -14,8 +13,24 @@ vi.mock('react-i18next', () => ({
 
 describe('OrganizationsSummaryCards', () => {
   const mockOrganizations = [
-    { name: 'Org A', totalBalance: 1000, reservedBalance: 200 },
-    { name: 'Org B', totalBalance: 1500, reservedBalance: 300 }
+    {
+      name: 'Org A',
+      totalBalance: 1000,
+      reservedBalance: 200,
+      orgStatus: { status: 'Registered' }
+    },
+    {
+      name: 'Org B',
+      totalBalance: 1500,
+      reservedBalance: 300,
+      orgStatus: { status: 'Registered' }
+    },
+    {
+      name: 'Org C',
+      totalBalance: 800,
+      reservedBalance: 100,
+      orgStatus: { status: 'Unregistered' }
+    }
   ]
 
   beforeEach(() => {
@@ -37,9 +52,9 @@ describe('OrganizationsSummaryCards', () => {
   it('renders correctly with default values', () => {
     render(<OrganizationsSummaryCard />, { wrapper })
 
-    expect(screen.getByText('2,500')).toBeInTheDocument() // Initial total balance
+    expect(screen.getByText('2,500')).toBeInTheDocument() // Total balance of registered orgs only (1000 + 1500)
     expect(screen.getByText('compliance units')).toBeInTheDocument()
-    expect(screen.getByText('(500 in reserve)')).toBeInTheDocument() // Initial reserved balance
+    expect(screen.getByText('(500 in reserve)')).toBeInTheDocument() // Reserved balance of registered orgs only (200 + 300)
   })
 
   it('displays organization names in the dropdown', () => {
@@ -73,18 +88,22 @@ describe('OrganizationsSummaryCards', () => {
       screen.getByRole('option', { name: 'txn:allOrganizations' })
     ) // Select All organizations
 
-    const totalBalance = mockOrganizations.reduce(
+    // Only registered organizations should be included in totals (Org A + Org B, not Org C)
+    const registeredOrgs = mockOrganizations.filter(
+      (org) => org.orgStatus?.status === 'Registered'
+    )
+    const totalBalance = registeredOrgs.reduce(
       (total, org) => total + org.totalBalance,
       0
     )
-    const totalReserved = mockOrganizations.reduce(
+    const totalReserved = registeredOrgs.reduce(
       (total, org) => total + org.reservedBalance,
       0
     )
 
-    expect(screen.getByText(totalBalance.toLocaleString())).toBeInTheDocument() // Total balance for all organizations
+    expect(screen.getByText(totalBalance.toLocaleString())).toBeInTheDocument() // Total balance for registered organizations only
     expect(
       screen.getByText(`(${totalReserved.toLocaleString()} in reserve)`)
-    ).toBeInTheDocument() // Total reserved balance for all organizations
+    ).toBeInTheDocument() // Total reserved balance for registered organizations only
   })
 })


### PR DESCRIPTION
This PR includes the following updates:

- Fixes a bug where unregistered organizations were incorrectly included in "All organizations" totals
- Updates test cases to ensure only registered orgs contribute to totals in "All organizations"

Closes #1789
