### PR TITLE
Fix: Correct Clear Filter Sorting Behavior - 2709

### DIFF
--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -172,7 +172,15 @@ class TransactionRepository:
         # Apply sorting
         for order in sort_orders:
             direction = asc if order.direction == "asc" else desc
-            query = query.order_by(direction(getattr(TransactionView, order.field)))
+
+            # Special handling for transaction_id sorting to sort by type first, then by id
+            if order.field == "transaction_id":
+                query = query.order_by(
+                    direction(TransactionView.transaction_type),
+                    direction(TransactionView.transaction_id),
+                )
+            else:
+                query = query.order_by(direction(getattr(TransactionView, order.field)))
 
         # Execute count query for total records matching the filter
         count_query = select(func.count(TransactionView.transaction_id)).where(

--- a/frontend/src/views/Admin/AdminMenu/components/AuditLog.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/AuditLog.jsx
@@ -9,6 +9,13 @@ import { defaultInitialPagination } from '@/constants/schedules.js'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer.jsx'
 import { useAuditLogs } from '@/hooks/useAuditLog.js'
 
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultAuditLogSortModel,
+  filters: []
+}
+
 export const AuditLog = () => {
   const { t } = useTranslation(['common', 'admin'])
   const gridRef = useRef()
@@ -24,7 +31,7 @@ export const AuditLog = () => {
   }, [])
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
 
   const queryData = useAuditLogs(paginationOptions, {
@@ -43,7 +50,7 @@ export const AuditLog = () => {
   )
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()
     }

--- a/frontend/src/views/Admin/AdminMenu/components/UserActivity.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/UserActivity.jsx
@@ -2,7 +2,10 @@ import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
 import { useTranslation } from 'react-i18next'
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { userActivityColDefs } from '@/views/Admin/AdminMenu/components/_schema'
+import {
+  userActivityColDefs,
+  defaultSortModel
+} from '@/views/Admin/AdminMenu/components/_schema'
 import { ClearFiltersButton } from '@/components/ClearFiltersButton'
 import { useGetUserActivities } from '@/hooks/useUser'
 import { LinkRenderer } from '@/utils/grid/cellRenderers.jsx'
@@ -10,12 +13,19 @@ import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer.jsx'
 import { defaultInitialPagination } from '@/constants/schedules.js'
 import ROUTES, { buildPath } from '@/routes/routes.js'
 
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultSortModel,
+  filters: []
+}
+
 export const UserActivity = () => {
   const { t } = useTranslation(['common', 'admin'])
   const gridRef = useRef(null)
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
 
   const queryData = useGetUserActivities(paginationOptions, {
@@ -55,7 +65,7 @@ export const UserActivity = () => {
   )
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()
     }

--- a/frontend/src/views/Admin/AdminMenu/components/UserLoginHistory.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/UserLoginHistory.jsx
@@ -2,18 +2,28 @@ import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
 import { useTranslation } from 'react-i18next'
 import { useCallback, useRef, useState } from 'react'
-import { userLoginHistoryColDefs } from '@/views/Admin/AdminMenu/components/_schema'
+import {
+  userLoginHistoryColDefs,
+  defaultSortModel
+} from '@/views/Admin/AdminMenu/components/_schema'
 import { ClearFiltersButton } from '@/components/ClearFiltersButton'
 import { useGetUserLoginHistory } from '@/hooks/useUser'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer.jsx'
 import { defaultInitialPagination } from '@/constants/schedules.js'
+
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultSortModel,
+  filters: []
+}
 
 export const UserLoginHistory = () => {
   const { t } = useTranslation(['common', 'admin'])
   const gridRef = useRef(null)
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
   const queryData = useGetUserLoginHistory(paginationOptions, {
     cacheTime: 0,
@@ -25,7 +35,7 @@ export const UserLoginHistory = () => {
   }, [])
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()
     }

--- a/frontend/src/views/Admin/AdminMenu/components/__tests__/UserActivity.test.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/__tests__/UserActivity.test.jsx
@@ -20,12 +20,19 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
-vi.mock('@/views/Admin/AdminMenu/components/_schema', () => ({
-  userActivityColDefs: [
-    { headerName: 'Column 1', field: 'col1' },
-    { headerName: 'Column 2', field: 'col2' }
-  ]
-}))
+vi.mock(
+  '@/views/Admin/AdminMenu/components/_schema',
+  async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+      ...actual,
+      userActivityColDefs: [
+        { headerName: 'Column 1', field: 'col1' },
+        { headerName: 'Column 2', field: 'col2' }
+      ]
+    }
+  }
+)
 
 // -- Mock BCGridViewer so we can inspect its props --
 vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({

--- a/frontend/src/views/Admin/AdminMenu/components/__tests__/UserLoginHistory.test.jsx
+++ b/frontend/src/views/Admin/AdminMenu/components/__tests__/UserLoginHistory.test.jsx
@@ -19,11 +19,18 @@ vi.mock('@/hooks/useUser', () => ({
 }))
 
 // Mock constants
-vi.mock('@/views/Admin/AdminMenu/components/_schema', () => ({
-  userLoginHistoryColDefs: (t) => [
-    { headerName: t('headerNameExample'), field: 'exampleField' }
-  ]
-}))
+vi.mock(
+  '@/views/Admin/AdminMenu/components/_schema',
+  async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+      ...actual,
+      userLoginHistoryColDefs: (t) => [
+        { headerName: t('headerNameExample'), field: 'exampleField' }
+      ]
+    }
+  }
+)
 
 // Mock BCGridViewer component
 vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({

--- a/frontend/src/views/ComplianceReports/ComplianceReports.jsx
+++ b/frontend/src/views/ComplianceReports/ComplianceReports.jsx
@@ -13,7 +13,7 @@ import {
   useCreateComplianceReport,
   useGetComplianceReportList
 } from '@/hooks/useComplianceReports'
-import { reportsColDefs } from './components/_schema'
+import { reportsColDefs, defaultSortModel } from './components/_schema'
 import { NewComplianceReportButton } from './components/NewComplianceReportButton'
 import BCTypography from '@/components/BCTypography'
 import { ClearFiltersButton } from '@/components/ClearFiltersButton'
@@ -23,6 +23,13 @@ import { defaultInitialPagination } from '@/constants/schedules.js'
 import BCButton from '@/components/BCButton'
 import { CalculateOutlined } from '@mui/icons-material'
 
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultSortModel,
+  filters: []
+}
+
 export const ComplianceReports = () => {
   const { t } = useTranslation(['common', 'report'])
   const [alertMessage, setAlertMessage] = useState('')
@@ -30,7 +37,7 @@ export const ComplianceReports = () => {
   const [alertSeverity, setAlertSeverity] = useState('info')
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
 
   const gridRef = useRef()
@@ -103,7 +110,7 @@ export const ComplianceReports = () => {
   )
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     sessionStorage.removeItem('compliance-reports-grid-filter')
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -18,7 +18,7 @@ import Grid2 from '@mui/material/Grid2'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { fuelCodeColDefs } from './_schema'
+import { fuelCodeColDefs, defaultSortModel } from './_schema'
 import { defaultInitialPagination } from '@/constants/schedules.js'
 
 const convertToBackendFilters = (model = {}) =>
@@ -31,6 +31,13 @@ const convertToBackendFilters = (model = {}) =>
     dateTo: cfg.dateTo
   }))
 
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultSortModel,
+  filters: []
+}
+
 const FuelCodesBase = () => {
   const gridRef = useRef(null)
 
@@ -41,7 +48,7 @@ const FuelCodesBase = () => {
   const downloadButtonRef = useRef(null)
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
 
   const { t } = useTranslation(['common', 'fuelCodes'])
@@ -101,10 +108,7 @@ const FuelCodesBase = () => {
   }
 
   const handleClearFilters = () => {
-    setPaginationOptions({
-      ...paginationOptions,
-      filters: []
-    })
+    setPaginationOptions(initialPaginationOptions)
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()
     }

--- a/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
+++ b/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
@@ -16,11 +16,12 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key, options) => {
       const translations = {
-        'FuelCodes': 'Fuel codes',
+        FuelCodes: 'Fuel codes',
         'fuelCode:newFuelCodeBtn': 'New fuel code',
         'fuelCode:fuelCodeDownloadBtn': 'Download fuel codes information',
         'fuelCode:fuelCodeDownloadingMsg': 'Downloading fuel codes information',
-        'fuelCode:fuelCodeDownloadFailMsg': 'Failed to download fuel code information',
+        'fuelCode:fuelCodeDownloadFailMsg':
+          'Failed to download fuel code information',
         'fuelCode:noFuelCodesFound': 'No fuel codes found',
         'common:ClearFilters': 'Clear filters'
       }
@@ -56,10 +57,7 @@ vi.mock('react-router-dom', () => ({
   useLocation: () => ({
     state: null
   }),
-  useSearchParams: () => [
-    new URLSearchParams(),
-    vi.fn()
-  ]
+  useSearchParams: () => [new URLSearchParams(), vi.fn()]
 }))
 
 // Mock useFuelCode hooks
@@ -150,7 +148,9 @@ describe('FuelCodes Component Tests', () => {
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
       expect(downloadButton).toBeInTheDocument()
       expect(downloadButton).toBeEnabled()
-      expect(downloadButton).toHaveTextContent('Download fuel codes information')
+      expect(downloadButton).toHaveTextContent(
+        'Download fuel codes information'
+      )
     })
 
     it('renders new fuel code button for analysts', () => {
@@ -172,9 +172,9 @@ describe('FuelCodes Component Tests', () => {
     it('handles download button click with no filters or sorting', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
@@ -182,7 +182,12 @@ describe('FuelCodes Component Tests', () => {
             page: 1,
             size: 10000,
             filters: [],
-            sortOrders: []
+            sortOrders: [
+              {
+                direction: 'desc',
+                field: 'lastUpdated'
+              }
+            ]
           }
         })
       })
@@ -193,9 +198,9 @@ describe('FuelCodes Component Tests', () => {
     it('calls buildExportPayload with correct format when download is triggered', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
@@ -212,9 +217,9 @@ describe('FuelCodes Component Tests', () => {
     it('verifies export payload structure includes both filters and sortOrders properties', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         const callArgs = mockDownloadMutate.mock.calls[0][0]
         expect(callArgs).toHaveProperty('format', 'xlsx')
@@ -228,9 +233,9 @@ describe('FuelCodes Component Tests', () => {
     it('confirms sortOrders property is not hardcoded as empty array', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         const callArgs = mockDownloadMutate.mock.calls[0][0]
         // The sortOrders should come from paginationOptions.sortOrders, not hardcoded []
@@ -243,28 +248,32 @@ describe('FuelCodes Component Tests', () => {
     it('shows loading state during download', async () => {
       // Mock a pending download
       mockDownloadMutate = vi.fn(() => new Promise(() => {})) // Never resolves
-      
+
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Downloading fuel codes information...')
+        expect(downloadButton).toHaveTextContent(
+          'Downloading fuel codes information...'
+        )
         expect(downloadButton).toBeDisabled()
       })
     })
 
     it('resets button state after successful download', async () => {
       mockDownloadMutate = vi.fn().mockResolvedValue(undefined)
-      
+
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Download fuel codes information')
+        expect(downloadButton).toHaveTextContent(
+          'Download fuel codes information'
+        )
         expect(downloadButton).toBeEnabled()
       })
     })
@@ -272,30 +281,38 @@ describe('FuelCodes Component Tests', () => {
 
   describe('Error Handling', () => {
     it('displays error message on download failure', async () => {
-      mockDownloadMutate = vi.fn().mockRejectedValue(new Error('Download failed'))
-      
+      mockDownloadMutate = vi
+        .fn()
+        .mockRejectedValue(new Error('Download failed'))
+
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         const alertBox = screen.getByTestId('alert-box')
         expect(alertBox).toBeInTheDocument()
-        expect(alertBox).toHaveTextContent('Failed to download fuel code information')
+        expect(alertBox).toHaveTextContent(
+          'Failed to download fuel code information'
+        )
       })
     })
 
     it('resets button state after download failure', async () => {
-      mockDownloadMutate = vi.fn().mockRejectedValue(new Error('Download failed'))
-      
+      mockDownloadMutate = vi
+        .fn()
+        .mockRejectedValue(new Error('Download failed'))
+
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Download fuel codes information')
+        expect(downloadButton).toHaveTextContent(
+          'Download fuel codes information'
+        )
         expect(downloadButton).toBeEnabled()
       })
     })
@@ -303,9 +320,9 @@ describe('FuelCodes Component Tests', () => {
     it('handles missing grid reference gracefully', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
@@ -313,7 +330,12 @@ describe('FuelCodes Component Tests', () => {
             page: 1,
             size: 10000,
             filters: [],
-            sortOrders: []
+            sortOrders: [
+              {
+                direction: 'desc',
+                field: 'lastUpdated'
+              }
+            ]
           }
         })
       })
@@ -323,10 +345,12 @@ describe('FuelCodes Component Tests', () => {
   describe('Clear Filters Functionality', () => {
     it('clears filters when clear filters button is clicked', () => {
       render(<FuelCodes />, { wrapper })
-      const clearFiltersButton = screen.getByRole('button', { name: /clear filters/i })
-      
+      const clearFiltersButton = screen.getByRole('button', {
+        name: /clear filters/i
+      })
+
       fireEvent.click(clearFiltersButton)
-      
+
       // The actual clearing logic would be tested through the grid's clearFilters method
       // This tests that the button exists and is clickable
       expect(clearFiltersButton).toBeInTheDocument()
@@ -338,7 +362,7 @@ describe('FuelCodes Component Tests', () => {
   describe('Alert Message Handling', () => {
     it('renders without alert when no location state message', () => {
       render(<FuelCodes />, { wrapper })
-      
+
       // Should not show alert box when there's no message
       const alertBox = screen.queryByTestId('alert-box')
       expect(alertBox).not.toBeInTheDocument()
@@ -351,9 +375,9 @@ describe('FuelCodes Component Tests', () => {
         ...mockGetFuelCodesData,
         isLoading: true
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       // The grid should show loading state
       const gridContainer = screen.getByTestId('bc-grid-container')
       expect(gridContainer).toBeInTheDocument()
@@ -368,9 +392,9 @@ describe('FuelCodes Component Tests', () => {
           response: { status: 500 }
         }
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       const errorMessage = screen.getByText(/Failed to load fuel codes/)
       expect(errorMessage).toBeInTheDocument()
     })
@@ -386,12 +410,12 @@ describe('FuelCodes Component Tests', () => {
           dateTo: '2024-12-31'
         }
       }
-      
+
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
@@ -406,9 +430,9 @@ describe('FuelCodes Component Tests', () => {
     it('verifies export functionality with proper payload structure', async () => {
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
-      
+
       fireEvent.click(downloadButton)
-      
+
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
@@ -436,9 +460,9 @@ describe('FuelCodes Component Tests', () => {
         error: null,
         isError: false
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       const gridContainer = screen.getByTestId('bc-grid-container')
       expect(gridContainer).toBeInTheDocument()
     })
@@ -453,9 +477,9 @@ describe('FuelCodes Component Tests', () => {
         error: null,
         isError: false
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       const gridContainer = screen.getByTestId('bc-grid-container')
       expect(gridContainer).toBeInTheDocument()
     })

--- a/frontend/src/views/FuelCodes/_schema.jsx
+++ b/frontend/src/views/FuelCodes/_schema.jsx
@@ -212,3 +212,5 @@ export const fuelCodeColDefs = (t, status = null) => [
     minWidth: 600
   }
 ]
+
+export const defaultSortModel = [{ field: 'lastUpdated', direction: 'desc' }]

--- a/frontend/src/views/Notifications/NotificationMenu/components/Notifications.jsx
+++ b/frontend/src/views/Notifications/NotificationMenu/components/Notifications.jsx
@@ -7,7 +7,12 @@ import { faSquareCheck } from '@fortawesome/free-solid-svg-icons'
 import BCButton from '@/components/BCButton'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer.jsx'
 import { ClearFiltersButton } from '@/components/ClearFiltersButton'
-import { columnDefs, routesMapping } from './_schema'
+import {
+  columnDefs,
+  routesMapping,
+  defaultColDef,
+  defaultSortModel
+} from './_schema'
 import {
   useDeleteNotificationMessages,
   useGetNotificationMessages,
@@ -15,6 +20,13 @@ import {
 } from '@/hooks/useNotifications'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { defaultInitialPagination } from '@/constants/schedules.js'
+
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: defaultSortModel,
+  filters: []
+}
 
 export const Notifications = () => {
   const gridRef = useRef(null)
@@ -24,7 +36,7 @@ export const Notifications = () => {
   const [selectedRowCount, setSelectedRowCount] = useState(0)
 
   const [paginationOptions, setPaginationOptions] = useState(
-    defaultInitialPagination
+    initialPaginationOptions
   )
 
   const { t } = useTranslation(['notifications'])
@@ -193,7 +205,7 @@ export const Notifications = () => {
   }, [])
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()
     }

--- a/frontend/src/views/Notifications/NotificationMenu/components/__tests__/Notifications.test.jsx
+++ b/frontend/src/views/Notifications/NotificationMenu/components/__tests__/Notifications.test.jsx
@@ -114,12 +114,16 @@ vi.mock('@/components/BCDataGrid/BCGridViewer', () => {
   }
 })
 
-vi.mock('../_schema', () => ({
-  columnDefs: (t, currentUser) => [],
-  routesMapping: (currentUser) => ({
-    testService: '/test-route/:transactionId'
-  })
-}))
+vi.mock('../_schema', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    columnDefs: (t, currentUser) => [],
+    routesMapping: (currentUser) => ({
+      testService: '/test-route/:transactionId'
+    })
+  }
+})
 
 describe('Notifications Component', () => {
   beforeEach(() => {

--- a/frontend/src/views/Notifications/NotificationMenu/components/_schema.jsx
+++ b/frontend/src/views/Notifications/NotificationMenu/components/_schema.jsx
@@ -22,7 +22,7 @@ export const columnDefs = (t, currentUser) => [
     headerName: t('notifications:notificationColLabels.date'),
     filter: 'agDateColumnFilter',
     filterParams: {
-      filterOptions: ['equals'],
+      filterOptions: ['equals']
     },
     valueGetter: (params) => params.data.createDate,
     valueFormatter: dateFormatter
@@ -74,3 +74,5 @@ export const routesMapping = (currentUser) => ({
     : ROUTES.TRANSACTIONS.INITIATIVE_AGREEMENT.ORG_VIEW,
   ComplianceReport: ROUTES.REPORTS.VIEW
 })
+
+export const defaultSortModel = [{ field: 'date', direction: 'desc' }]

--- a/frontend/src/views/Transactions/Transactions.jsx
+++ b/frontend/src/views/Transactions/Transactions.jsx
@@ -222,7 +222,7 @@ export const Transactions = () => {
   }, [location.state])
 
   const handleClearFilters = () => {
-    setPaginationOptions(defaultInitialPagination)
+    setPaginationOptions(initialPaginationOptions)
     setSelectedOrg({ organizationId: null, label: null })
     if (gridRef && gridRef.current) {
       gridRef.current.clearFilters()

--- a/frontend/src/views/Transactions/Transactions.jsx
+++ b/frontend/src/views/Transactions/Transactions.jsx
@@ -333,7 +333,7 @@ export const Transactions = () => {
       <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
         <BCGridViewer
           gridRef={gridRef}
-          gridKey="transactions-grid"
+          gridKey="transactions-grid-v2"
           columnDefs={transactionsColDefs(t)}
           getRowId={getRowId}
           overlayNoRowsTemplate={t('txn:noTxnsFound')}


### PR DESCRIPTION
This PR includes the following:
- Fixed clear filter sorting in Transactions view and all other tables to use default sort.
- Added missing default sort models and updated clear filter functions for consistency.

Closes #2709