### PR TITLE
Feat: Bulk FSE redirect and charging site context - 3642

### DIFF
--- a/frontend/src/views/ChargingEquipment/AddEditChargingEquipment.jsx
+++ b/frontend/src/views/ChargingEquipment/AddEditChargingEquipment.jsx
@@ -219,6 +219,13 @@ export const AddEditChargingEquipment = ({ mode }) => {
   const gridRef = useRef(null)
   const lastImportJobIdRef = useRef(null)
 
+  // Get pre-populated charging site ID from location state
+  const prePopulatedChargingSiteId = location.state?.chargingSiteId || null
+  
+  // Lock the Charging Site field only when coming from a Charging Site page
+  // (indicated by having a chargingSiteId in the location state)
+  const isChargingSiteLocked = Boolean(prePopulatedChargingSiteId)
+
   // Navigate back to origin page or default to Manage FSE
   const navigateBack = useCallback(() => {
     navigate(location.state?.returnTo || `${ROUTES.REPORTS.LIST}/fse`)
@@ -456,7 +463,7 @@ export const AddEditChargingEquipment = ({ mode }) => {
           message: isEdit
             ? t('chargingEquipment:updateSuccess')
             : t('chargingEquipment:createSuccess'),
-            severity: 'success'
+          severity: 'success'
         })
       } catch (error) {
         alertRef.current?.triggerAlert({
@@ -593,67 +600,84 @@ export const AddEditChargingEquipment = ({ mode }) => {
   }
 
   // Default empty row template
-  const getEmptyRow = (id = uuid()) => ({
-    id,
-    chargingSiteId: '',
-    serialNumber: '',
-    manufacturer: '',
-    model: '',
-    levelOfEquipmentId: '',
-    ports: '',
-    latitude: 0,
-    longitude: 0,
-    notes: '',
-    intendedUseIds: [],
-    intendedUserIds: [],
-    registrationNumber: ''
-  })
+  const getEmptyRow = useCallback(
+    (id = uuid()) => {
+      const chargingSiteIdValue = prePopulatedChargingSiteId
+        ? Number(prePopulatedChargingSiteId)
+        : ''
 
-  const buildSingleRowData = useCallback(
-    (equipmentData = {}) => {
-      const baseId =
-        equipmentData?.chargingEquipmentId ??
-        equipmentData?.id ??
-        uuid()
-
-      return {
-        id: baseId,
-        chargingEquipmentId: equipmentData?.chargingEquipmentId,
-        chargingSiteId: equipmentData?.chargingSiteId || '',
-        serialNumber: equipmentData?.serialNumber || '',
-        manufacturer: equipmentData?.manufacturer || '',
-        model: equipmentData?.model || '',
-        levelOfEquipmentId: equipmentData?.levelOfEquipmentId || '',
-        ports: equipmentData?.ports || '',
-        latitude: equipmentData?.latitude || 0,
-        longitude: equipmentData?.longitude || 0,
-        notes: equipmentData?.notes || '',
-        intendedUseIds:
-          equipmentData?.intendedUses?.map((use) => use.endUseTypeId) ||
-          equipmentData?.intendedUseIds ||
-          [],
-        intendedUserIds:
-          equipmentData?.intendedUsers?.map((user) => user.endUserTypeId) ||
-          equipmentData?.intendedUserIds ||
-          [],
-        status: equipmentData?.status || 'Draft',
-        registrationNumber: equipmentData?.registrationNumber || ''
+      const row = {
+        id,
+        chargingSiteId: chargingSiteIdValue,
+        serialNumber: '',
+        manufacturer: '',
+        model: '',
+        levelOfEquipmentId: '',
+        ports: '',
+        latitude: 0,
+        longitude: 0,
+        notes: '',
+        intendedUseIds: [],
+        intendedUserIds: [],
+        registrationNumber: ''
       }
+
+      // If charging site is pre-populated, also set the lat/long from the site
+      if (prePopulatedChargingSiteId && chargingSites) {
+        const site = chargingSites.find(
+          (s) => s.chargingSiteId === Number(prePopulatedChargingSiteId)
+        )
+        if (site) {
+          row.latitude = site.latitude || 0
+          row.longitude = site.longitude || 0
+        }
+      }
+
+      return row
     },
-    []
+    [prePopulatedChargingSiteId, chargingSites]
   )
 
+  const buildSingleRowData = useCallback((equipmentData = {}) => {
+    const baseId =
+      equipmentData?.chargingEquipmentId ?? equipmentData?.id ?? uuid()
+
+    return {
+      id: baseId,
+      chargingEquipmentId: equipmentData?.chargingEquipmentId,
+      chargingSiteId: equipmentData?.chargingSiteId || '',
+      serialNumber: equipmentData?.serialNumber || '',
+      manufacturer: equipmentData?.manufacturer || '',
+      model: equipmentData?.model || '',
+      levelOfEquipmentId: equipmentData?.levelOfEquipmentId || '',
+      ports: equipmentData?.ports || '',
+      latitude: equipmentData?.latitude || 0,
+      longitude: equipmentData?.longitude || 0,
+      notes: equipmentData?.notes || '',
+      intendedUseIds:
+        equipmentData?.intendedUses?.map((use) => use.endUseTypeId) ||
+        equipmentData?.intendedUseIds ||
+        [],
+      intendedUserIds:
+        equipmentData?.intendedUsers?.map((user) => user.endUserTypeId) ||
+        equipmentData?.intendedUserIds ||
+        [],
+      status: equipmentData?.status || 'Draft',
+      registrationNumber: equipmentData?.registrationNumber || ''
+    }
+  }, [])
+
   // Bulk mode handlers
-  const handleAddRow = () => {
-    setBulkData([...bulkData, getEmptyRow()])
-  }
+  const handleAddRow = useCallback(() => {
+    setBulkData((prev) => [...prev, getEmptyRow()])
+  }, [getEmptyRow])
 
   // Auto-create one row on load to match Charging Site UX
   useEffect(() => {
-    if (isBulkMode && bulkData.length === 0) {
+    if (isBulkMode && bulkData.length === 0 && !sitesLoading) {
       handleAddRow()
     }
-  }, [isBulkMode, bulkData.length])
+  }, [isBulkMode, bulkData.length, handleAddRow, sitesLoading])
 
   useEffect(() => {
     if (isBulkMode) {
@@ -666,13 +690,7 @@ export const AddEditChargingEquipment = ({ mode }) => {
     } else if (!isEdit && !equipmentLoading) {
       setSingleRowData([buildSingleRowData()])
     }
-  }, [
-    buildSingleRowData,
-    equipment,
-    equipmentLoading,
-    isBulkMode,
-    isEdit
-  ])
+  }, [buildSingleRowData, equipment, equipmentLoading, isBulkMode, isEdit])
 
   const handleBulkSave = async () => {
     try {
@@ -869,7 +887,10 @@ export const AddEditChargingEquipment = ({ mode }) => {
                   endUserTypes,
                   gridErrors,
                   gridWarnings,
-                  { enableDuplicate: true }
+                  { enableDuplicate: true },
+                  true,
+                  true,
+                  isChargingSiteLocked
                 )}
                 defaultColDef={defaultBulkColDef}
                 stopEditingWhenCellsLoseFocus
@@ -1008,10 +1029,10 @@ export const AddEditChargingEquipment = ({ mode }) => {
         </Grid>
         <Grid item xs={12}>
           <Box sx={{ width: '100%' }}>
-              <BCGridEditor
-                gridRef={gridRef}
-                alertRef={alertRef}
-                stopEditingWhenCellsLoseFocus
+            <BCGridEditor
+              gridRef={gridRef}
+              alertRef={alertRef}
+              stopEditingWhenCellsLoseFocus
               columnDefs={bulkChargingEquipmentColDefs(
                 chargingSites,
                 organizations,
@@ -1022,7 +1043,8 @@ export const AddEditChargingEquipment = ({ mode }) => {
                 gridWarnings,
                 { enableDelete: isEdit && equipment?.status === 'Draft' },
                 true,
-                isEdit && equipment?.status === 'Draft'
+                isEdit && equipment?.status === 'Draft',
+                isChargingSiteLocked // Lock only when coming from Charging Site page
               )}
               defaultColDef={{ ...defaultBulkColDef, singleClickEdit: canEdit }}
               rowData={singleRowData}

--- a/frontend/src/views/ChargingEquipment/ChargingEquipment.jsx
+++ b/frontend/src/views/ChargingEquipment/ChargingEquipment.jsx
@@ -234,7 +234,9 @@ export const ChargingEquipment = () => {
   )
 
   const handleNewFSE = () => {
-    navigate(`${ROUTES.REPORTS.LIST}/fse/add`)
+    navigate(`${ROUTES.REPORTS.LIST}/fse/add`, {
+      state: { returnTo: location.pathname }
+    })
   }
 
   const handleSelectAllDraftUpdated = () => {

--- a/frontend/src/views/ChargingEquipment/__tests__/AddEditChargingEquipment.test.jsx
+++ b/frontend/src/views/ChargingEquipment/__tests__/AddEditChargingEquipment.test.jsx
@@ -78,6 +78,10 @@ vi.mock('@/components/BCDataGrid/BCGridEditor', () => ({
   ))
 }))
 
+vi.mock('@/components/ImportDialog', () => ({
+  default: () => <div data-testid="import-dialog">Import Dialog Mock</div>
+}))
+
 const TestWrapper = ({ children }) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
@@ -148,9 +152,7 @@ describe('getNextRegistrationNumber helper', () => {
       { registrationNumber: 'XYZ-0010' }
     ]
 
-    expect(
-      getNextRegistrationNumber('ABC-0003', existingRows)
-    ).toBe('ABC-0006')
+    expect(getNextRegistrationNumber('ABC-0003', existingRows)).toBe('ABC-0006')
   })
 
   it('returns empty string when registration number cannot be parsed', () => {
@@ -225,7 +227,7 @@ describe('AddEditChargingEquipment - Navigation', () => {
     })
 
     useCurrentUser.mockReturnValue({
-      data: { 
+      data: {
         userId: 1,
         organization: { organizationId: 123 }
       },
@@ -285,5 +287,285 @@ describe('AddEditChargingEquipment - Navigation', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       '/compliance-reporting/charging-sites/123'
     )
+  })
+
+  it('navigates back to charging site when returnTo includes charging-sites path', () => {
+    mockLocationState = {
+      returnTo: '/compliance-reporting/charging-sites/456'
+    }
+
+    render(
+      <TestWrapper>
+        <AddEditChargingEquipment />
+      </TestWrapper>
+    )
+
+    fireEvent.click(screen.getByTestId('save-return-btn'))
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/compliance-reporting/charging-sites/456'
+    )
+  })
+
+  it('navigates back to manage FSE when returnTo includes fse path', () => {
+    mockLocationState = {
+      returnTo: '/compliance-reporting/fse'
+    }
+
+    render(
+      <TestWrapper>
+        <AddEditChargingEquipment />
+      </TestWrapper>
+    )
+
+    fireEvent.click(screen.getByTestId('save-return-btn'))
+    expect(mockNavigate).toHaveBeenCalledWith('/compliance-reporting/fse')
+  })
+})
+
+// --------------------
+// AddEditChargingEquipment - Charging Site Pre-population and Locking
+// --------------------
+
+describe('AddEditChargingEquipment - Charging Site Field Behavior', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockLocationState = null
+
+    const { useApiService } = await import('@/services/useApiService')
+    const { useCurrentUser } = await import('@/hooks/useCurrentUser')
+    const {
+      useGetChargingEquipment,
+      useCreateChargingEquipment,
+      useUpdateChargingEquipment,
+      useDeleteChargingEquipment,
+      useChargingEquipmentMetadata,
+      useChargingSites,
+      useOrganizations,
+      useHasAllocationAgreements
+    } = await import('@/hooks/useChargingEquipment')
+
+    useApiService.mockReturnValue({
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} })
+    })
+
+    useCurrentUser.mockReturnValue({
+      data: {
+        userId: 1,
+        organization: { organizationId: 123 }
+      },
+      hasAnyRole: vi.fn(() => false)
+    })
+
+    useGetChargingEquipment.mockReturnValue({
+      data: {
+        chargingEquipmentId: 1,
+        status: 'Draft',
+        chargingSiteId: 456,
+        serialNumber: 'SN001'
+      },
+      isLoading: false,
+      isError: false
+    })
+
+    useChargingEquipmentMetadata.mockReturnValue({
+      statuses: [],
+      levels: [{ levelOfEquipmentId: 1, name: 'Level 2' }],
+      endUseTypes: [{ endUseTypeId: 1, typeName: 'Public' }],
+      endUserTypes: [{ endUserTypeId: 1, typeName: 'Fleet' }],
+      isLoading: false
+    })
+
+    useChargingSites.mockReturnValue({
+      data: [
+        {
+          chargingSiteId: 456,
+          siteName: 'Test Site',
+          latitude: 49.2827,
+          longitude: -123.1207
+        }
+      ],
+      isLoading: false
+    })
+    useOrganizations.mockReturnValue({ data: [], isLoading: false })
+    useHasAllocationAgreements.mockReturnValue({ data: false })
+    useCreateChargingEquipment.mockReturnValue({ mutateAsync: vi.fn() })
+    useUpdateChargingEquipment.mockReturnValue({ mutateAsync: vi.fn() })
+    useDeleteChargingEquipment.mockReturnValue({ mutateAsync: vi.fn() })
+  })
+
+  describe('When accessed from Charging Site page (with chargingSiteId in state)', () => {
+    it('should pre-populate chargingSiteId for new FSE', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/charging-sites/456',
+        chargingSiteId: '456'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      // The component should be rendered (basic smoke test)
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should lock charging site field when chargingSiteId is in state', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/charging-sites/456',
+        chargingSiteId: '456'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      // Component renders successfully with locked state
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should lock charging site field when editing FSE from charging site', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/charging-sites/456',
+        chargingSiteId: '456'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="single" />
+        </TestWrapper>
+      )
+
+      // Component renders with locked field
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+  })
+
+  describe('When accessed from Manage FSE page (without chargingSiteId in state)', () => {
+    it('should NOT pre-populate chargingSiteId for new FSE', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should NOT lock charging site field when no chargingSiteId in state', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      // Component renders with editable field
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should allow editing charging site field when editing FSE from manage FSE', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse'
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="single" />
+        </TestWrapper>
+      )
+
+      // Component renders with editable field
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases and validation', () => {
+    it('should handle chargingSiteId as string and convert to number', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/charging-sites/456',
+        chargingSiteId: '456' // String value
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should handle chargingSiteId as number', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/charging-sites/456',
+        chargingSiteId: 456 // Number value
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should not lock field when chargingSiteId is null', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse',
+        chargingSiteId: null
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should not lock field when chargingSiteId is undefined', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse',
+        chargingSiteId: undefined
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
+
+    it('should not lock field when chargingSiteId is empty string', () => {
+      mockLocationState = {
+        returnTo: '/compliance-reporting/fse',
+        chargingSiteId: ''
+      }
+
+      render(
+        <TestWrapper>
+          <AddEditChargingEquipment mode="bulk" />
+        </TestWrapper>
+      )
+
+      expect(screen.getByTestId('bc-grid-editor')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/views/ChargingEquipment/__tests__/ChargingEquipment.test.jsx
+++ b/frontend/src/views/ChargingEquipment/__tests__/ChargingEquipment.test.jsx
@@ -411,7 +411,9 @@ describe('ChargingEquipment', () => {
     const newFseButton = screen.getByText('New FSE')
     fireEvent.click(newFseButton)
 
-    expect(mockNavigate).toHaveBeenCalledWith('/compliance-reporting/fse/add')
+    expect(mockNavigate).toHaveBeenCalledWith('/compliance-reporting/fse/add', {
+      state: { returnTo: mockPathname }
+    })
   })
 
   it('handles row click for draft equipment with returnTo state', async () => {

--- a/frontend/src/views/ChargingEquipment/_bulkSchema.js
+++ b/frontend/src/views/ChargingEquipment/_bulkSchema.js
@@ -30,7 +30,8 @@ export const bulkChargingEquipmentColDefs = (
   warnings = {},
   actionsOptions = null,
   allowAllocatingOrg = true,
-  showActions = true
+  showActions = true,
+  isChargingSiteLocked = false
 ) => {
   const cols = [validation]
   if (showActions) {
@@ -78,6 +79,7 @@ export const bulkChargingEquipmentColDefs = (
         return true
       },
       editable: (params) =>
+        !isChargingSiteLocked &&
         isEditableByStatus(params) &&
         (!params.data?.chargingEquipmentId || params.data?.status === 'Draft'),
       valueFormatter: (params) => {
@@ -86,12 +88,18 @@ export const bulkChargingEquipmentColDefs = (
         )
         return site ? site.siteName : ''
       },
-      cellStyle: (params) =>
-        StandardCellWarningAndErrors(params, errors, warnings),
-      minWidth: 310,
-      editable: (params) =>
-        isEditableByStatus(params) &&
-        (!params.data?.chargingEquipmentId || params.data?.status === 'Draft')
+      cellStyle: (params) => {
+        const baseStyle = StandardCellWarningAndErrors(params, errors, warnings)
+        if (isChargingSiteLocked) {
+          return {
+            ...baseStyle,
+            backgroundColor: '#f5f5f5',
+            cursor: 'not-allowed'
+          }
+        }
+        return baseStyle
+      },
+      minWidth: 310
     },
     {
       field: 'serialNumber',

--- a/frontend/src/views/ChargingSite/__tests__/components/ChargingSiteFSEGrid.test.jsx
+++ b/frontend/src/views/ChargingSite/__tests__/components/ChargingSiteFSEGrid.test.jsx
@@ -96,7 +96,7 @@ describe('ChargingSiteFSEGrid', () => {
     ).toBeInTheDocument()
   })
 
-  it('handles row click navigation with returnTo state', () => {
+  it('handles row click navigation with returnTo state and chargingSiteId', () => {
     render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
 
     const rowButton = screen.getByText('Row Click')
@@ -105,7 +105,10 @@ describe('ChargingSiteFSEGrid', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       '/compliance-reporting/fse/456/edit',
       {
-        state: { returnTo: mockPathname }
+        state: { 
+          returnTo: mockPathname,
+          chargingSiteId: '123' // Should include siteId for locking
+        }
       }
     )
   })
@@ -119,5 +122,128 @@ describe('ChargingSiteFSEGrid', () => {
 
     render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
     expect(screen.getByText('Row Click')).toBeInTheDocument()
+  })
+
+  describe('New FSE Button', () => {
+    it('renders New FSE button for BCeID users', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      expect(newFSEButton).toBeInTheDocument()
+    })
+
+    it('does not render New FSE button for IDIR users', () => {
+      const idirProps = { ...mockProps, isIDIR: true }
+      render(<ChargingSiteFSEGrid {...idirProps} />, { wrapper })
+
+      const newFSEButton = screen.queryByText('chargingSite:buttons.newFSE')
+      expect(newFSEButton).not.toBeInTheDocument()
+    })
+
+    it('navigates to bulk FSE add page with returnTo and chargingSiteId', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      fireEvent.click(newFSEButton)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/compliance-reporting/fse/add',
+        {
+          state: {
+            returnTo: mockPathname,
+            chargingSiteId: '123'
+          }
+        }
+      )
+    })
+
+    it('includes correct siteId from useParams in navigation state', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      fireEvent.click(newFSEButton)
+
+      const navigationCall = mockNavigate.mock.calls[0]
+      expect(navigationCall[1].state.chargingSiteId).toBe('123')
+    })
+  })
+
+  describe('Navigation State Management', () => {
+    it('passes chargingSiteId when editing FSE from charging site', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      const rowButton = screen.getByText('Row Click')
+      fireEvent.click(rowButton)
+
+      const navigationCall = mockNavigate.mock.calls[0]
+      expect(navigationCall[0]).toBe('/compliance-reporting/fse/456/edit')
+      expect(navigationCall[1].state).toEqual({
+        returnTo: mockPathname,
+        chargingSiteId: '123'
+      })
+    })
+
+    it('preserves current pathname in returnTo state', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      fireEvent.click(newFSEButton)
+
+      const navigationCall = mockNavigate.mock.calls[0]
+      expect(navigationCall[1].state.returnTo).toBe(mockPathname)
+    })
+
+    it('does not navigate when IDIR user clicks row', () => {
+      const idirProps = { ...mockProps, isIDIR: true }
+      render(<ChargingSiteFSEGrid {...idirProps} />, { wrapper })
+
+      const rowButton = screen.getByText('Row Click')
+      fireEvent.click(rowButton)
+
+      // IDIR users should not navigate when clicking rows
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Integration with Charging Site Context', () => {
+    it('uses siteId from URL params for all navigation', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      // Test New FSE navigation
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      fireEvent.click(newFSEButton)
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          state: expect.objectContaining({
+            chargingSiteId: '123'
+          })
+        })
+      )
+    })
+
+    it('maintains consistent siteId across multiple navigations', () => {
+      render(<ChargingSiteFSEGrid {...mockProps} />, { wrapper })
+
+      // Navigate to new FSE
+      const newFSEButton = screen.getByText('chargingSite:buttons.newFSE')
+      fireEvent.click(newFSEButton)
+
+      const firstCall = mockNavigate.mock.calls[0]
+      expect(firstCall[1].state.chargingSiteId).toBe('123')
+
+      // Navigate to edit FSE
+      const rowButton = screen.getByText('Row Click')
+      fireEvent.click(rowButton)
+
+      const secondCall = mockNavigate.mock.calls[1]
+      expect(secondCall[1].state.chargingSiteId).toBe('123')
+
+      // Both should have the same siteId
+      expect(firstCall[1].state.chargingSiteId).toBe(
+        secondCall[1].state.chargingSiteId
+      )
+    })
   })
 })

--- a/frontend/src/views/ChargingSite/components/ChargingSiteFSEGrid.jsx
+++ b/frontend/src/views/ChargingSite/components/ChargingSiteFSEGrid.jsx
@@ -242,11 +242,23 @@ export const ChargingSiteFSEGrid = ({
       if (colId === 'ag-Grid-ControlsColumn') return
       const { chargingEquipmentId } = params.data
       navigate(`${ROUTES.REPORTS.LIST}/fse/${chargingEquipmentId}/edit`, {
-        state: { returnTo: location.pathname }
+        state: {
+          returnTo: location.pathname,
+          chargingSiteId: siteId // Pass siteId to lock the Charging Site field
+        }
       })
     },
-    [navigate, siteId, isIDIR]
+    [navigate, siteId, isIDIR, location.pathname]
   )
+
+  const handleNewFSE = useCallback(() => {
+    navigate(`${ROUTES.REPORTS.LIST}/fse/add`, {
+      state: {
+        returnTo: location.pathname,
+        chargingSiteId: siteId
+      }
+    })
+  }, [navigate, location.pathname, siteId])
 
   // Build context for button configuration
   const buttonContext = useMemo(() => {
@@ -313,6 +325,22 @@ export const ChargingSiteFSEGrid = ({
           onClose={() => setModalData(null)}
           data={modalData}
         />
+        {/* New FSE Button - Only for BCeID users */}
+        {!isIDIR && (
+          <Grid container spacing={2} sx={{ mb: 2 }}>
+            <Grid item xs={12} sm={6} md={3}>
+              <BCButton
+                variant="contained"
+                color="primary"
+                type="button"
+                onClick={handleNewFSE}
+                fullWidth
+              >
+                {t('chargingSite:buttons.newFSE')}
+              </BCButton>
+            </Grid>
+          </Grid>
+        )}
         {/* Dynamic Action Buttons Based on Role */}
         {availableButtons.length > 0 && (
           <Grid container spacing={2} sx={{ mb: 3 }}>


### PR DESCRIPTION
This PR includes the following:
- Aligns Bulk FSE redirect behaviour with single Edit FSE flow
- Preserves entry-point context for save and exit actions
- Pre-populates and locks Charging Site when accessed from site pages

Closes #3642
