### PR TITLE
Fix: Run Missing Migration - 1775

### DIFF
--- a/backend/lcfs/db/migrations/versions/2025-07-07-13-33_07cce665fabc.py
+++ b/backend/lcfs/db/migrations/versions/2025-07-07-13-33_07cce665fabc.py
@@ -1,7 +1,7 @@
 """Add assigned_analyst_id field to compliance_report table
 
 Revision ID: 07cce665fabc
-Revises: ae2306fa8d72
+Revises: 413eef467edd
 Create Date: 2025-07-07 13:33:00.000000
 
 """
@@ -16,7 +16,7 @@ from lcfs.db.dependencies import (
 
 # revision identifiers, used by Alembic.
 revision = "07cce665fabc"
-down_revision = "ae2306fa8d72"
+down_revision = "413eef467edd"
 branch_labels = None
 depends_on = None
 

--- a/backend/lcfs/db/migrations/versions/2025-07-25-10-31_ae2306fa8d72.py
+++ b/backend/lcfs/db/migrations/versions/2025-07-25-10-31_ae2306fa8d72.py
@@ -1,7 +1,7 @@
 """Add fuel code versioning
 
 Revision ID: ae2306fa8d72
-Revises: 413eef467edd
+Revises: b2c3d4e5f8g9
 Create Date: 2025-07-02 10:31:37.335578
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "ae2306fa8d72"
-down_revision = "413eef467edd"
+down_revision = "b2c3d4e5f8g9"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This PR includes the following:
- Moves the `ae2306fa8d72` migration to end of chain
- Fixes 500s on Fuel Code page due to missing column

Closes #1775