### PR TITLE
Fix: LCFS - BUG - Internal commenting #2908

### DIFF
--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -4,7 +4,7 @@ from typing import List
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, desc
+from sqlalchemy import asc, select, desc
 
 from lcfs.web.exception.exceptions import DataNotFoundException
 from lcfs.db.dependencies import get_async_db_session
@@ -178,7 +178,7 @@ class InternalCommentRepository:
                 UserProfile.keycloak_username == InternalComment.create_user,
             )
             .where(InternalComment.internal_comment_id.in_(distinct_comment_ids_query))
-            .order_by(desc(InternalComment.update_date))
+            .order_by(asc(InternalComment.create_date))
         )
 
         # Execute the query

--- a/frontend/src/hooks/useInternalComments.js
+++ b/frontend/src/hooks/useInternalComments.js
@@ -341,7 +341,7 @@ export const useInternalComments = (entityType, entityId, options = {}) => {
   }, [commentInput, addCommentMutation])
 
   const handleEditComment = useCallback(
-    (commentId, commentText) => {
+    ({ commentId, commentText }) => {
       return editCommentMutation.mutateAsync({ commentId, commentText })
     },
     [editCommentMutation]


### PR DESCRIPTION
Fix #2908, https://github.com/bcgov/lcfs/issues/2908#issuecomment-2989093407
- get distinct comments ordered by create_date asc.
- fix bug in useInternalComments.