### PR TITLE
Add site-scoped serial number validation and Serial # column to kWh template

### DIFF
--- a/backend/lcfs/tests/charging_equipment/test_charging_equipment_importer.py
+++ b/backend/lcfs/tests/charging_equipment/test_charging_equipment_importer.py
@@ -1,27 +1,42 @@
 from lcfs.web.api.charging_equipment.importer import _DuplicateSerialTracker
 
 
-def test_duplicate_tracker_detects_file_duplicates():
+def test_duplicate_tracker_detects_file_duplicates_same_site():
     tracker = _DuplicateSerialTracker()
-    assert tracker.is_duplicate("ABC123") is False  # first occurrence allowed
+    assert tracker.is_duplicate("ABC123", 1) is False  # first occurrence allowed
     assert tracker.summary_message() is None
-    assert tracker.is_duplicate("abc123") is True  # case-insensitive duplicate
+    assert tracker.is_duplicate("abc123", 1) is True  # case-insensitive duplicate at same site
     assert (
         tracker.summary_message()
         == "1 record with duplicate serial numbers was not uploaded."
     )
 
 
-def test_duplicate_tracker_existing_serials_blocked():
-    tracker = _DuplicateSerialTracker(existing_serials={"SER-9"})
-    assert tracker.is_duplicate("SER-9") is True
+def test_duplicate_tracker_allows_same_serial_different_site():
+    """Same serial number at a different charging site should be allowed."""
+    tracker = _DuplicateSerialTracker()
+    assert tracker.is_duplicate("ABC123", 1) is False
+    assert tracker.is_duplicate("ABC123", 2) is False  # different site → allowed
+    assert tracker.summary_message() is None
+
+
+def test_duplicate_tracker_existing_serials_blocked_same_site():
+    tracker = _DuplicateSerialTracker(existing_serials=[("SER-9", 10)])
+    assert tracker.is_duplicate("SER-9", 10) is True  # same site → blocked
     assert (
         tracker.summary_message()
         == "1 record with duplicate serial numbers was not uploaded."
     )
     # Subsequent duplicates continue to increment
-    assert tracker.is_duplicate("ser-9") is True
+    assert tracker.is_duplicate("ser-9", 10) is True
     assert (
         tracker.summary_message()
         == "2 records with duplicate serial numbers were not uploaded."
     )
+
+
+def test_duplicate_tracker_existing_serials_allowed_different_site():
+    """Existing serial at a different site should not block the upload."""
+    tracker = _DuplicateSerialTracker(existing_serials=[("SER-9", 10)])
+    assert tracker.is_duplicate("SER-9", 20) is False  # different site → allowed
+    assert tracker.summary_message() is None

--- a/backend/lcfs/tests/charging_equipment/test_charging_equipment_repo.py
+++ b/backend/lcfs/tests/charging_equipment/test_charging_equipment_repo.py
@@ -67,18 +67,18 @@ async def test_get_charging_equipment_by_id_not_found(repo, mock_db):
 
 @pytest.mark.anyio
 async def test_get_serial_numbers_for_organization(repo, mock_db):
-    """Serial numbers for org should be normalized and deduplicated."""
+    """Serial numbers for org should be normalized, paired with site_id, and deduplicated."""
     mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [
-        "SER-1",
-        " ser-2 ",
-        None,
+    mock_result.all.return_value = [
+        ("SER-1", 10),
+        (" ser-2 ", 20),
+        (None, 30),
     ]
     mock_db.execute.return_value = mock_result
 
     serials = await repo.get_serial_numbers_for_organization(5)
 
-    assert serials == {"SER-1", "SER-2"}
+    assert serials == {("SER-1", 10), ("SER-2", 20)}
     mock_db.execute.assert_called_once()
 
 

--- a/backend/lcfs/tests/final_supply_equipment/test_fse_reporting_export.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_fse_reporting_export.py
@@ -66,6 +66,7 @@ def _make_exporter(fse_rows=None, report_found=True, group_uuid="group-abc"):
 def _fse_row(
     registration="ORG-AAAA1A-001",
     site_name="Charge Site 1",
+    serial_number="SN-12345",
     supply_from=datetime.date(2024, 1, 1),
     supply_to=datetime.date(2024, 12, 31),
     kwh_usage=1500.0,
@@ -76,6 +77,7 @@ def _fse_row(
     row = MagicMock()
     row.registration_number = registration
     row.site_name = site_name
+    row.serial_number = serial_number
     row.supply_from_date = supply_from
     row.supply_to_date = supply_to
     row.kwh_usage = kwh_usage
@@ -153,12 +155,16 @@ def test_headers_second_column_is_registration():
     assert HEADERS[1] == "Registration #"
 
 
+def test_headers_third_column_is_serial():
+    assert HEADERS[2] == "Serial #"
+
+
 def test_header_labels():
     """Spot-check all header labels."""
-    assert HEADERS[2] == "Dates of supply from"
-    assert HEADERS[3] == "Dates of supply to"
-    assert HEADERS[4] == "kWh usage"
-    assert HEADERS[5] == "Compliance notes"
+    assert HEADERS[3] == "Dates of supply from"
+    assert HEADERS[4] == "Dates of supply to"
+    assert HEADERS[5] == "kWh usage"
+    assert HEADERS[6] == "Compliance notes"
 
 
 def test_column_count_matches_headers():
@@ -184,6 +190,7 @@ def _sample_row():
     return [
         "Charge Site 1",
         "ORG-001",
+        "SN-12345",
         datetime.date(2024, 1, 1),
         datetime.date(2024, 12, 31),
         500,
@@ -220,42 +227,57 @@ def test_registration_cell_is_locked():
     assert ws.cell(row=2, column=2).protection.locked is True
 
 
-def test_editable_columns_are_unlocked():
-    """Cols C–F (dates, kWh, notes) must be unlocked for existing data rows."""
+def test_serial_cell_is_locked():
+    """Col C (serial #) must be locked for existing data rows."""
     exp = _make_exporter()
     period = _compliance_period()
     wb = exp._build_workbook([_sample_row()], period)
     ws = wb[FSE_UPDATE_SHEETNAME]
-    for col in (3, 4, 5, 6):
+    assert ws.cell(row=2, column=3).protection.locked is True
+
+
+def test_editable_columns_are_unlocked():
+    """Cols D–G (dates, kWh, notes) must be unlocked for existing data rows."""
+    exp = _make_exporter()
+    period = _compliance_period()
+    wb = exp._build_workbook([_sample_row()], period)
+    ws = wb[FSE_UPDATE_SHEETNAME]
+    for col in (4, 5, 6, 7):
         assert ws.cell(row=2, column=col).protection.locked is False, (
             f"Column {col} should be unlocked"
         )
 
 
 def test_empty_rows_for_new_entries_are_unlocked():
-    """The 500 empty rows appended after data rows must all be unlocked."""
+    """The 500 empty rows appended after data rows must be unlocked (except Serial #)."""
     exp = _make_exporter()
     period = _compliance_period()
     wb = exp._build_workbook([_sample_row()], period)
     ws = wb[FSE_UPDATE_SHEETNAME]
     # Data rows start at row 2; one data row → first empty row is row 3
     first_empty = 3
-    for col in range(1, 7):
+    for col in range(1, 8):
         cell = ws.cell(row=first_empty, column=col)
-        assert cell.protection.locked is False, (
-            f"Empty row col {col} should be unlocked"
-        )
+        if col == 3:
+            # Serial # column is always locked
+            assert cell.protection.locked is True, (
+                "Empty row Serial # col should be locked"
+            )
+        else:
+            assert cell.protection.locked is False, (
+                f"Empty row col {col} should be unlocked"
+            )
 
 
 def test_empty_rows_date_columns_have_date_format():
-    """Empty rows' date columns (C, D) must carry the date number format."""
+    """Empty rows' date columns (D, E) must carry the date number format."""
     exp = _make_exporter()
     period = _compliance_period()
     wb = exp._build_workbook([], period)
     ws = wb[FSE_UPDATE_SHEETNAME]
     # No data rows → first empty row is row 2
-    assert ws.cell(row=2, column=3).number_format == "yyyy-mm-dd"
     assert ws.cell(row=2, column=4).number_format == "yyyy-mm-dd"
+    assert ws.cell(row=2, column=5).number_format == "yyyy-mm-dd"
 
 
 def test_sheet_protection_is_enabled():
@@ -271,9 +293,9 @@ def test_date_columns_have_date_number_format():
     period = _compliance_period()
     wb = exp._build_workbook([_sample_row()], period)
     ws = wb[FSE_UPDATE_SHEETNAME]
-    # Col C = 3, Col D = 4
-    assert ws.cell(row=2, column=3).number_format == "yyyy-mm-dd"
+    # Col D = 4, Col E = 5
     assert ws.cell(row=2, column=4).number_format == "yyyy-mm-dd"
+    assert ws.cell(row=2, column=5).number_format == "yyyy-mm-dd"
 
 
 def test_kwh_column_has_numeric_format():
@@ -281,8 +303,8 @@ def test_kwh_column_has_numeric_format():
     period = _compliance_period()
     wb = exp._build_workbook([_sample_row()], period)
     ws = wb[FSE_UPDATE_SHEETNAME]
-    # Col E = 5
-    assert ws.cell(row=2, column=5).number_format == "#,##0"
+    # Col F = 6
+    assert ws.cell(row=2, column=6).number_format == "#,##0"
 
 
 def test_data_validators_are_added():
@@ -330,6 +352,14 @@ async def test_load_fse_data_registration_is_second_column():
 
 
 @pytest.mark.anyio
+async def test_load_fse_data_serial_is_third_column():
+    row = _fse_row(serial_number="SN-99")
+    exporter = _make_exporter(fse_rows=[row])
+    rows = await exporter._load_fse_data(1, "group-abc")
+    assert rows[0][2] == "SN-99"
+
+
+@pytest.mark.anyio
 async def test_load_fse_data_converts_datetime_to_date():
     """datetime objects from the DB must be converted to plain date."""
     dt_from = datetime.datetime(2024, 3, 15, 0, 0, 0)
@@ -339,8 +369,8 @@ async def test_load_fse_data_converts_datetime_to_date():
     exporter = _make_exporter(fse_rows=[row])
     rows = await exporter._load_fse_data(1, "group-abc")
 
-    assert rows[0][2] == datetime.date(2024, 3, 15)
-    assert rows[0][3] == datetime.date(2024, 9, 30)
+    assert rows[0][3] == datetime.date(2024, 3, 15)
+    assert rows[0][4] == datetime.date(2024, 9, 30)
 
 
 @pytest.mark.anyio
@@ -349,7 +379,7 @@ async def test_load_fse_data_kwh_none_becomes_zero_for_active_rows():
     row = _fse_row(kwh_usage=None)
     exporter = _make_exporter(fse_rows=[row])
     rows = await exporter._load_fse_data(1, "group-abc")
-    assert rows[0][4] == 0
+    assert rows[0][5] == 0
 
 
 @pytest.mark.anyio
@@ -361,10 +391,11 @@ async def test_load_fse_data_inactive_row_shows_only_site_and_reg():
 
     assert rows[0][0] == "Charge Site 1"   # site name preserved
     assert rows[0][1] == "ORG-AAAA1A-001"  # reg # preserved
-    assert rows[0][2] is None              # from date blank
-    assert rows[0][3] is None              # to date blank
-    assert rows[0][4] is None              # kWh blank
-    assert rows[0][5] is None              # notes blank
+    assert rows[0][2] == "SN-12345"        # serial # preserved
+    assert rows[0][3] is None              # from date blank
+    assert rows[0][4] is None              # to date blank
+    assert rows[0][5] is None              # kWh blank
+    assert rows[0][6] is None              # notes blank
 
 
 @pytest.mark.anyio
@@ -377,8 +408,9 @@ async def test_load_fse_data_other_report_group_shows_only_site_and_reg():
 
     assert rows[0][0] == "Charge Site 1"
     assert rows[0][1] == "ORG-AAAA1A-001"
-    assert rows[0][2] is None
-    assert rows[0][4] is None
+    assert rows[0][2] == "SN-12345"        # serial # preserved
+    assert rows[0][3] is None
+    assert rows[0][5] is None
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/final_supply_equipment/test_fse_reporting_importer.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_fse_reporting_importer.py
@@ -440,12 +440,12 @@ async def _run_import(rows: list, fse_repo_override=None):
     return progress_records
 
 
-# col layout: [site_name, reg_num, from, to, kwh, notes]
+# col layout: [site_name, reg_num, serial#, from, to, kwh, notes]
 
 @pytest.mark.anyio
 async def test_row_missing_registration_is_rejected():
     """Empty registration number → rejected."""
-    rows = [["Site A", None, "2024-01-01", "2024-12-31", 500, "note"]]
+    rows = [["Site A", None, "SN-1", "2024-01-01", "2024-12-31", 500, "note"]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["rejected"] == 1
@@ -455,7 +455,7 @@ async def test_row_missing_registration_is_rejected():
 @pytest.mark.anyio
 async def test_row_invalid_kwh_is_rejected():
     """Non-numeric kWh value → rejected."""
-    rows = [["Site A", "REG-001", "2024-01-01", "2024-12-31", "NOT_A_NUMBER", "note"]]
+    rows = [["Site A", "REG-001", "SN-1", "2024-01-01", "2024-12-31", "NOT_A_NUMBER", "note"]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["rejected"] == 1
@@ -465,7 +465,7 @@ async def test_row_invalid_kwh_is_rejected():
 @pytest.mark.anyio
 async def test_row_negative_kwh_is_rejected():
     """Negative kWh value → rejected."""
-    rows = [["Site A", "REG-001", "2024-01-01", "2024-12-31", -100, "note"]]
+    rows = [["Site A", "REG-001", "SN-1", "2024-01-01", "2024-12-31", -100, "note"]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["rejected"] == 1
@@ -474,7 +474,7 @@ async def test_row_negative_kwh_is_rejected():
 @pytest.mark.anyio
 async def test_row_invalid_date_is_rejected():
     """Unparseable 'from' date → rejected."""
-    rows = [["Site A", "REG-001", "not-a-date", "2024-12-31", 500, "note"]]
+    rows = [["Site A", "REG-001", "SN-1", "not-a-date", "2024-12-31", 500, "note"]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["rejected"] == 1
@@ -483,7 +483,7 @@ async def test_row_invalid_date_is_rejected():
 @pytest.mark.anyio
 async def test_row_inverted_date_range_is_rejected():
     """supply_from > supply_to → rejected."""
-    rows = [["Site A", "REG-001", "2024-12-31", "2024-01-01", 500, "note"]]
+    rows = [["Site A", "REG-001", "SN-1", "2024-12-31", "2024-01-01", 500, "note"]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["rejected"] == 1
@@ -496,7 +496,7 @@ async def test_row_registration_not_found_is_rejected():
     fse_repo.get_charging_equipment_by_registration_number = AsyncMock(
         return_value=None
     )
-    rows = [["Site A", "UNKNOWN-REG", "2024-01-01", "2024-12-31", 500, "note"]]
+    rows = [["Site A", "UNKNOWN-REG", "SN-1", "2024-01-01", "2024-12-31", 500, "note"]]
     records = await _run_import(rows, fse_repo_override=fse_repo)
     final = records[-1]
     assert final["rejected"] == 1
@@ -519,7 +519,7 @@ async def test_valid_row_existing_record_is_updated_and_activated():
     fse_repo.get_fse_reporting_record_for_group = AsyncMock(return_value=existing)
     fse_repo.bulk_update_fse_reporting_record = AsyncMock(return_value=None)
 
-    rows = [["Site A", "ORG-001-001", "2024-01-01", "2024-12-31", 500, "good note"]]
+    rows = [["Site A", "ORG-001-001", "SN-1", "2024-01-01", "2024-12-31", 500, "good note"]]
     records = await _run_import(rows, fse_repo_override=fse_repo)
     final = records[-1]
 
@@ -558,7 +558,7 @@ async def test_row_all_editable_empty_with_existing_record_calls_deactivate():
     fse_repo.bulk_update_fse_reporting_record = AsyncMock(return_value=None)
 
     # All editable columns blank: no from, no to, no kWh, no notes
-    rows = [["Site A", "ORG-001-001", None, None, None, None]]
+    rows = [["Site A", "ORG-001-001", "SN-1", None, None, None, None]]
     records = await _run_import(rows, fse_repo_override=fse_repo)
 
     fse_repo.bulk_update_fse_reporting_record.assert_called_once()
@@ -584,7 +584,7 @@ async def test_row_all_editable_empty_no_existing_record_is_skipped():
     fse_repo.get_fse_reporting_record_for_group = AsyncMock(return_value=None)
     fse_repo.bulk_update_fse_reporting_record = AsyncMock(return_value=None)
 
-    rows = [["Site A", "ORG-001-001", None, None, None, None]]
+    rows = [["Site A", "ORG-001-001", "SN-1", None, None, None, None]]
     records = await _run_import(rows, fse_repo_override=fse_repo)
     final = records[-1]
 
@@ -612,7 +612,7 @@ async def test_row_note_only_activates_row_with_zero_kwh():
     fse_repo.get_fse_reporting_record_for_group = AsyncMock(return_value=existing)
     fse_repo.bulk_update_fse_reporting_record = AsyncMock(return_value=None)
 
-    rows = [["Site A", "ORG-001-001", None, None, None, "Just a note"]]
+    rows = [["Site A", "ORG-001-001", "SN-1", None, None, None, "Just a note"]]
     records = await _run_import(rows, fse_repo_override=fse_repo)
     final = records[-1]
 
@@ -626,7 +626,7 @@ async def test_row_note_only_activates_row_with_zero_kwh():
 @pytest.mark.anyio
 async def test_fully_blank_row_is_silently_skipped():
     """Rows where every cell is None are silently ignored (not counted)."""
-    rows = [[None, None, None, None, None, None]]
+    rows = [[None, None, None, None, None, None, None]]
     records = await _run_import(rows)
     final = records[-1]
     assert final["updated"] == 0
@@ -652,9 +652,9 @@ async def test_mixed_rows_counters_are_accurate():
     fse_repo.bulk_update_fse_reporting_record = AsyncMock(return_value=None)
 
     rows = [
-        ["Site A", "ORG-001", "2024-01-01", "2024-12-31", 300, "ok"],     # updated
-        ["Site A", "ORG-001", None, None, None, None],                     # deactivated (also counted as updated)
-        [None, None, "2024-01-01", "2024-12-31", 100, "no reg"],           # rejected
+        ["Site A", "ORG-001", "SN-1", "2024-01-01", "2024-12-31", 300, "ok"],     # updated
+        ["Site A", "ORG-001", "SN-1", None, None, None, None],                     # deactivated (also counted as updated)
+        [None, None, None, "2024-01-01", "2024-12-31", 100, "no reg"],             # rejected
     ]
     records = await _run_import(rows, fse_repo_override=fse_repo)
     final = records[-1]

--- a/backend/lcfs/web/api/charging_equipment/importer.py
+++ b/backend/lcfs/web/api/charging_equipment/importer.py
@@ -376,7 +376,7 @@ async def import_async(
                                         f"Row {row_idx}: Intended User '{clean}' not found; skipping this value"
                                     )
 
-                        if duplicate_tracker.is_duplicate(serial_number):
+                        if duplicate_tracker.is_duplicate(serial_number, charging_site_id):
                             rejected += 1
                             continue
 
@@ -485,31 +485,39 @@ async def _update_progress(
 
 class _DuplicateSerialTracker:
     """
-    Tracks duplicate serial numbers within a single upload while
-    considering existing records for an organization.
+    Tracks duplicate serial numbers *per charging site* within a single upload
+    while considering existing records for an organization.
+
+    Duplicate serial numbers are only blocked when they occur within the same
+    Charging Site.  The same serial number at a different site is allowed
+    (equipment may be relocated between sites).
     """
 
-    def __init__(self, existing_serials: Iterable[str] | None = None) -> None:
-        normalized_existing: set[str] = set()
-        for serial in existing_serials or []:
+    def __init__(
+        self, existing_serials: Iterable[tuple[str, int]] | None = None
+    ) -> None:
+        # Store as set of (normalized_serial, charging_site_id) tuples
+        normalized_existing: set[tuple[str, int]] = set()
+        for serial, site_id in existing_serials or []:
             normalized = _normalize_serial(serial)
             if normalized:
-                normalized_existing.add(normalized)
+                normalized_existing.add((normalized, site_id))
         self._existing_serials = normalized_existing
-        self._current_upload_serials: set[str] = set()
+        self._current_upload_serials: set[tuple[str, int]] = set()
         self._duplicate_count = 0
 
-    def is_duplicate(self, serial_number) -> bool:
+    def is_duplicate(self, serial_number, charging_site_id: int) -> bool:
         normalized = _normalize_serial(serial_number)
         if not normalized:
             return False
+        key = (normalized, charging_site_id)
         if (
-            normalized in self._existing_serials
-            or normalized in self._current_upload_serials
+            key in self._existing_serials
+            or key in self._current_upload_serials
         ):
             self._duplicate_count += 1
             return True
-        self._current_upload_serials.add(normalized)
+        self._current_upload_serials.add(key)
         return False
 
     def summary_message(self) -> str | None:

--- a/backend/lcfs/web/api/charging_equipment/repo.py
+++ b/backend/lcfs/web/api/charging_equipment/repo.py
@@ -864,13 +864,20 @@ class ChargingEquipmentRepository:
     @repo_handler
     async def get_serial_numbers_for_organization(
         self, organization_id: int
-    ) -> set[str]:
+    ) -> set[tuple[str, int]]:
         """
-        Retrieve serial numbers for all charging equipment owned by the organization.
+        Retrieve (serial_number, charging_site_id) pairs for all charging
+        equipment owned by the organization.
         Limited to non-deleted equipment and latest site versions.
+
+        Duplicate serial numbers are scoped per charging site — the same
+        serial at a different site is allowed.
         """
         stmt = (
-            select(ChargingEquipment.serial_number)
+            select(
+                ChargingEquipment.serial_number,
+                ChargingEquipment.charging_site_id,
+            )
             .join(
                 ChargingSite,
                 ChargingEquipment.charging_site_id == ChargingSite.charging_site_id,
@@ -883,12 +890,13 @@ class ChargingEquipmentRepository:
         )
         stmt = self._apply_latest_site_filter(stmt)
         result = await self.db.execute(stmt)
-        normalized = set()
-        for serial in result.scalars().all():
+        normalized: set[tuple[str, int]] = set()
+        for row in result.all():
+            serial, site_id = row
             if isinstance(serial, str):
                 clean = serial.strip()
                 if clean:
-                    normalized.add(clean.upper())
+                    normalized.add((clean.upper(), site_id))
         return normalized
 
     @repo_handler

--- a/backend/lcfs/web/api/final_supply_equipment/fse_reporting_export.py
+++ b/backend/lcfs/web/api/final_supply_equipment/fse_reporting_export.py
@@ -21,13 +21,14 @@ FSE_UPDATE_SHEETNAME = "FSE"
 HEADERS = [
     "Site name",
     "Registration #",
+    "Serial #",
     "Dates of supply from",
     "Dates of supply to",
     "kWh usage",
     "Compliance notes",
 ]
 
-COLUMN_WIDTHS = [25, 18, 22, 22, 14, 40]
+COLUMN_WIDTHS = [25, 18, 18, 22, 22, 14, 40]
 
 
 class FSEReportingExporter:
@@ -101,11 +102,13 @@ class FSEReportingExporter:
                 not getattr(record, "is_active", True)
                 or record_group != compliance_report_group_uuid
             )
+            serial_number = getattr(record, "serial_number", None) or ""
             if is_inactive:
                 rows.append(
                     [
                         getattr(record, "site_name", None) or "",
                         record.registration_number or "",
+                        serial_number,
                         None,
                         None,
                         None,
@@ -123,6 +126,7 @@ class FSEReportingExporter:
                 [
                     getattr(record, "site_name", None) or "",
                     record.registration_number or "",
+                    serial_number,
                     supply_from,
                     supply_to,
                     record.kwh_usage if record.kwh_usage is not None else 0,
@@ -151,24 +155,25 @@ class FSEReportingExporter:
         # Column layout:
         # Col A (1): Site name        – locked for existing rows, unlocked for new rows
         # Col B (2): Registration #   – locked for existing rows, unlocked for new rows
-        # Col C (3): Supply from      – editable, date
-        # Col D (4): Supply to        – editable, date
-        # Col E (5): kWh usage        – editable, integer
-        # Col F (6): Compliance notes – editable, text
+        # Col C (3): Serial #         – locked (read-only) always
+        # Col D (4): Supply from      – editable, date
+        # Col E (5): Supply to        – editable, date
+        # Col F (6): kWh usage        – editable, integer
+        # Col G (7): Compliance notes – editable, text
 
         # Pre-populated data rows
         for row_idx, row_data in enumerate(rows, start=2):
             for col_idx, value in enumerate(row_data, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx, value=value)
-                if col_idx in (1, 2):
-                    # Site name & Registration # – locked (read-only)
+                if col_idx in (1, 2, 3):
+                    # Site name, Registration # & Serial # – locked (read-only)
                     cell.protection = Protection(locked=True)
                     cell.alignment = Alignment(horizontal="left")
-                elif col_idx in (3, 4):
+                elif col_idx in (4, 5):
                     cell.protection = Protection(locked=False)
                     cell.number_format = "yyyy-mm-dd"
                     cell.alignment = Alignment(horizontal="left")
-                elif col_idx == 5:
+                elif col_idx == 6:
                     cell.protection = Protection(locked=False)
                     cell.number_format = "#,##0"
                     cell.alignment = Alignment(horizontal="right")
@@ -176,15 +181,19 @@ class FSEReportingExporter:
                     cell.protection = Protection(locked=False)
                     cell.alignment = Alignment(horizontal="left", wrap_text=True)
 
-        # Empty rows for new entries – unlock all 6 columns so users can add new FSE
+        # Empty rows for new entries – unlock editable columns; Serial # stays locked
         first_empty_row = len(rows) + 2
         for row_idx in range(first_empty_row, first_empty_row + 500):
-            for col_idx in range(1, 7):
+            for col_idx in range(1, 8):
                 cell = ws.cell(row=row_idx, column=col_idx)
-                cell.protection = Protection(locked=False)
-                if col_idx in (3, 4):
+                if col_idx == 3:
+                    # Serial # – always locked
+                    cell.protection = Protection(locked=True)
+                else:
+                    cell.protection = Protection(locked=False)
+                if col_idx in (4, 5):
                     cell.number_format = "yyyy-mm-dd"
-                elif col_idx == 5:
+                elif col_idx == 6:
                     cell.number_format = "#,##0"
 
         # Data validators (allow blank – do not block partial updates)
@@ -205,8 +214,8 @@ class FSEReportingExporter:
                 "calendar year."
             ),
         )
-        date_validator.add("C2:C10000")
         date_validator.add("D2:D10000")
+        date_validator.add("E2:E10000")
         ws.add_data_validation(date_validator)
 
         kwh_validator = DataValidation(
@@ -215,7 +224,7 @@ class FSEReportingExporter:
             showErrorMessage=True,
             error="Please enter a valid integer.",
         )
-        kwh_validator.add("E2:E10000")
+        kwh_validator.add("F2:F10000")
         ws.add_data_validation(kwh_validator)
 
         # Protect the sheet – only rows with locked=False cells will be editable

--- a/backend/lcfs/web/api/final_supply_equipment/fse_reporting_importer.py
+++ b/backend/lcfs/web/api/final_supply_equipment/fse_reporting_importer.py
@@ -215,14 +215,15 @@ async def _import_async(
                         if all(cell is None for cell in row):
                             continue
 
-                        # Column layout: A=Site name, B=Reg#, C=From, D=To, E=kWh, F=Notes
-                        expanded = list(row) + [None] * max(0, 6 - len(list(row)))
+                        # Column layout: A=Site name, B=Reg#, C=Serial#, D=From, E=To, F=kWh, G=Notes
+                        expanded = list(row) + [None] * max(0, 7 - len(list(row)))
                         # col A (index 0) = site name — read-only identifier, not used
                         registration_number = expanded[1]
-                        supply_from_raw = expanded[2]
-                        supply_to_raw = expanded[3]
-                        kwh_usage_raw = expanded[4]
-                        compliance_notes = expanded[5]
+                        # col C (index 2) = serial # — read-only identifier, not used
+                        supply_from_raw = expanded[3]
+                        supply_to_raw = expanded[4]
+                        kwh_usage_raw = expanded[5]
+                        compliance_notes = expanded[6]
 
                         # Registration number is required
                         if not registration_number:

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -1388,6 +1388,7 @@ class FinalSupplyEquipmentRepository:
                     ChargingSite.site_code + "-" + ChargingEquipment.equipment_number
                 ).label("registration_number"),
                 ChargingSite.site_name.label("site_name"),
+                ChargingEquipment.serial_number.label("serial_number"),
                 ComplianceReportChargingEquipment.charging_equipment_compliance_id,
                 ComplianceReportChargingEquipment.supply_from_date,
                 ComplianceReportChargingEquipment.supply_to_date,
@@ -1465,6 +1466,7 @@ class FinalSupplyEquipmentRepository:
                 all_rows_subquery.c.charging_equipment_version,
                 all_rows_subquery.c.registration_number,
                 all_rows_subquery.c.site_name,
+                all_rows_subquery.c.serial_number,
                 all_rows_subquery.c.charging_equipment_compliance_id,
                 all_rows_subquery.c.supply_from_date,
                 all_rows_subquery.c.supply_to_date,


### PR DESCRIPTION
## Summary
Cherry-pick of #4113 into `release-v1.2.9`.

- **#4067:** Changed charging equipment upload duplicate check to scope by charging site — same serial number at a different site is now allowed, only blocked within the same site.
- **#4066:** Added a read-only "Serial #" column to the kWh Excel download template (between Registration # and Dates of supply from) and updated the importer to handle the new column layout.

## Test plan
- [ ] Upload charging equipment with duplicate serial numbers across different sites — should succeed
- [ ] Upload charging equipment with duplicate serial numbers within the same site — should be rejected
- [ ] Download kWh Excel template and verify Serial # column appears after Registration #, is read-only
- [ ] Upload kWh Excel template with the new Serial # column — should import correctly