### PR TITLE
Feat: Add "Recommended" Status Filter to Fuel Code Index Page - 2591

### DIFF
--- a/backend/lcfs/db/migrations/versions/2025-06-18-08-48_d432ee9659f.py
+++ b/backend/lcfs/db/migrations/versions/2025-06-18-08-48_d432ee9659f.py
@@ -1,0 +1,86 @@
+"""Add Recommended status to fuel code status enum
+
+Revision ID: d432ee9659f
+Revises: 0a5836cb1b71
+Create Date: 2025-06-18 08:48:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d432ee9659f"
+down_revision = "0a5836cb1b71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Check if the enum value already exists
+    check_enum_query = sa.text(
+        "SELECT EXISTS(SELECT 1 FROM pg_enum WHERE enumlabel = :enum_value AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'fuel_code_status_enum'))"
+    )
+    result = op.get_bind().execute(check_enum_query, {"enum_value": "Recommended"})
+    if not result.scalar():
+        # Add 'Recommended' to the fuel code status enum
+        op.execute("ALTER TYPE fuel_code_status_enum ADD VALUE 'Recommended'")
+
+        # Commit the transaction to make the enum value available
+        op.get_bind().commit()
+
+    # Insert the new status into the fuel_code_status table
+    # Check if the record already exists before inserting
+    check_status_query = sa.text(
+        "SELECT EXISTS(SELECT 1 FROM fuel_code_status WHERE status = 'Recommended')"
+    )
+    result = op.get_bind().execute(check_status_query)
+    if not result.scalar():
+        op.execute(
+            """
+            INSERT INTO fuel_code_status (fuel_code_status_id, status, description, display_order)
+            VALUES (4, 'Recommended', 'Fuel code recommended for approval', 2)
+            ON CONFLICT (fuel_code_status_id) DO NOTHING;
+            """
+        )
+
+    # Update display order for existing statuses to maintain proper order
+    # Draft (1), Recommended (2), Approved (3), Deleted (4)
+    op.execute(
+        """
+        UPDATE fuel_code_status 
+        SET display_order = 3 
+        WHERE status = 'Approved' AND display_order != 3;
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE fuel_code_status 
+        SET display_order = 4 
+        WHERE status = 'Deleted' AND display_order != 4;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Remove the status from the fuel_code_status table
+    op.execute("DELETE FROM fuel_code_status WHERE status = 'Recommended'")
+
+    # Restore original display orders
+    # Draft (1), Approved (2), Deleted (3)
+    op.execute(
+        """
+        UPDATE fuel_code_status 
+        SET display_order = 2 
+        WHERE status = 'Approved';
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE fuel_code_status 
+        SET display_order = 3 
+        WHERE status = 'Deleted';
+        """
+    )

--- a/backend/lcfs/db/models/fuel/FuelCodeStatus.py
+++ b/backend/lcfs/db/models/fuel/FuelCodeStatus.py
@@ -6,6 +6,7 @@ import enum
 
 class FuelCodeStatusEnum(enum.Enum):
     Draft: str = "Draft"
+    Recommended: str = "Recommended"
     Approved: str = "Approved"
     Deleted: str = "Deleted"
 

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -392,6 +392,16 @@ async def test_get_fuel_code_status_enum(fuel_code_repo, mock_db):
 
 
 @pytest.mark.anyio
+async def test_get_fuel_code_status_recommended(fuel_code_repo, mock_db):
+    """Test getting Recommended fuel code status."""
+    fcs = FuelCodeStatus(fuel_code_status_id=3, status=FuelCodeStatusEnum.Recommended)
+    mock_db.scalar.return_value = fcs
+    result = await fuel_code_repo.get_fuel_code_status(FuelCodeStatusEnum.Recommended)
+    assert result == fcs
+    assert result.status == FuelCodeStatusEnum.Recommended
+
+
+@pytest.mark.anyio
 async def test_update_fuel_code(fuel_code_repo, mock_db, valid_fuel_code):
     mock_db.flush = AsyncMock()
     mock_db.refresh = AsyncMock()
@@ -824,6 +834,4 @@ async def test_get_standardized_fuel_data_unknown_no_codes_found_falls_back_to_d
 
     assert result.effective_carbon_intensity == 123.45
 
-    fuel_code_repo.get_default_carbon_intensity.assert_awaited_once_with(
-        1, "2024"
-    )
+    fuel_code_repo.get_default_carbon_intensity.assert_awaited_once_with(1, "2024")

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
@@ -591,7 +591,10 @@ async def test_get_fuel_code_statuses_success(
                 fuel_code_status_id=1, status=FuelCodeStatusEnum.Draft
             ),
             FuelCodeStatusSchema(
-                fuel_code_status_id=2, status=FuelCodeStatusEnum.Approved
+                fuel_code_status_id=2, status=FuelCodeStatusEnum.Recommended
+            ),
+            FuelCodeStatusSchema(
+                fuel_code_status_id=3, status=FuelCodeStatusEnum.Approved
             ),
         ]
 
@@ -603,11 +606,13 @@ async def test_get_fuel_code_statuses_success(
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
         assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(result) == 3
         assert result[0]["fuelCodeStatusId"] == 1
         assert result[0]["status"] == "Draft"
         assert result[1]["fuelCodeStatusId"] == 2
-        assert result[1]["status"] == "Approved"
+        assert result[1]["status"] == "Recommended"
+        assert result[2]["fuelCodeStatusId"] == 3
+        assert result[2]["status"] == "Approved"
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -452,7 +452,7 @@ class FuelCodeRepository:
 
     @repo_handler
     async def get_fuel_code_statuses(self):
-        query = select(FuelCodeStatus).order_by(asc(FuelCodeStatus.status))
+        query = select(FuelCodeStatus).order_by(asc(FuelCodeStatus.display_order))
         status_results = await self.db.execute(query)
         return status_results.scalars().all()
 

--- a/backend/lcfs/web/api/fuel_code/schema.py
+++ b/backend/lcfs/web/api/fuel_code/schema.py
@@ -18,6 +18,7 @@ from lcfs.web.utils.schema_validators import fuel_suffix_format_validator
 
 class FuelCodeStatusEnumSchema(str, Enum):
     Draft = "Draft"
+    Recommended = "Recommended"
     Approved = "Approved"
     Deleted = "Deleted"
 

--- a/backend/lcfs/web/api/other_uses/schema.py
+++ b/backend/lcfs/web/api/other_uses/schema.py
@@ -16,6 +16,7 @@ from lcfs.web.utils.schema_validators import fuel_code_required_label
 
 class FuelCodeStatusEnumSchema(str, Enum):
     Draft = "Draft"
+    Recommended = "Recommended"
     Approved = "Approved"
     Deleted = "Deleted"
 

--- a/frontend/src/constants/statuses.js
+++ b/frontend/src/constants/statuses.js
@@ -61,6 +61,7 @@ export function getAllTerminalTransferStatuses() {
 
 export const FUEL_CODE_STATUSES = {
   DRAFT: 'Draft',
+  RECOMMENDED: 'Recommended',
   APPROVED: 'Approved',
   DELETED: 'Deleted'
 }

--- a/frontend/src/utils/grid/cellRenderers.jsx
+++ b/frontend/src/utils/grid/cellRenderers.jsx
@@ -220,7 +220,7 @@ export const YesNoTextRenderer = (props) => (
 export const FuelCodeStatusRenderer = (props) => {
   const location = useLocation()
   const statusArr = getAllFuelCodeStatuses()
-  const statusColorArr = ['info', 'warning', 'success', 'error']
+  const statusColorArr = ['info', 'info', 'success', 'error']
   const statusIndex = statusArr.indexOf(props.data.fuelCodeStatus.status)
   return (
     <Link

--- a/frontend/src/utils/grid/cellRenderers.jsx
+++ b/frontend/src/utils/grid/cellRenderers.jsx
@@ -220,7 +220,7 @@ export const YesNoTextRenderer = (props) => (
 export const FuelCodeStatusRenderer = (props) => {
   const location = useLocation()
   const statusArr = getAllFuelCodeStatuses()
-  const statusColorArr = ['info', 'success', 'error']
+  const statusColorArr = ['info', 'warning', 'success', 'error']
   const statusIndex = statusArr.indexOf(props.data.fuelCodeStatus.status)
   return (
     <Link

--- a/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
+++ b/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
@@ -94,7 +94,10 @@ const AddEditFuelCodeBase = () => {
         errors,
         !existingFuelCode,
         existingFuelCode?.fuelCodeStatus.status !==
-          FUEL_CODE_STATUSES.APPROVED && hasRoles(roles.analyst)
+          FUEL_CODE_STATUSES.APPROVED &&
+          existingFuelCode?.fuelCodeStatus.status !==
+            FUEL_CODE_STATUSES.RECOMMENDED &&
+          hasRoles(roles.analyst)
       )
       setColumnDefs(updatedColumnDefs)
     }
@@ -447,6 +450,9 @@ const AddEditFuelCodeBase = () => {
               {existingFuelCode?.fuelCodeStatus.status ===
                 FUEL_CODE_STATUSES.DRAFT && t('fuelCode:editFuelCodeTitle')}
               {existingFuelCode?.fuelCodeStatus.status ===
+                FUEL_CODE_STATUSES.RECOMMENDED &&
+                t('fuelCode:viewFuelCodeTitle')}
+              {existingFuelCode?.fuelCodeStatus.status ===
                 FUEL_CODE_STATUSES.APPROVED && t('fuelCode:viewFuelCodeTitle')}
             </BCTypography>
             <BCTypography variant="body2" mt={2} mb={3}>
@@ -471,28 +477,33 @@ const AddEditFuelCodeBase = () => {
             handlePaste={handlePaste}
           />
           {existingFuelCode?.fuelCodeStatus.status !==
-            FUEL_CODE_STATUSES.APPROVED && (
-            <Stack
-              direction={{ md: 'column', lg: 'row' }}
-              spacing={{ xs: 2, sm: 2, md: 3 }}
-              useFlexGap
-              flexWrap="wrap"
-            >
-              <BCButton
-                variant="contained"
-                size="medium"
-                color="primary"
-                startIcon={
-                  <FontAwesomeIcon icon={faFloppyDisk} className="small-icon" />
-                }
-                onClick={handleOpenApprovalModal}
+            FUEL_CODE_STATUSES.APPROVED &&
+            existingFuelCode?.fuelCodeStatus.status !==
+              FUEL_CODE_STATUSES.RECOMMENDED && (
+              <Stack
+                direction={{ md: 'column', lg: 'row' }}
+                spacing={{ xs: 2, sm: 2, md: 3 }}
+                useFlexGap
+                flexWrap="wrap"
               >
-                <BCTypography variant="subtitle2">
-                  {t('fuelCode:approveFuelCodeBtn')}
-                </BCTypography>
-              </BCButton>
-            </Stack>
-          )}
+                <BCButton
+                  variant="contained"
+                  size="medium"
+                  color="primary"
+                  startIcon={
+                    <FontAwesomeIcon
+                      icon={faFloppyDisk}
+                      className="small-icon"
+                    />
+                  }
+                  onClick={handleOpenApprovalModal}
+                >
+                  <BCTypography variant="subtitle2">
+                    {t('fuelCode:approveFuelCodeBtn')}
+                  </BCTypography>
+                </BCButton>
+              </Stack>
+            )}
         </Grid2>
         <BCModal
           open={!!modalData}

--- a/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
+++ b/frontend/src/views/FuelCodes/AddFuelCode/AddEditFuelCode.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Stack } from '@mui/material'
 import Grid2 from '@mui/material/Grid2'
@@ -58,6 +58,17 @@ const AddEditFuelCodeBase = () => {
     refetch
   } = useGetFuelCode(fuelCodeID)
 
+  const nonEditableStatuses = useMemo(
+    () => [FUEL_CODE_STATUSES.APPROVED, FUEL_CODE_STATUSES.RECOMMENDED],
+    []
+  )
+
+  const isEditable = useMemo(
+    () =>
+      !nonEditableStatuses.includes(existingFuelCode?.fuelCodeStatus.status),
+    [nonEditableStatuses, existingFuelCode?.fuelCodeStatus.status]
+  )
+
   useEffect(() => {
     // Only initialize rowData once when all data is available and the grid is ready
     if (!initialized && isFetched && !isLoadingExistingCode && isGridReady) {
@@ -93,15 +104,11 @@ const AddEditFuelCodeBase = () => {
         optionsData,
         errors,
         !existingFuelCode,
-        existingFuelCode?.fuelCodeStatus.status !==
-          FUEL_CODE_STATUSES.APPROVED &&
-          existingFuelCode?.fuelCodeStatus.status !==
-            FUEL_CODE_STATUSES.RECOMMENDED &&
-          hasRoles(roles.analyst)
+        isEditable && hasRoles(roles.analyst)
       )
       setColumnDefs(updatedColumnDefs)
     }
-  }, [errors, optionsData, existingFuelCode])
+  }, [errors, optionsData, existingFuelCode, isEditable, hasRoles])
 
   useEffect(() => {
     if (existingFuelCode) {
@@ -476,34 +483,28 @@ const AddEditFuelCodeBase = () => {
             context={{ errors }}
             handlePaste={handlePaste}
           />
-          {existingFuelCode?.fuelCodeStatus.status !==
-            FUEL_CODE_STATUSES.APPROVED &&
-            existingFuelCode?.fuelCodeStatus.status !==
-              FUEL_CODE_STATUSES.RECOMMENDED && (
-              <Stack
-                direction={{ md: 'column', lg: 'row' }}
-                spacing={{ xs: 2, sm: 2, md: 3 }}
-                useFlexGap
-                flexWrap="wrap"
+          {isEditable && (
+            <Stack
+              direction={{ md: 'column', lg: 'row' }}
+              spacing={{ xs: 2, sm: 2, md: 3 }}
+              useFlexGap
+              flexWrap="wrap"
+            >
+              <BCButton
+                variant="contained"
+                size="medium"
+                color="primary"
+                startIcon={
+                  <FontAwesomeIcon icon={faFloppyDisk} className="small-icon" />
+                }
+                onClick={handleOpenApprovalModal}
               >
-                <BCButton
-                  variant="contained"
-                  size="medium"
-                  color="primary"
-                  startIcon={
-                    <FontAwesomeIcon
-                      icon={faFloppyDisk}
-                      className="small-icon"
-                    />
-                  }
-                  onClick={handleOpenApprovalModal}
-                >
-                  <BCTypography variant="subtitle2">
-                    {t('fuelCode:approveFuelCodeBtn')}
-                  </BCTypography>
-                </BCButton>
-              </Stack>
-            )}
+                <BCTypography variant="subtitle2">
+                  {t('fuelCode:approveFuelCodeBtn')}
+                </BCTypography>
+              </BCButton>
+            </Stack>
+          )}
         </Grid2>
         <BCModal
           open={!!modalData}

--- a/frontend/src/views/FuelCodes/_schema.jsx
+++ b/frontend/src/views/FuelCodes/_schema.jsx
@@ -13,6 +13,7 @@ export const fuelCodeColDefs = (t, status = null) => [
   {
     field: 'status',
     headerName: t('fuelCode:fuelCodeColLabels.status'),
+    minWidth: 200,
     floatingFilterComponent: BCSelectFloatingFilter,
     floatingFilterComponentParams: {
       valueKey: 'status',


### PR DESCRIPTION
This PR includes the following updates:

- Added "Recommended" to `fuel_code_status_enum` and table
- Updated backend models, queries, and test cases
- Adjusted frontend logic to handle and display "Recommended" status
- Enabled filtering by Recommended in the fuel code index

Closes #2591