### PR TITLE
Feat: Add Last Comment column to Compliance Report Index - 2641

### DIFF
--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -21,6 +21,7 @@ from typing import List, Optional, TypedDict, Type, Any, Coroutine, Sequence
 from lcfs.db.dependencies import get_async_db_session
 from lcfs.db.models import CompliancePeriod
 from lcfs.db.models.comment import ComplianceReportInternalComment
+from lcfs.db.models.comment.InternalComment import InternalComment
 from lcfs.db.models.compliance import (
     CompliancePeriod,
     ComplianceReportListView,
@@ -54,6 +55,7 @@ from lcfs.web.api.base import (
 from lcfs.web.api.compliance_report.schema import (
     ComplianceReportBaseSchema,
     ComplianceReportViewSchema,
+    LastCommentSchema,
 )
 from lcfs.web.api.fuel_supply.repo import FuelSupplyRepository
 from lcfs.web.api.role.schema import user_has_roles
@@ -352,11 +354,79 @@ class ComplianceReportRepository:
         total_count_query = select(func.count()).select_from(query)
         total_count = (await self.db.execute(total_count_query)).scalar()
 
-        # Transform results into Pydantic schemas
-        reports = [
-            ComplianceReportViewSchema.model_validate(report) for report in query_result
-        ]
+        # Transform results into Pydantic schemas and fetch latest comments
+        reports = []
+        for report in query_result:
+            report_dict = {
+                "compliance_report_id": report.compliance_report_id,
+                "compliance_report_group_uuid": report.compliance_report_group_uuid,
+                "version": report.version,
+                "compliance_period_id": report.compliance_period_id,
+                "compliance_period": report.compliance_period,
+                "organization_id": report.organization_id,
+                "organization_name": report.organization_name,
+                "report_type": report.report_type,
+                "report_status_id": report.report_status_id,
+                "report_status": report.report_status,
+                "update_date": report.update_date,
+            }
+
+            # Get latest comment for this report (only for government users)
+            if user_has_roles(user, [RoleEnum.GOVERNMENT]):
+                latest_comment = await self._get_latest_comment_for_report(
+                    report.compliance_report_id
+                )
+                report_dict["last_comment"] = latest_comment
+
+            reports.append(ComplianceReportViewSchema.model_validate(report_dict))
+
         return reports, total_count
+
+    async def _get_latest_comment_for_report(
+        self, compliance_report_id: int
+    ) -> Optional[LastCommentSchema]:
+        """
+        Retrieve the latest internal comment for a compliance report
+        """
+        # Get all related compliance report IDs for this report (including chain)
+        related_ids = await self.get_related_compliance_report_ids(compliance_report_id)
+
+        # Query for the latest comment across all related reports
+        query = (
+            select(
+                InternalComment.comment,
+                InternalComment.create_date,
+                (UserProfile.first_name + " " + UserProfile.last_name).label(
+                    "full_name"
+                ),
+            )
+            .join(
+                ComplianceReportInternalComment,
+                ComplianceReportInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .join(
+                UserProfile,
+                UserProfile.keycloak_username == InternalComment.create_user,
+            )
+            .where(
+                ComplianceReportInternalComment.compliance_report_id.in_(related_ids)
+            )
+            .order_by(InternalComment.create_date.desc())
+            .limit(1)
+        )
+
+        result = await self.db.execute(query)
+        row = result.first()
+
+        if row:
+            return LastCommentSchema(
+                comment=row.comment,
+                full_name=row.full_name,
+                create_date=row.create_date,
+            )
+
+        return None
 
     def _apply_filters(self, pagination, conditions):
         for filter in pagination.filters:

--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -137,6 +137,12 @@ class ComplianceReportBaseSchema(BaseSchema):
     assessment_statement: Optional[str] = None
 
 
+class LastCommentSchema(BaseSchema):
+    comment: str
+    full_name: str
+    create_date: datetime
+
+
 class ComplianceReportViewSchema(BaseSchema):
     compliance_report_id: int
     compliance_report_group_uuid: str
@@ -149,6 +155,7 @@ class ComplianceReportViewSchema(BaseSchema):
     report_status_id: int
     report_status: str
     update_date: datetime
+    last_comment: Optional[LastCommentSchema] = None
 
 
 class ChainedComplianceReportSchema(BaseSchema):

--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -8,6 +8,7 @@
     "organization": "Organization",
     "type": "Type",
     "status": "Current status",
+    "lastComment": "Last comment",
     "lastUpdated": "Last status update"
   },
   "noReportsFound": "No compliance reports found",

--- a/frontend/src/components/BCUserInitials/BCUserInitials.jsx
+++ b/frontend/src/components/BCUserInitials/BCUserInitials.jsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { Chip, Tooltip } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+/**
+ * A component that displays user initials in a circular chip with an optional tooltip
+ * @param {string} fullName - The full name of the user
+ * @param {string} tooltipText - Text to display in the tooltip (truncated to maxLength if needed)
+ * @param {number} maxLength - Maximum length for tooltip text (default: 500)
+ * @param {string} variant - Chip variant ('filled' | 'outlined')
+ * @param {string} color - Chip color
+ * @param {object} sx - Additional styles
+ */
+const BCUserInitials = ({
+  fullName,
+  tooltipText = '',
+  maxLength = 500,
+  variant = 'filled',
+  color = 'primary',
+  sx = {},
+  ...props
+}) => {
+  const theme = useTheme()
+
+  // Extract initials from full name
+  const getInitials = (name) => {
+    if (!name) return ''
+    return name
+      .split(' ')
+      .map((part) => part.charAt(0).toUpperCase())
+      .join('')
+      .substring(0, 2) // Limit to 2 characters
+  }
+
+  // Function to strip HTML tags from text (for safety and reusability)
+  const stripHtmlTags = (html) => {
+    if (!html) return ''
+    const tmp = document.createElement('div')
+    tmp.innerHTML = html
+    return tmp.textContent || tmp.innerText || ''
+  }
+
+  // Clean and truncate tooltip text
+  const cleanTooltipText = stripHtmlTags(tooltipText)
+  const truncatedTooltipText =
+    cleanTooltipText.length > maxLength
+      ? `${cleanTooltipText.substring(0, maxLength)}...`
+      : cleanTooltipText
+
+  const initials = getInitials(fullName)
+
+  const pillStyles = {
+    height: '24px',
+    fontSize: '0.75rem',
+    fontWeight: 'bold',
+    minWidth: '32px',
+    '& .MuiChip-label': {
+      padding: '0 6px'
+    },
+    ...sx
+  }
+
+  const pill = (
+    <Chip
+      label={initials}
+      variant={variant}
+      color={color}
+      size="small"
+      sx={pillStyles}
+      {...props}
+    />
+  )
+
+  // Only wrap with tooltip if there's tooltip text
+  if (truncatedTooltipText) {
+    return (
+      <Tooltip
+        title={truncatedTooltipText}
+        placement="top"
+        arrow
+        enterDelay={500}
+        leaveDelay={200}
+      >
+        <span>{pill}</span>
+      </Tooltip>
+    )
+  }
+
+  return pill
+}
+
+export default BCUserInitials

--- a/frontend/src/components/BCUserInitials/index.js
+++ b/frontend/src/components/BCUserInitials/index.js
@@ -1,0 +1,1 @@
+export { default as BCUserInitials } from './BCUserInitials'

--- a/frontend/src/components/__tests__/BCUserInitials.test.jsx
+++ b/frontend/src/components/__tests__/BCUserInitials.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import BCUserInitials from '@/components/BCUserInitials/BCUserInitials'
+
+describe('BCUserInitials Component', () => {
+  const defaultProps = {
+    fullName: 'John Doe',
+    tooltipText: 'This is a test comment',
+    maxLength: 500
+  }
+
+  it('should render the component with user initials', () => {
+    render(<BCUserInitials {...defaultProps} />)
+
+    const chipLabel = screen.getByText('JD')
+    expect(chipLabel).toBeInTheDocument()
+  })
+
+  it('should generate correct initials for various name formats', () => {
+    const testCases = [
+      { name: 'John Doe', expected: 'JD' },
+      { name: 'John', expected: 'J' },
+      { name: 'John Michael Doe', expected: 'JM' }, // First two words only
+      { name: 'jean-pierre martin', expected: 'JM' } // Note: jean-pierre is one word
+    ]
+
+    testCases.forEach(({ name, expected }) => {
+      const { unmount } = render(
+        <BCUserInitials fullName={name} tooltipText="test" />
+      )
+
+      const chipLabel = screen.getByText(expected)
+      expect(chipLabel).toBeInTheDocument()
+
+      unmount()
+    })
+  })
+
+  it('should display tooltip with clean text', () => {
+    render(<BCUserInitials {...defaultProps} />)
+
+    const tooltip = screen.getByLabelText('This is a test comment')
+    expect(tooltip).toBeInTheDocument()
+  })
+
+  it('should strip HTML tags from tooltip text', () => {
+    const htmlTooltip =
+      '<p>This is <strong>bold</strong> text with <em>emphasis</em></p>'
+    const expectedCleanText = 'This is bold text with emphasis'
+
+    render(<BCUserInitials fullName="John Doe" tooltipText={htmlTooltip} />)
+
+    const tooltip = screen.getByLabelText(expectedCleanText)
+    expect(tooltip).toBeInTheDocument()
+  })
+
+  it('should truncate tooltip text when exceeding maxLength', () => {
+    const longText =
+      'This is a very long comment that should be truncated when it exceeds the maximum length specified in the component props'
+    const maxLength = 50
+
+    render(
+      <BCUserInitials
+        fullName="John Doe"
+        tooltipText={longText}
+        maxLength={maxLength}
+      />
+    )
+
+    // Should find the truncated version (check what was actually rendered)
+    const tooltip = screen.getByLabelText(
+      /This is a very long comment that should be truncat\.\.\./
+    )
+    expect(tooltip).toBeInTheDocument()
+  })
+
+  it('should handle empty tooltip text gracefully', () => {
+    render(<BCUserInitials fullName="John Doe" tooltipText="" />)
+
+    const chipLabel = screen.getByText('JD')
+    expect(chipLabel).toBeInTheDocument()
+  })
+
+  it('should handle special characters in names', () => {
+    const specialNames = [
+      { name: 'José María', expected: 'JM' },
+      { name: 'François Müller', expected: 'FM' }
+    ]
+
+    specialNames.forEach(({ name, expected }) => {
+      const { unmount } = render(
+        <BCUserInitials fullName={name} tooltipText="test" />
+      )
+
+      const chipLabel = screen.getByText(expected)
+      expect(chipLabel).toBeInTheDocument()
+
+      unmount()
+    })
+  })
+
+  it('should handle very long names gracefully', () => {
+    const longName =
+      'John Michael Christopher Alexander Benjamin Theodore Roosevelt'
+
+    render(<BCUserInitials fullName={longName} tooltipText="test" />)
+
+    // Should get first two initials (limited to 2 characters)
+    const chipLabel = screen.getByText('JM')
+    expect(chipLabel).toBeInTheDocument()
+  })
+
+  it('should use default maxLength when not provided', () => {
+    const longText = 'A'.repeat(600) // Longer than default 500
+
+    render(<BCUserInitials fullName="John Doe" tooltipText={longText} />)
+
+    const chipLabel = screen.getByText('JD')
+    expect(chipLabel).toBeInTheDocument()
+
+    // The tooltip should be truncated (we can't easily test the exact truncation without accessing internals)
+    const tooltip = screen.getByLabelText(/A{500,}\.\.\./)
+    expect(tooltip).toBeInTheDocument()
+  })
+
+  it('should handle mixed HTML and text content', () => {
+    const mixedContent =
+      'Plain text <b>bold</b> more plain text <i>italic</i> end'
+    const expectedClean = 'Plain text bold more plain text italic end'
+
+    render(<BCUserInitials fullName="Test User" tooltipText={mixedContent} />)
+
+    const tooltip = screen.getByLabelText(expectedClean)
+    expect(tooltip).toBeInTheDocument()
+  })
+})

--- a/frontend/src/utils/grid/cellRenderers.jsx
+++ b/frontend/src/utils/grid/cellRenderers.jsx
@@ -1,5 +1,6 @@
 import BCBadge from '@/components/BCBadge'
 import BCBox from '@/components/BCBox'
+import BCUserInitials from '@/components/BCUserInitials/BCUserInitials'
 import { roles } from '@/constants/roles'
 import {
   COMPLIANCE_REPORT_STATUSES,
@@ -674,5 +675,64 @@ export const RoleRenderer = (props) => {
         roleRenderOverflowChip(count, isGovernmentRole)
       }
     />
+  )
+}
+
+export const LastCommentRenderer = (props) => {
+  const location = useLocation()
+  const { lastComment } = props.data
+
+  // If no comment exists, return empty cell
+  if (!lastComment || !lastComment.fullName) {
+    return (
+      <Link
+        to={`${location.pathname}/${props.data.compliancePeriod}/${props.data.complianceReportId}`}
+        style={{ color: '#000' }}
+      >
+        <BCBox component="div" sx={{ width: '100%', height: '100%' }}>
+          {/* Empty cell but still clickable */}
+        </BCBox>
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      to={`${location.pathname}/${props.data.compliancePeriod}/${props.data.complianceReportId}`}
+      style={{ color: '#000' }}
+    >
+      <BCBox
+        component="div"
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          py: 1
+        }}
+      >
+        <BCUserInitials
+          fullName={lastComment.fullName}
+          tooltipText={lastComment.comment}
+          maxLength={500}
+          variant="filled"
+          sx={{
+            bgcolor: '#606060',
+            color: 'white',
+            borderRadius: '50%',
+            width: '32px',
+            height: '32px',
+            minWidth: '32px',
+            '& .MuiChip-label': {
+              padding: 0
+            },
+            '&:hover': {
+              bgcolor: '#505050'
+            }
+          }}
+        />
+      </BCBox>
+    </Link>
   )
 }

--- a/frontend/src/views/ComplianceReports/components/_schema.jsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.jsx
@@ -3,7 +3,10 @@ import {
   BCSelectFloatingFilter
 } from '@/components/BCDataGrid/components'
 import { SUMMARY } from '@/constants/common'
-import { ReportsStatusRenderer } from '@/utils/grid/cellRenderers'
+import {
+  ReportsStatusRenderer,
+  LastCommentRenderer
+} from '@/utils/grid/cellRenderers'
 import { timezoneFormatter } from '@/utils/formatters'
 import { useGetComplianceReportStatuses } from '@/hooks/useComplianceReports'
 
@@ -11,7 +14,7 @@ export const reportsColDefs = (t, isSupplier) => [
   {
     field: 'status',
     headerName: t('report:reportColLabels.status'),
-    width: 300,
+    width: 200,
     valueGetter: ({ data }) => data.reportStatus || '',
     filterParams: {
       textFormatter: (value) => value.replace(/\s+/g, '_').toLowerCase(),
@@ -41,6 +44,18 @@ export const reportsColDefs = (t, isSupplier) => [
       labelKey: 'status'
     },
     suppressFloatingFilterButton: true
+  },
+  {
+    field: 'lastComment',
+    headerName: t('report:reportColLabels.lastComment'),
+    width: 160,
+    hide: isSupplier, // Only show for IDIR users
+    cellRenderer: LastCommentRenderer,
+    sortable: false,
+    filter: false,
+    floatingFilter: false,
+    suppressHeaderFilterButton: true,
+    valueGetter: ({ data }) => data.lastComment || null
   },
   {
     field: 'compliancePeriod',


### PR DESCRIPTION
This PR includes the following changes:
- Added a "Last Comment" column to the IDIR Compliance Report index
- Displayed initials of the latest commenter in a pill-style UI
- Tooltip on hover shows the full text of the latest internal comment (up to 500 chars)

Closes #2641