### PR TITLE
fix: recorded/approved dates show Pacific time in transaction export

### DIFF
--- a/backend/lcfs/tests/transaction/test_transaction_services.py
+++ b/backend/lcfs/tests/transaction/test_transaction_services.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from math import ceil
 from unittest.mock import AsyncMock, MagicMock
 
@@ -122,3 +122,96 @@ async def test_export_transactions(transactions_service):
     assert "From Org Comment" in content_str
     assert "To Org Comment" in content_str
     assert "Government Comment" in content_str
+
+
+# -- _to_pacific / recorded-date export tests ----------------------------------
+
+
+class TestToPacific:
+    """Unit tests for TransactionsService._to_pacific."""
+
+    def test_naive_utc_before_midnight_stays_same_day(self):
+        """7 AM UTC on Feb 10 = 11 PM PST on Feb 9 — should roll back a day."""
+        dt = datetime(2026, 2, 10, 7, 0, 0)  # naive, treated as UTC
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-02-09"
+
+    def test_naive_utc_after_8am_stays_same_day(self):
+        """8 AM UTC on Feb 10 = midnight PST on Feb 10 — same calendar day."""
+        dt = datetime(2026, 2, 10, 8, 0, 0)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-02-10"
+
+    def test_naive_utc_midnight_rolls_back(self):
+        """Midnight UTC on Feb 11 = 4 PM PST on Feb 10."""
+        dt = datetime(2026, 2, 11, 0, 0, 0)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-02-10"
+
+    def test_aware_utc_midnight_rolls_back(self):
+        """Same as above but with an explicit UTC tzinfo."""
+        dt = datetime(2026, 2, 11, 0, 0, 0, tzinfo=timezone.utc)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-02-10"
+
+    def test_naive_utc_late_afternoon_pacific(self):
+        """11:59 PM UTC on Feb 10 = 3:59 PM PST on Feb 10 — same day."""
+        dt = datetime(2026, 2, 10, 23, 59, 0)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-02-10"
+
+    def test_pdt_summer_offset(self):
+        """During PDT (UTC-7): 6:59 AM UTC on Jul 15 = 11:59 PM PDT on Jul 14."""
+        dt = datetime(2026, 7, 15, 6, 59, 0)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-07-14"
+
+    def test_pdt_summer_after_7am(self):
+        """During PDT (UTC-7): 7 AM UTC on Jul 15 = midnight PDT on Jul 15."""
+        dt = datetime(2026, 7, 15, 7, 0, 0)
+        result = TransactionsService._to_pacific(dt)
+        assert result.strftime("%Y-%m-%d") == "2026-07-15"
+
+
+@pytest.mark.anyio
+async def test_export_recorded_date_utc_midnight(transactions_service):
+    """A transfer recorded at midnight UTC should export as the previous Pacific day."""
+    mock_transactions = [
+        MagicMock(
+            transaction_type="Transfer",
+            transaction_id=99,
+            compliance_period="2026",
+            from_organization="Org X",
+            to_organization="Org Y",
+            quantity=4338,
+            price_per_unit=189.40,
+            category="A",
+            status="Recorded",
+            transaction_effective_date=datetime(2026, 2, 10, 8, 0, 0),
+            # Midnight UTC Feb 11 = 4 PM PST Feb 10
+            recorded_date=datetime(2026, 2, 11, 0, 0, 0),
+            approved_date=None,
+            from_org_comment=None,
+            to_org_comment=None,
+            government_comment=None,
+        )
+    ]
+    transactions_service.repo.get_transactions_paginated.return_value = (
+        mock_transactions,
+        1,
+    )
+
+    response = await transactions_service.export_transactions(export_format="csv")
+
+    content = b""
+    async for chunk in response.body_iterator:
+        content += chunk
+    content_str = content.decode("utf-8")
+
+    # recorded_date should show Feb 10 (Pacific), not Feb 11 (UTC)
+    lines = content_str.strip().split("\n")
+    data_line = lines[1]  # first data row after header
+    assert "2026-02-10" in data_line
+    # Make sure Feb 11 does NOT appear as the recorded date
+    # (effective date is also 2026-02-10 so only that date should appear)
+    assert "2026-02-11" not in data_line


### PR DESCRIPTION
## Summary
- Cherry-pick of `b1e5258ae` from develop
- Converts recorded_date and approved_date to Pacific time (America/Vancouver) before formatting in transaction CSV export
- Adds `_to_pacific` helper and comprehensive tests for timezone conversion

## Test plan
- [ ] Export transactions CSV and verify recorded/approved dates reflect Pacific time
- [ ] Run transaction service tests