### PR TITLE
Fix: File upload MIME type validation - 2704

### DIFF
--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -2,6 +2,7 @@ from fastapi import HTTPException
 import os
 import uuid
 
+from lcfs.utils.constants import ALLOWED_MIME_TYPES, ALLOWED_FILE_TYPES
 from lcfs.db.models.admin_adjustment.AdminAdjustment import (
     admin_adjustment_document_association,
     AdminAdjustment,
@@ -69,6 +70,13 @@ class DocumentService:
 
         file_id = uuid.uuid4()
         file_key = f"{settings.s3_docs_path}/{parent_type}/{parent_id}/{file_id}"
+
+        # Validate MIME type
+        if file.content_type not in ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"File type '{file.content_type or 'unknown'}' is not allowed. Please upload files of the following types: {ALLOWED_FILE_TYPES}",
+            )
 
         # Scan file size
         file_size = os.fstat(file.file.fileno()).st_size

--- a/backend/lcfs/utils/constants.py
+++ b/backend/lcfs/utils/constants.py
@@ -104,3 +104,17 @@ id_prefix_to_transaction_type_map = {
 FUEL_CATEGORIES = ["Diesel", "Gasoline", "Jet fuel"]
 
 POSTAL_REGEX = r"^[A-Za-z]\d[A-Za-z] \d[A-Za-z]\d$"
+
+
+ALLOWED_MIME_TYPES = [
+    "application/pdf",
+    "image/png",
+    "image/jpeg",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]
+ALLOWED_FILE_TYPES = (
+    "PDF, PNG, JPG/JPEG, Word Documents (.doc/.docx), Excel Spreadsheets (.xls/.xlsx)"
+)

--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -36,7 +36,7 @@
   "downloadExcel": "Download Excel",
   "supplementalCreated": "Supplemental report created successfully.",
   "analystAdjustmentCreated": "Analyst adjustment created successfully.",
-  "clickDrag": "Drag and drop your (PDF, JPG, PNG, MSG, DOC, XLS) file(s) here or click to select the file(s) from your machine to upload.",
+  "clickDrag": "Drag and drop your (PDF, JPG, JPEG, PNG, DOC, DOCX, XLS, XLSX) file(s) here or click to select the file(s) from your machine to upload.",
   "activityLinksList": "Click links to report activities",
   "activitySecondList": "Verification details",
   "activityLists": {

--- a/frontend/src/components/ImportDialog.jsx
+++ b/frontend/src/components/ImportDialog.jsx
@@ -6,7 +6,10 @@ import BCTypography from '@/components/BCTypography'
 import { styled } from '@mui/system'
 import { CloudUpload } from '@mui/icons-material'
 import { useEffect, useRef, useState } from 'react'
-import { MAX_FILE_SIZE_BYTES } from '@/constants/common.js'
+import {
+  MAX_FILE_SIZE_BYTES,
+  SCHEDULE_IMPORT_FILE_TYPES
+} from '@/constants/common'
 import BCAlert from '@/components/BCAlert'
 import BCBox from '@/components/BCBox'
 
@@ -343,6 +346,7 @@ function ImportDialog({
               ref={fileInputRef}
               style={{ display: 'none' }}
               onChange={handleFileChange}
+              accept={SCHEDULE_IMPORT_FILE_TYPES.ACCEPT_STRING}
             />
 
             {/* Render UI based on current dialog state */}

--- a/frontend/src/constants/common.js
+++ b/frontend/src/constants/common.js
@@ -79,5 +79,33 @@ export const FILTER_KEYS = {
 
 export const MAX_FILE_SIZE_BYTES = 52428800 // 50MB
 
+// File upload constants for compliance reports
+export const COMPLIANCE_REPORT_FILE_TYPES = {
+  MIME_TYPES: [
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  ],
+  DESCRIPTION:
+    'PDF, PNG, JPG/JPEG, Word Documents (.doc/.docx), Excel Spreadsheets (.xls/.xlsx)',
+  get ACCEPT_STRING() {
+    return this.MIME_TYPES.join(',')
+  }
+}
+
+// File upload constants for schedule imports
+export const SCHEDULE_IMPORT_FILE_TYPES = {
+  MIME_TYPES: [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  ],
+  get ACCEPT_STRING() {
+    return this.MIME_TYPES.join(',')
+  }
+}
+
 export const FUEL_CATEGORIES = ['Diesel', 'Gasoline', 'Jet fuel']
 export const LEGISLATION_TRANSITION_YEAR = 2024

--- a/frontend/src/utils/fileValidation.js
+++ b/frontend/src/utils/fileValidation.js
@@ -1,0 +1,48 @@
+/**
+ * Validates if a file's MIME type is allowed
+ * @param {File} file - The file to validate
+ * @param {Object} fileTypes - Object containing MIME_TYPES array and DESCRIPTION string
+ * @returns {Object} - { isValid: boolean, errorMessage: string|null }
+ */
+export const validateFileMimeType = (file, fileTypes) => {
+  if (!file) {
+    return { isValid: false, errorMessage: 'No file selected' }
+  }
+
+  const isValid = fileTypes.MIME_TYPES.includes(file.type)
+
+  if (!isValid) {
+    return {
+      isValid: false,
+      errorMessage: `File type "${file.type || 'unknown'}" is not allowed. Please upload files of the following types: ${fileTypes.DESCRIPTION}`
+    }
+  }
+
+  return { isValid: true, errorMessage: null }
+}
+
+/**
+ * Validates multiple aspects of a file including MIME type and size
+ * @param {File} file - The file to validate
+ * @param {number} maxSizeBytes - Maximum allowed file size in bytes
+ * @param {Object} fileTypes - Object containing MIME_TYPES array and DESCRIPTION string
+ * @returns {Object} - { isValid: boolean, errorMessage: string|null }
+ */
+export const validateFile = (file, maxSizeBytes, fileTypes) => {
+  // Check MIME type first
+  const mimeValidation = validateFileMimeType(file, fileTypes)
+  if (!mimeValidation.isValid) {
+    return mimeValidation
+  }
+
+  // Check file size
+  if (file.size > maxSizeBytes) {
+    const maxSizeMB = Math.round(maxSizeBytes / 1024 / 1024)
+    return {
+      isValid: false,
+      errorMessage: `File size exceeds the maximum limit of ${maxSizeMB} MB`
+    }
+  }
+
+  return { isValid: true, errorMessage: null }
+}


### PR DESCRIPTION
This PR includes the following:

- Enforced frontend and backend MIME type validation for compliance report file uploads
- Applied the same validation logic to the schedule upload
- Fixed a bug where uploaded date appeared as 'Invalid Date' during compliance report upload

Closes #2704
