### PR TITLE
Feat: Update Organization View Table on IDIR Side - 2676

### DIFF
--- a/frontend/src/assets/locales/en/organization.json
+++ b/frontend/src/assets/locales/en/organization.json
@@ -5,7 +5,8 @@
     "orgName": "Organization name",
     "complianceUnits": "Compliance units",
     "inReserve": "In reserve",
-    "status": "Status"
+    "status": "Status",
+    "earlyIssuance": "Early Issuance"
   },
   "orgId": "Organization ID",
   "noOrgsFound": "No organizations found",

--- a/frontend/src/utils/__tests__/cellRenderers.test.jsx
+++ b/frontend/src/utils/__tests__/cellRenderers.test.jsx
@@ -1,1 +1,65 @@
-describe.todo()
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { YesNoTextRenderer } from '../grid/cellRenderers'
+
+describe('YesNoTextRenderer', () => {
+  it('renders "Yes" when value is true', () => {
+    const props = {
+      value: true
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('renders "No" when value is false', () => {
+    const props = {
+      value: false
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+
+  it('renders "No" when value is undefined', () => {
+    const props = {
+      value: undefined
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+
+  it('renders "No" when value is null', () => {
+    const props = {
+      value: null
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+
+  it('renders "Yes" when value is truthy', () => {
+    const props = {
+      value: 1
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('renders "No" when value is falsy', () => {
+    const props = {
+      value: 0
+    }
+
+    render(<YesNoTextRenderer {...props} />)
+
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/utils/grid/cellRenderers.jsx
+++ b/frontend/src/utils/grid/cellRenderers.jsx
@@ -206,6 +206,13 @@ export const OrgStatusRenderer = (props) => {
     </Link>
   )
 }
+
+export const YesNoTextRenderer = (props) => (
+  <BCBox component="div" sx={{ width: '100%', height: '100%' }}>
+    {props.value ? 'Yes' : 'No'}
+  </BCBox>
+)
+
 export const FuelCodeStatusRenderer = (props) => {
   const location = useLocation()
   const statusArr = getAllFuelCodeStatuses()

--- a/frontend/src/views/Organizations/OrganizationView/__tests__/_schema.test.js
+++ b/frontend/src/views/Organizations/OrganizationView/__tests__/_schema.test.js
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
-import { organizationsColDefs, getUserColumnDefs, defaultSortModel } from '../_schema'
-import { LinkRenderer, OrgStatusRenderer } from '@/utils/grid/cellRenderers'
+import {
+  organizationsColDefs,
+  getUserColumnDefs,
+  defaultSortModel
+} from '../_schema'
+import {
+  LinkRenderer,
+  OrgStatusRenderer,
+  YesNoTextRenderer
+} from '@/utils/grid/cellRenderers'
 import { numberFormatter } from '@/utils/formatters'
 
 // Mock dependencies
@@ -11,65 +19,111 @@ vi.mock('@/hooks/useOrganizations', () => ({
 vi.mock('@/views/Admin/AdminMenu/components/_schema', () => ({
   usersColumnDefs: () => [
     {
-        field: 'isActive',
-        sortable: true,
-        headerName: 'Status',
-        width: 120
-      },
-      {
-        field: 'role',
-        headerName: 'Role',
-        floatingFilterComponentParams: {
-          params: '',
-          key: ''
-        }
-      },
-      {
-        field: 'someOtherField',
-        headerName: 'Other Field'
+      field: 'isActive',
+      sortable: true,
+      headerName: 'Status',
+      width: 120
+    },
+    {
+      field: 'role',
+      headerName: 'Role',
+      floatingFilterComponentParams: {
+        params: '',
+        key: ''
       }
+    },
+    {
+      field: 'someOtherField',
+      headerName: 'Other Field'
+    }
   ]
 }))
 
 describe('ViewOrganization Schema', () => {
   // Test organizations column definitions
   describe('organizationsColDefs', () => {
-    const t = vi.fn(key => key)
+    const t = vi.fn((key) => key)
     const colDefs = organizationsColDefs(t)
 
     it('defines the correct number of columns', () => {
-      expect(colDefs).toHaveLength(4)
+      expect(colDefs).toHaveLength(5)
+    })
+
+    it('defines the status column as the first column', () => {
+      const statusCol = colDefs[0]
+      expect(statusCol.colId).toBe('status')
+      expect(statusCol.field).toBe('status')
+      expect(statusCol.headerName).toBe('org:orgColLabels.status')
+      expect(statusCol.cellRenderer).toBe(OrgStatusRenderer)
+      expect(statusCol.filter).toBe(true)
+      expect(statusCol.suppressFloatingFilterButton).toBe(true)
     })
 
     it('defines the organization name column correctly', () => {
-      const nameCol = colDefs.find(col => col.colId === 'name')
+      const nameCol = colDefs.find((col) => col.colId === 'name')
       expect(nameCol).toBeDefined()
       expect(nameCol.field).toBe('name')
       expect(nameCol.headerName).toBe('org:orgColLabels.orgName')
       expect(nameCol.cellRenderer).toBe(LinkRenderer)
     })
 
+    it('defines the early issuance column correctly', () => {
+      const earlyIssuanceCol = colDefs.find(
+        (col) => col.colId === 'hasEarlyIssuance'
+      )
+      expect(earlyIssuanceCol).toBeDefined()
+      expect(earlyIssuanceCol.field).toBe('hasEarlyIssuance')
+      expect(earlyIssuanceCol.headerName).toBe('org:orgColLabels.earlyIssuance')
+      expect(earlyIssuanceCol.cellRenderer).toBe(YesNoTextRenderer)
+      expect(earlyIssuanceCol.filter).toBe(true)
+      expect(earlyIssuanceCol.sortable).toBe(true)
+      expect(earlyIssuanceCol.suppressFloatingFilterButton).toBe(true)
+    })
+
+    it('calculates early issuance value correctly in valueGetter', () => {
+      const earlyIssuanceCol = colDefs.find(
+        (col) => col.colId === 'hasEarlyIssuance'
+      )
+      const mockParams = { data: { hasEarlyIssuance: true } }
+      expect(earlyIssuanceCol.valueGetter(mockParams)).toBe(true)
+    })
+
+    it('defines early issuance filter options correctly', () => {
+      const earlyIssuanceCol = colDefs.find(
+        (col) => col.colId === 'hasEarlyIssuance'
+      )
+      const filterParams = earlyIssuanceCol.floatingFilterComponentParams
+      expect(filterParams.valueKey).toBe('value')
+      expect(filterParams.labelKey).toBe('label')
+
+      const options = filterParams.optionsQuery()
+      expect(options.data).toHaveLength(2)
+      expect(options.data[0]).toEqual({ value: true, label: 'Yes' })
+      expect(options.data[1]).toEqual({ value: false, label: 'No' })
+      expect(options.isLoading).toBe(false)
+    })
+
     it('defines the compliance units column correctly', () => {
-      const cuCol = colDefs.find(col => col.colId === 'complianceUnits')
+      const cuCol = colDefs.find((col) => col.colId === 'complianceUnits')
       expect(cuCol).toBeDefined()
       expect(cuCol.valueFormatter).toBe(numberFormatter)
       expect(cuCol.filter).toBe(false)
     })
 
     it('calculates total balance correctly in valueGetter', () => {
-      const cuCol = colDefs.find(col => col.colId === 'complianceUnits')
+      const cuCol = colDefs.find((col) => col.colId === 'complianceUnits')
       const mockParams = { data: { totalBalance: 150 } }
       expect(cuCol.valueGetter(mockParams)).toBe(150)
     })
 
     it('calculates reserve balance correctly in valueGetter', () => {
-      const reserveCol = colDefs.find(col => col.colId === 'reserve')
+      const reserveCol = colDefs.find((col) => col.colId === 'reserve')
       const mockParams = { data: { reservedBalance: -75 } }
       expect(reserveCol.valueGetter(mockParams)).toBe(75) // Should return absolute value
     })
 
     it('defines the status column with correct renderer and filter', () => {
-      const statusCol = colDefs.find(col => col.colId === 'status')
+      const statusCol = colDefs.find((col) => col.colId === 'status')
       expect(statusCol).toBeDefined()
       expect(statusCol.cellRenderer).toBe(OrgStatusRenderer)
       expect(statusCol.filter).toBe(true)
@@ -79,24 +133,28 @@ describe('ViewOrganization Schema', () => {
 
   // Test user column definitions
   describe('getUserColumnDefs', () => {
-    const t = vi.fn(key => key)
+    const t = vi.fn((key) => key)
     const userColDefs = getUserColumnDefs(t)
 
     it('modifies isActive column to be non-sortable', () => {
-      const isActiveCol = userColDefs.find(col => col.field === 'isActive')
+      const isActiveCol = userColDefs.find((col) => col.field === 'isActive')
       expect(isActiveCol).toBeDefined()
       expect(isActiveCol.sortable).toBe(false)
     })
 
     it('configures role column with correct filter parameters', () => {
-      const roleCol = userColDefs.find(col => col.field === 'role')
+      const roleCol = userColDefs.find((col) => col.field === 'role')
       expect(roleCol).toBeDefined()
-      expect(roleCol.floatingFilterComponentParams.params).toBe('government_roles_only=false')
-      expect(roleCol.floatingFilterComponentParams.key).toBe('organization-users')
+      expect(roleCol.floatingFilterComponentParams.params).toBe(
+        'government_roles_only=false'
+      )
+      expect(roleCol.floatingFilterComponentParams.key).toBe(
+        'organization-users'
+      )
     })
 
     it('preserves other columns without modification', () => {
-      const otherCol = userColDefs.find(col => col.field === 'someOtherField')
+      const otherCol = userColDefs.find((col) => col.field === 'someOtherField')
       expect(otherCol).toBeDefined()
       // Verify the column is unchanged from original definition
     })

--- a/frontend/src/views/Organizations/OrganizationView/_schema.js
+++ b/frontend/src/views/Organizations/OrganizationView/_schema.js
@@ -1,10 +1,31 @@
 import { numberFormatter } from '@/utils/formatters'
-import { LinkRenderer, OrgStatusRenderer } from '@/utils/grid/cellRenderers'
+import {
+  LinkRenderer,
+  OrgStatusRenderer,
+  YesNoTextRenderer
+} from '@/utils/grid/cellRenderers'
 import { BCSelectFloatingFilter } from '@/components/BCDataGrid/components'
 import { useOrganizationStatuses } from '@/hooks/useOrganizations'
 import { usersColumnDefs } from '@/views/Admin/AdminMenu/components/_schema'
 
 export const organizationsColDefs = (t) => [
+  {
+    colId: 'status',
+    field: 'status',
+    headerName: t('org:orgColLabels.status'),
+    width: 300,
+    valueGetter: (params) => params.data.orgStatus.status,
+    cellRenderer: OrgStatusRenderer,
+    cellClass: 'vertical-middle',
+    filter: true,
+    floatingFilterComponent: BCSelectFloatingFilter,
+    floatingFilterComponentParams: {
+      valueKey: 'status',
+      labelKey: 'status',
+      optionsQuery: useOrganizationStatuses
+    },
+    suppressFloatingFilterButton: true
+  },
   {
     colId: 'name',
     field: 'name',
@@ -12,6 +33,35 @@ export const organizationsColDefs = (t) => [
     cellRenderer: LinkRenderer,
     minWidth: 400,
     flex: 1
+  },
+  {
+    colId: 'hasEarlyIssuance',
+    field: 'hasEarlyIssuance',
+    headerName: t('org:orgColLabels.earlyIssuance'),
+    width: 200,
+    valueGetter: (params) => params.data.hasEarlyIssuance,
+    cellRenderer: YesNoTextRenderer,
+    cellClass: 'vertical-middle',
+    filter: true,
+    sortable: true,
+    filterParams: {
+      textMatcher: () => {
+        return true
+      }
+    },
+    floatingFilterComponent: BCSelectFloatingFilter,
+    floatingFilterComponentParams: {
+      valueKey: 'value',
+      labelKey: 'label',
+      optionsQuery: () => ({
+        data: [
+          { value: true, label: 'Yes' },
+          { value: false, label: 'No' }
+        ],
+        isLoading: false
+      })
+    },
+    suppressFloatingFilterButton: true
   },
   {
     colId: 'complianceUnits',
@@ -34,23 +84,6 @@ export const organizationsColDefs = (t) => [
     cellRenderer: LinkRenderer,
     filter: false,
     sortable: false
-  },
-  {
-    colId: 'status',
-    field: 'status',
-    headerName: t('org:orgColLabels.status'),
-    width: 300,
-    valueGetter: (params) => params.data.orgStatus.status,
-    cellRenderer: OrgStatusRenderer,
-    cellClass: 'vertical-middle',
-    filter: true,
-    floatingFilterComponent: BCSelectFloatingFilter,
-    floatingFilterComponentParams: {
-      valueKey: 'status',
-      labelKey: 'status',
-      optionsQuery: useOrganizationStatuses
-    },
-    suppressFloatingFilterButton: true
   }
 ]
 


### PR DESCRIPTION
This PR includes the following updates to the Organization view table on the IDIR side:

- Moved the "Status" column to the first position (far left)
- Added a new "Early Issuance" column displaying either "Yes" or "No", with filter and sort functionality

Closes #2676
