### PR TITLE
Fix: Clean deletion flow without error flash - 2916

### DIFF
--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -75,11 +75,6 @@ export const EditViewComplianceReport = ({ isError, error }) => {
   const [isScrollingUp, setIsScrollingUp] = useState(false)
   const [lastScrollTop, setLastScrollTop] = useState(0)
 
-  // Early return if report is deleted or being deleted
-  if (isDeleted || isDeleting) {
-    return <Loading />
-  }
-
   const scrollToTopOrBottom = () => {
     if (isScrollingUp) {
       window.scrollTo({


### PR DESCRIPTION
This PR fixes the error flash on report deletion to ensure a smooth success flow.

Closes #2916
