### PR TITLE
Fix: Fuel code edit/save restrictions - 3038 3039

### DIFF
--- a/frontend/src/views/FuelCodes/AddFuelCode/buttonConfigs.jsx
+++ b/frontend/src/views/FuelCodes/AddFuelCode/buttonConfigs.jsx
@@ -191,13 +191,13 @@ const FUEL_CODE_BUTTON_RULES = {
   },
 
   [FUEL_CODE_STATUSES.RECOMMENDED]: {
-    [USER_TYPES.ANALYST]: ['save', 'edit'],
+    [USER_TYPES.ANALYST]: ['save'],
     [USER_TYPES.DIRECTOR]: ['save', 'edit', 'approve', 'returnToAnalyst']
   },
 
   [FUEL_CODE_STATUSES.APPROVED]: {
     [USER_TYPES.ANALYST]: ['save', 'edit'],
-    [USER_TYPES.DIRECTOR]: ['save', 'edit']
+    [USER_TYPES.DIRECTOR]: ['edit']
   }
 }
 


### PR DESCRIPTION
This PR includes the following:

- Hide Edit for Analysts when status is Recommended  
- Hide Save for Directors when status is Approved  

Closes #3038  
Closes #3039
