### PR TITLE
Feat: Left align buttons on transfer pages - 3256

### DIFF
--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -469,8 +469,8 @@ export const AddEditViewTransfer = () => {
             <Stack
               component="div"
               direction={{ md: 'coloumn', lg: 'row' }}
-              justifyContent="flex-end"
-              mt={2}
+              justifyContent="flex-start"
+              mt={4}
               gap={2}
               spacing={2}
             >


### PR DESCRIPTION
This PR aligns all transfer page buttons to the left for consistency and accessibility.

Closes #3256