### PR TITLE
Fix: Update FSE map status label - 3751

### DIFF
--- a/frontend/src/assets/locales/en/finalSupplyEquipment.json
+++ b/frontend/src/assets/locales/en/finalSupplyEquipment.json
@@ -94,7 +94,7 @@
     "submitted": "Submitted",
     "draft": "Draft",
     "updated": "Updated",
-    "retired": "Retired",
+    "decommissioned": "Decommissioned",
     "searchEquipment": "Search equipment...",
     "noEquipmentFound": "No equipment found",
     "showFewerResults": "Show fewer results",

--- a/frontend/src/views/FinalSupplyEquipments/components/constants.js
+++ b/frontend/src/views/FinalSupplyEquipments/components/constants.js
@@ -97,7 +97,7 @@ export const STATUS_CONFIG = {
     color: theme.colors.error,
     bg: theme.colors.errorBg,
     icon: BlockIcon,
-    labelKey: 'map.retired',
+    labelKey: 'map.decommissioned',
     markerColor: 'red'
   }
 }


### PR DESCRIPTION
This PR includes the following:
- Update map label from "Retired" to "Decommissioned"

Closes #3751
