### PR TITLE
Feat: Transaction view status column refinement - 2624

### DIFF
--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -9,6 +9,40 @@ import { useGetComplianceReportStatuses } from '@/hooks/useComplianceReports'
 
 export const reportsColDefs = (t, isSupplier) => [
   {
+    field: 'status',
+    headerName: t('report:reportColLabels.status'),
+    width: 300,
+    valueGetter: ({ data }) => data.reportStatus || '',
+    filterParams: {
+      textFormatter: (value) => value.replace(/\s+/g, '_').toLowerCase(),
+      textCustomComparator: (filter, value, filterText) => {
+        // Split the filter text by comma and trim each value
+        const filterValues = filterText
+          .split(',')
+          .map((text) => text.trim().replace(/\s+/g, '_').toLowerCase())
+
+        const cleanValue = value.replace(/[\s]+/g, '_').toLowerCase()
+
+        // Return true if the value matches any of the filter values
+        return filterValues.some((filterValue) =>
+          cleanValue.includes(filterValue)
+        )
+      },
+      buttons: ['clear']
+    },
+    cellRenderer: ReportsStatusRenderer,
+    cellRendererParams: {
+      url: ({ data }) => `${data.compliancePeriod}/${data.complianceReportId}`
+    },
+    floatingFilterComponent: BCSelectFloatingFilter,
+    floatingFilterComponentParams: {
+      optionsQuery: useGetComplianceReportStatuses,
+      valueKey: 'status',
+      labelKey: 'status'
+    },
+    suppressFloatingFilterButton: true
+  },
+  {
     field: 'compliancePeriod',
     headerName: t('report:reportColLabels.compliancePeriod'),
     width: 210,
@@ -51,40 +85,6 @@ export const reportsColDefs = (t, isSupplier) => [
       valueKey: 'name',
       labelKey: 'name'
     }
-  },
-  {
-    field: 'status',
-    headerName: t('report:reportColLabels.status'),
-    width: 300,
-    valueGetter: ({ data }) => data.reportStatus || '',
-    filterParams: {
-      textFormatter: (value) => value.replace(/\s+/g, '_').toLowerCase(),
-      textCustomComparator: (filter, value, filterText) => {
-        // Split the filter text by comma and trim each value
-        const filterValues = filterText
-          .split(',')
-          .map((text) => text.trim().replace(/\s+/g, '_').toLowerCase())
-
-        const cleanValue = value.replace(/[\s]+/g, '_').toLowerCase()
-
-        // Return true if the value matches any of the filter values
-        return filterValues.some((filterValue) =>
-          cleanValue.includes(filterValue)
-        )
-      },
-      buttons: ['clear']
-    },
-    cellRenderer: ReportsStatusRenderer,
-    cellRendererParams: {
-      url: ({ data }) => `${data.compliancePeriod}/${data.complianceReportId}`
-    },
-    floatingFilterComponent: BCSelectFloatingFilter,
-    floatingFilterComponentParams: {
-      optionsQuery: useGetComplianceReportStatuses,
-      valueKey: 'status',
-      labelKey: 'status'
-    },
-    suppressFloatingFilterButton: true
   },
   {
     field: 'updateDate',

--- a/frontend/src/views/Transactions/_schema.js
+++ b/frontend/src/views/Transactions/_schema.js
@@ -20,10 +20,42 @@ const prefixMap = {
 
 export const transactionsColDefs = (t) => [
   {
+    colId: 'status',
+    field: 'status',
+    headerName: t('txn:txnColLabels.status'),
+    cellRenderer: TransactionStatusRenderer,
+    cellClass: 'vertical-middle',
+    floatingFilterComponent: BCSelectFloatingFilter,
+    floatingFilterComponentParams: {
+      valueKey: 'status',
+      labelKey: 'status',
+      optionsQuery: useTransactionStatuses
+    },
+    filterParams: {
+      textFormatter: (value) => value.toLowerCase(),
+      textCustomComparator: (filter, value, filterText) => {
+        // Split the filter text by comma and trim each value
+        const filterValues = filterText
+          .split(',')
+          .map((text) => text.trim().toLowerCase())
+
+        const cleanValue = value.toLowerCase()
+
+        // Return true if the value matches any of the filter values
+        return filterValues.some((filterValue) =>
+          cleanValue.includes(filterValue)
+        )
+      },
+      buttons: ['clear']
+    },
+    suppressFloatingFilterButton: true,
+    minWidth: 150
+  },
+  {
     colId: 'transactionId',
     field: 'transactionId',
     headerName: t('txn:txnColLabels.txnId'),
-    width: 175,
+    width: 130,
     valueGetter: (params) => {
       const transactionType = params.data.transactionType
       const prefix = prefixMap[transactionType] || ''
@@ -43,7 +75,7 @@ export const transactionsColDefs = (t) => [
     colId: 'compliancePeriod',
     field: 'compliancePeriod',
     headerName: t('txn:txnColLabels.compliancePeriod'),
-    minWidth: 190,
+    width: 130,
     valueGetter: (params) => {
       return params.data?.compliancePeriod || 'N/A'
     },
@@ -145,39 +177,6 @@ export const transactionsColDefs = (t) => [
       filterOptions: ['startsWith'],
       buttons: ['clear']
     }
-  },
-  {
-    colId: 'status',
-    field: 'status',
-    headerName: t('txn:txnColLabels.status'),
-    cellRenderer: TransactionStatusRenderer,
-    cellClass: 'vertical-middle',
-    floatingFilterComponent: BCSelectFloatingFilter,
-    floatingFilterComponentParams: {
-      valueKey: 'status',
-      labelKey: 'status',
-      optionsQuery: useTransactionStatuses
-    },
-    filterParams: {
-      textFormatter: (value) => value.toLowerCase(),
-      textCustomComparator: (filter, value, filterText) => {
-        // Split the filter text by comma and trim each value
-        const filterValues = filterText
-          .split(',')
-          .map((text) => text.trim().toLowerCase())
-
-        const cleanValue = value.toLowerCase()
-
-        // Return true if the value matches any of the filter values
-        return filterValues.some((filterValue) =>
-          cleanValue.includes(filterValue)
-        )
-      },
-      buttons: ['clear']
-    },
-    suppressFloatingFilterButton: true,
-    minWidth: 180,
-    width: 250
   },
   {
     colId: 'updateDate',


### PR DESCRIPTION
This PR includes the following changes to improve usability of the Transactions table:

- Moved the "Status" column to the far left to make it immediately visible.
- Reduced width of "ID" and "Year" columns to optimize table layout.
- Moved the "Status" column to the far left in the Compliance Report list.

Closes #2624
