### PR TITLE
Hotfix: PGBouncer Connection Pooling

### DIFF
--- a/backend/lcfs/db/dependencies.py
+++ b/backend/lcfs/db/dependencies.py
@@ -9,6 +9,7 @@ from fastapi import Request
 from sqlalchemy import text
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from lcfs.db.base import current_user_var, get_current_user
 from lcfs.settings import settings
@@ -21,12 +22,7 @@ db_url = make_url(str(settings.db_url.with_path(f"/{settings.db_base}")))
 async_engine = create_async_engine(
     db_url,
     future=True,
-    pool_size=30,
-    max_overflow=50,
-    pool_pre_ping=True,
-    pool_recycle=3600,
-    pool_timeout=30,
-    pool_reset_on_return="commit",
+    poolclass=NullPool,
 )
 logger = structlog.get_logger("sqlalchemy.engine")
 register_query_analyzer(async_engine.sync_engine)

--- a/backend/lcfs/db/migrations/env.py
+++ b/backend/lcfs/db/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy.ext.asyncio.engine import create_async_engine
+from sqlalchemy.pool import NullPool
 from sqlalchemy.future import Connection
 
 from lcfs.db.meta import meta
@@ -95,7 +96,7 @@ async def run_migrations_online() -> None:
     In this scenario we need to create an Engine
     and associate a connection with the context.
     """
-    connectable = create_async_engine(str(settings.db_url))
+    connectable = create_async_engine(str(settings.db_url), poolclass=NullPool)
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)

--- a/backend/lcfs/db/seeders/seed_database.py
+++ b/backend/lcfs/db/seeders/seed_database.py
@@ -4,6 +4,7 @@ import structlog
 
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 
 from lcfs.db.seeders.dev_seeder import seed_dev
 from lcfs.db.seeders.prod_seeder import seed_prod
@@ -15,7 +16,7 @@ logger = structlog.get_logger(__name__)
 
 
 async def seed_database(environment):
-    engine = create_async_engine(str(settings.db_url))
+    engine = create_async_engine(str(settings.db_url), poolclass=NullPool)
     AsyncSessionLocal = sessionmaker(bind=engine, class_=AsyncSession)
 
     async with AsyncSessionLocal() as session:

--- a/backend/lcfs/db/sql/manage_views.py
+++ b/backend/lcfs/db/sql/manage_views.py
@@ -15,6 +15,7 @@ import structlog
 from typing import Dict, List
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 from sqlalchemy import text
 from sqlalchemy.engine import make_url
 
@@ -192,9 +193,7 @@ async def create_views(environment: str = "dev"):
     engine = create_async_engine(
         db_url,
         future=True,
-        pool_size=10,
-        max_overflow=20,
-        pool_pre_ping=True,
+        poolclass=NullPool,
     )
 
     AsyncSessionLocal = sessionmaker(bind=engine, class_=AsyncSession)


### PR DESCRIPTION
## Summary
- Removes SQLAlchemy's application-side connection pooling (`pool_size`, `max_overflow`, etc.) in favour of `NullPool` across all database engines
- Pgbouncer handles all connection pooling — double-pooling was causing `ConnectionDoesNotExistError` and `QueuePool limit reached` errors in production
- Applied to: main app engine (`dependencies.py`), Alembic migrations (`env.py`), database seeder (`seed_database.py`), and views manager (`manage_views.py`)