### PR TITLE
Hotfix: FSE Site Status Changes, FSE Inclusion

### DIFF
--- a/backend/lcfs/web/api/charging_site/validation.py
+++ b/backend/lcfs/web/api/charging_site/validation.py
@@ -84,10 +84,10 @@ class ChargingSiteValidation:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Validation for authorization failed.",
             )
-        if delete and charging_site.status.status != "Draft":
+        if delete and charging_site.status.status not in ["Draft", "Submitted"]:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Only charging sites with 'Draft' status can be deleted.",
+                detail="Only charging sites with 'Draft' or 'Submitted' status can be deleted.",
             )
         # Validate duplicate site name on update
         if data and data.site_name:

--- a/frontend/src/assets/locales/en/finalSupplyEquipment.json
+++ b/frontend/src/assets/locales/en/finalSupplyEquipment.json
@@ -29,6 +29,7 @@
   ],
   "newFinalSupplyEquipmentBtn": "New final supply equipment",
   "noFinalSupplyEquipmentsFound": "No final supply equipments found",
+  "noFseLinkedToReport": "No final supply equipment has been added to this report yet. Click here to add validated FSE.",
   "noChargingEquipmentMessage": "Charging sites and final supply equipment must first be created in the FSE maintenance system to report them.",
   "defaultFromDate": "Default from",
   "defaultToDate": "Default to",

--- a/frontend/src/views/ChargingSite/components/buttonConfig.jsx
+++ b/frontend/src/views/ChargingSite/components/buttonConfig.jsx
@@ -309,13 +309,16 @@ const BUTTON_RULES = {
     [USER_TYPES.BCEID_USER]: [
       'createFSE',
       'selectAllDraft',
+      'selectAllSubmitted',
       'returnSelectedToDraft',
       'clearFilters'
     ],
     [USER_TYPES.BCEID_MANAGER]: [
       'createFSE',
       'selectAllDraft',
+      'selectAllSubmitted',
       'setSelectedAsSubmitted',
+      'returnSelectedToDraft',
       'selectAllValidated',
       'setToDecommission',
       'clearFilters'
@@ -356,8 +359,8 @@ function shouldShowButton(buttonName, context) {
       // Only show for non-government users (BCeID)
       return !context.isGovernmentUser
     case 'selectAllSubmitted':
-      // Only show if there are submitted equipment
-      return context.isGovernmentUser
+      // Show for all users if there are submitted equipment
+      return true
     case 'selectAllDraft':
     case 'selectAllValidated':
       if (!context.isGovernmentUser) {
@@ -381,10 +384,8 @@ function shouldShowButton(buttonName, context) {
       )
 
     case 'returnSelectedToDraft':
-      // BCeID users can only modify their own organization's equipment
-      if (!context.isGovernmentUser) {
-        return false
-      }
+      // Both BCeID and government users can return equipment to Draft
+      // BCeID users can modify their own organization's equipment
       return (
         (context.selectedRows.length > 0 && context.canReturnToDraft) ||
         context.isGovernmentUser

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -273,13 +273,17 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.finalSupplyEquipments,
         useFetch: useGetFSEReportingList,
         component: (data) =>
-          data.finalSupplyEquipments.length > 0 && (
+          data.finalSupplyEquipments.length > 0 ? (
             <FinalSupplyEquipmentSummary
               status={currentStatus}
               data={data}
               organizationId={complianceReportData?.report?.organizationId}
             />
-          )
+          ) : data.hasChargingEquipment ? (
+            <BCTypography variant="body4" color="text">
+              {t('finalSupplyEquipment:noFseLinkedToReport')}
+            </BCTypography>
+          ) : null
       },
       {
         name: t('report:activityLists.allocationAgreements'),
@@ -427,15 +431,25 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
 
       const hasRealData = !isArrayEmpty(scheduleData)
 
+      // For FSE section: show if organization has any charging equipment,
+      // not just if there's FSE linked to the current report group.
+      // This ensures users can add FSE to supplemental reports even when
+      // FSE was deleted and recreated after the original report.
+      const hasFSECapability =
+        activity.key === 'finalSupplyEquipments' &&
+        dataResult?.data?.hasChargingEquipment === true
+
       // Show if has data OR if in editing mode OR if it was recently edited
+      // OR (for FSE) if organization has charging equipment
       const shouldShow =
         hasRealData ||
+        hasFSECapability ||
         activity.key === 'supportingDocs' ||
         expandedSchedule === activity.key
 
       accordionsData.set(panelId, {
         shouldShow,
-        hasData: hasRealData,
+        hasData: hasRealData || hasFSECapability,
         activity,
         data: dataResult?.data,
         isLoading: dataResult?.isLoading,


### PR DESCRIPTION
Issue 1: FSE Section Missing in Draft Supplemental Report

- Fixed FSE section visibility logic to show when organization has any charging equipment (hasChargingEquipment flag), not just when there are existing FSE records for the current report
- Added noFseLinkedToReport message when FSE section is visible but no equipment is linked yet

Issue 2: Charging Site Status - Cannot change Submitted → Draft

- Enabled BCeID users to return equipment from Submitted to Draft status
- Added calculate_site_status_from_equipment method to recalculate site status based on equipment statuses when returning to Draft

Issue 3: Cannot delete incorrect Charging Sites

- Updated validation to allow deletion of both "Draft" and "Submitted" status charging sites (previously only "Draft")