### PR TITLE
Feat: BCeID permission fix for compliance reports - 3596

### DIFF
--- a/backend/lcfs/web/api/organization/views.py
+++ b/backend/lcfs/web/api/organization/views.py
@@ -240,7 +240,7 @@ async def update_transfer(
     response_model=ComplianceReportBaseSchema,
     status_code=status.HTTP_201_CREATED,
 )
-@view_handler([RoleEnum.COMPLIANCE_REPORTING, RoleEnum.SIGNING_AUTHORITY])
+@view_handler([RoleEnum.COMPLIANCE_REPORTING])
 async def create_compliance_report(
     request: Request,
     organization_id: int,

--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -147,8 +147,7 @@ export const useComplianceReportWithCache = (reportId, options = {}) => {
   const cachedReport = getCachedReport(reportId)
   const needsFetch = shouldFetchReport(reportId)
   const { data: currentUser } = useCurrentUser({
-    enabled:
-      needsFetch && !!reportId
+    enabled: needsFetch && !!reportId
   })
   const queryResult = useGetComplianceReport(
     currentUser?.organization?.organizationId,
@@ -479,7 +478,12 @@ export const useGetComplianceReportList = (
   options = {}
 ) => {
   const client = useApiService()
-  const { data: currentUser, hasRoles, isLoading } = useCurrentUser()
+  const {
+    data: currentUser,
+    hasRoles,
+    hasAnyRole,
+    isLoading
+  } = useCurrentUser()
 
   const {
     staleTime = DEFAULT_STALE_TIME,
@@ -491,7 +495,7 @@ export const useGetComplianceReportList = (
   return useQuery({
     queryKey: ['compliance-reports-list', page, size, sortOrders, filters],
     queryFn: async () => {
-      if (hasRoles(roles.compliance_reporting, roles.signing_authority)) {
+      if (hasAnyRole(roles.compliance_reporting, roles.signing_authority)) {
         const orgId = currentUser?.organization?.organizationId
         if (!orgId) {
           throw new Error('Organization ID not found for supplier')
@@ -511,7 +515,9 @@ export const useGetComplianceReportList = (
         })
         return response.data
       } else {
-        throw new Error('User does not have permission to view compliance reports')
+        throw new Error(
+          'User does not have permission to view compliance reports'
+        )
       }
     },
     enabled: enabled && !isLoading,

--- a/frontend/src/views/ComplianceReports/ComplianceReports.jsx
+++ b/frontend/src/views/ComplianceReports/ComplianceReports.jsx
@@ -161,7 +161,7 @@ export const ComplianceReports = () => {
         my={{ xs: 1, sm: 1, md: 2 }}
         mx={0}
       >
-        <Role roles={[roles.supplier]}>
+        <Role roles={[roles.compliance_reporting]}>
           <NewComplianceReportButton
             ref={newButtonRef}
             handleNewReport={(option) => {


### PR DESCRIPTION
This PR corrects role-based access so each BCeID role gets its proper report permissions.

Closes https://github.com/bcgov/lcfs/issues/3596