### PR TITLE
Fix: LCFS - BUG - Internal commenting #2908

### DIFF
--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -147,10 +147,10 @@ class InternalCommentRepository:
 
         # Get the specific model and where condition for the given entity_type
         entity_model, where_condition = entity_mapping[entity_type]
-        report_ids = [entity_id]
+        entity_ids = [entity_id]
         if entity_type == EntityTypeEnum.COMPLIANCE_REPORT:
             # Get all related compliance report IDs in the same chain
-            report_ids = (
+            entity_ids = (
                 await self.report_repo.get_related_compliance_report_ids(entity_id)
             )
 
@@ -170,7 +170,7 @@ class InternalCommentRepository:
                 UserProfile,
                 UserProfile.keycloak_username == InternalComment.create_user,
             )
-            .where(where_condition.in_(report_ids))
+            .where(where_condition.in_(entity_ids))
             .order_by(desc(InternalComment.internal_comment_id))
         )
 


### PR DESCRIPTION
Fix #2908
- While retrieving internal comments for a compliance ReportID, ensure all the reportIds are included within the report chain.