### PR TITLE
Hotfix: Fuel code expiry - 3682

### DIFF
--- a/backend/lcfs/db/migrations/versions/2025-12-30-09-00_5897848af3c9.py
+++ b/backend/lcfs/db/migrations/versions/2025-12-30-09-00_5897848af3c9.py
@@ -1,0 +1,34 @@
+"""Add expiry_notification_sent_at column to fuel_code table
+
+Revision ID: 5897848af3c9
+Revises: 7ca5289dff90
+Create Date: 2025-12-30 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5897848af3c9"
+down_revision = "7ca5289dff90"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add column to track when expiry notification was sent
+    # This prevents duplicate notifications from being sent on subsequent scheduler runs
+    op.add_column(
+        "fuel_code",
+        sa.Column(
+            "expiry_notification_sent_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Timestamp when expiry notification email was sent. Used to prevent duplicate notifications.",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fuel_code", "expiry_notification_sent_at")

--- a/backend/lcfs/db/models/fuel/FuelCode.py
+++ b/backend/lcfs/db/models/fuel/FuelCode.py
@@ -15,6 +15,13 @@ from .FuelType import QuantityUnitsEnum
 
 
 class FuelCode(BaseModel, Auditable, EffectiveDates, Versioning):
+    """
+    Contains a list of all fuel codes.
+
+    The expiry_notification_sent_at field tracks when an expiry notification
+    email was sent for this fuel code. This prevents duplicate notifications
+    from being sent on subsequent scheduler runs.
+    """
     __tablename__ = "fuel_code"
     __table_args__ = {"comment": "Contains a list of all of fuel codes"}
 
@@ -87,6 +94,11 @@ class FuelCode(BaseModel, Auditable, EffectiveDates, Versioning):
     )
     former_company = Column(String(500), nullable=True, comment="Former company")
     notes = Column(String(1000), nullable=True, comment="Notes")
+    expiry_notification_sent_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp when expiry notification email was sent. Used to prevent duplicate notifications.",
+    )
 
     # Define the relationships
     fuel_code_status = relationship(

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -887,3 +887,21 @@ async def test_get_fuel_code_history(fuel_code_repo, mock_db):
 
     result = await fuel_code_repo.get_fuel_code_history(1, version=0)
     assert result == history
+
+
+@pytest.mark.anyio
+async def test_mark_fuel_codes_notified(fuel_code_repo, mock_db):
+    """Test marking fuel codes as notified"""
+    fuel_code_ids = [1, 2, 3]
+
+    await fuel_code_repo.mark_fuel_codes_notified(fuel_code_ids)
+
+    mock_db.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_fuel_codes_notified_empty_list(fuel_code_repo, mock_db):
+    """Test marking fuel codes as notified with empty list does nothing"""
+    await fuel_code_repo.mark_fuel_codes_notified([])
+
+    mock_db.execute.assert_not_called()

--- a/backend/lcfs/web/api/fuel_code/services.py
+++ b/backend/lcfs/web/api/fuel_code/services.py
@@ -391,6 +391,9 @@ class FuelCodeServices:
             if not fuel_code_data.notes:
                 raise ValueError("Notes is required")
 
+        # Store original expiration_date to detect changes
+        original_expiration_date = fuel_code.expiration_date
+
         for field, value in fuel_code_data.model_dump(
             exclude={
                 "feedstock_fuel_transport_modes",
@@ -400,6 +403,11 @@ class FuelCodeServices:
             }
         ).items():
             setattr(fuel_code, field, value)
+
+        # If expiration_date changed, clear the notification timestamp
+        # so a new expiry notification will be sent
+        if fuel_code.expiration_date != original_expiration_date:
+            fuel_code.expiry_notification_sent_at = None
 
         fuel_code.feedstock_fuel_transport_modes.clear()
 


### PR DESCRIPTION
- added new date tracking field to fuel code to prevent multiple emails being sent for expired fuel codes
- when expiration date is updated on fuel code, notification sent date is reset
- updated tests