### PR TITLE
feat: Show all organizations in Organizations Summary Card menu - 1789

### DIFF
--- a/backend/lcfs/tests/organizations/test_organizations_service.py
+++ b/backend/lcfs/tests/organizations/test_organizations_service.py
@@ -2,15 +2,6 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from lcfs.web.api.organizations.services import OrganizationsService
 from lcfs.web.api.organizations.schema import OrganizationSummaryResponseSchema
-from lcfs.db.models.organization.OrganizationStatus import OrganizationStatus, OrgStatusEnum
-
-
-def create_mock_org_status(status_enum: OrgStatusEnum):
-    mock_status = MagicMock(spec=OrganizationStatus)
-    mock_status.organization_status_id = 1
-    mock_status.status = status_enum
-    mock_status.description = f"{status_enum.value} status"
-    return mock_status
 
 
 @pytest.fixture
@@ -49,7 +40,6 @@ async def test_get_organization_names_with_statuses(organizations_service, mock_
             "operating_name": "Test Operating 1",
             "total_balance": 1000,
             "reserved_balance": 100,
-            "status": create_mock_org_status(OrgStatusEnum.Registered),
         },
         {
             "organization_id": 2,
@@ -57,7 +47,6 @@ async def test_get_organization_names_with_statuses(organizations_service, mock_
             "operating_name": "Test Operating 2",
             "total_balance": 2000,
             "reserved_balance": 200,
-            "status": create_mock_org_status(OrgStatusEnum.Unregistered),
         },
     ]
 
@@ -102,7 +91,6 @@ async def test_get_organization_names_registered_status(
             "operating_name": "Registered Operating",
             "total_balance": 1000,
             "reserved_balance": 100,
-            "status": create_mock_org_status(OrgStatusEnum.Registered),
         }
     ]
 
@@ -139,7 +127,6 @@ async def test_get_organization_names_no_statuses_filter(
             "operating_name": "Any Operating",
             "total_balance": 1000,
             "reserved_balance": 100,
-            "status": create_mock_org_status(OrgStatusEnum.Registered),
         }
     ]
 

--- a/backend/lcfs/tests/organizations/test_organizations_service.py
+++ b/backend/lcfs/tests/organizations/test_organizations_service.py
@@ -2,6 +2,18 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from lcfs.web.api.organizations.services import OrganizationsService
 from lcfs.web.api.organizations.schema import OrganizationSummaryResponseSchema
+from lcfs.db.models.organization.OrganizationStatus import (
+    OrganizationStatus,
+    OrgStatusEnum,
+)
+
+
+def create_mock_org_status(status_enum: OrgStatusEnum):
+    mock_status = MagicMock(spec=OrganizationStatus)
+    mock_status.organization_status_id = 1
+    mock_status.status = status_enum
+    mock_status.description = f"{status_enum.value} status"
+    return mock_status
 
 
 @pytest.fixture
@@ -40,6 +52,7 @@ async def test_get_organization_names_with_statuses(organizations_service, mock_
             "operating_name": "Test Operating 1",
             "total_balance": 1000,
             "reserved_balance": 100,
+            "status": create_mock_org_status(OrgStatusEnum.Registered),
         },
         {
             "organization_id": 2,
@@ -47,6 +60,7 @@ async def test_get_organization_names_with_statuses(organizations_service, mock_
             "operating_name": "Test Operating 2",
             "total_balance": 2000,
             "reserved_balance": 200,
+            "status": create_mock_org_status(OrgStatusEnum.Unregistered),
         },
     ]
 
@@ -91,6 +105,7 @@ async def test_get_organization_names_registered_status(
             "operating_name": "Registered Operating",
             "total_balance": 1000,
             "reserved_balance": 100,
+            "status": create_mock_org_status(OrgStatusEnum.Registered),
         }
     ]
 
@@ -127,6 +142,7 @@ async def test_get_organization_names_no_statuses_filter(
             "operating_name": "Any Operating",
             "total_balance": 1000,
             "reserved_balance": 100,
+            "status": create_mock_org_status(OrgStatusEnum.Registered),
         }
     ]
 

--- a/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/OrganizationsSummaryCard.jsx
@@ -7,10 +7,7 @@ import { numberFormatter } from '@/utils/formatters.js'
 import { useTranslation } from 'react-i18next'
 
 const OrganizationsSummaryCard = () => {
-  const { data: organizations, isLoading } = useOrganizationNames([
-    'Registered',
-    'Unregistered'
-  ])
+  const { data: organizations, isLoading } = useOrganizationNames()
   const { t } = useTranslation(['common', 'transaction'])
 
   const [formattedOrgs, setFormattedOrgs] = useState([])
@@ -44,15 +41,10 @@ const OrganizationsSummaryCard = () => {
   }
 
   const setAllOrgSelected = () => {
-    // Only calculate totals from registered organizations
-    const registeredOrgs = organizations.filter(
-      (org) => org.orgStatus?.status === 'Registered'
-    )
-
-    const totalBalance = registeredOrgs.reduce((total, org) => {
+    const totalBalance = organizations.reduce((total, org) => {
       return total + org.totalBalance
     }, 0)
-    const reservedBalance = registeredOrgs.reduce((total, org) => {
+    const reservedBalance = organizations.reduce((total, org) => {
       return total + Math.abs(org.reservedBalance)
     }, 0)
 

--- a/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/__tests__/OrganizationsSummaryCard.test.jsx
@@ -13,24 +13,8 @@ vi.mock('react-i18next', () => ({
 
 describe('OrganizationsSummaryCards', () => {
   const mockOrganizations = [
-    {
-      name: 'Org A',
-      totalBalance: 1000,
-      reservedBalance: 200,
-      orgStatus: { status: 'Registered' }
-    },
-    {
-      name: 'Org B',
-      totalBalance: 1500,
-      reservedBalance: 300,
-      orgStatus: { status: 'Registered' }
-    },
-    {
-      name: 'Org C',
-      totalBalance: 800,
-      reservedBalance: 100,
-      orgStatus: { status: 'Unregistered' }
-    }
+    { name: 'Org A', totalBalance: 1000, reservedBalance: 200 },
+    { name: 'Org B', totalBalance: 1500, reservedBalance: 300 }
   ]
 
   beforeEach(() => {
@@ -40,21 +24,18 @@ describe('OrganizationsSummaryCards', () => {
     })
   })
 
-  it('calls useOrganizationNames with correct statuses for dashboard', () => {
+  it('calls useOrganizationNames to fetch all organizations', () => {
     render(<OrganizationsSummaryCard />, { wrapper })
 
-    expect(useOrganizationNames).toHaveBeenCalledWith([
-      'Registered',
-      'Unregistered'
-    ])
+    expect(useOrganizationNames).toHaveBeenCalledWith()
   })
 
   it('renders correctly with default values', () => {
     render(<OrganizationsSummaryCard />, { wrapper })
 
-    expect(screen.getByText('2,500')).toBeInTheDocument() // Total balance of registered orgs only (1000 + 1500)
+    expect(screen.getByText('2,500')).toBeInTheDocument() // Initial total balance
     expect(screen.getByText('compliance units')).toBeInTheDocument()
-    expect(screen.getByText('(500 in reserve)')).toBeInTheDocument() // Reserved balance of registered orgs only (200 + 300)
+    expect(screen.getByText('(500 in reserve)')).toBeInTheDocument() // Initial reserved balance
   })
 
   it('displays organization names in the dropdown', () => {
@@ -88,22 +69,18 @@ describe('OrganizationsSummaryCards', () => {
       screen.getByRole('option', { name: 'txn:allOrganizations' })
     ) // Select All organizations
 
-    // Only registered organizations should be included in totals (Org A + Org B, not Org C)
-    const registeredOrgs = mockOrganizations.filter(
-      (org) => org.orgStatus?.status === 'Registered'
-    )
-    const totalBalance = registeredOrgs.reduce(
+    const totalBalance = mockOrganizations.reduce(
       (total, org) => total + org.totalBalance,
       0
     )
-    const totalReserved = registeredOrgs.reduce(
+    const totalReserved = mockOrganizations.reduce(
       (total, org) => total + org.reservedBalance,
       0
     )
 
-    expect(screen.getByText(totalBalance.toLocaleString())).toBeInTheDocument() // Total balance for registered organizations only
+    expect(screen.getByText(totalBalance.toLocaleString())).toBeInTheDocument() // Total balance for all organizations
     expect(
       screen.getByText(`(${totalReserved.toLocaleString()} in reserve)`)
-    ).toBeInTheDocument() // Total reserved balance for registered organizations only
+    ).toBeInTheDocument() // Total reserved balance for all organizations
   })
 })


### PR DESCRIPTION
This PR includes the following:
- Updated Organizations Summary Card to fetch and display all organizations without filtering by status.
- Removed unnecessary filtering logic for organization statuses in the backend tests.

Closes #1789