### PR TITLE
fix: disable prepared statement caching for pgbouncer compatibility

### DIFF
--- a/backend/lcfs/db/dependencies.py
+++ b/backend/lcfs/db/dependencies.py
@@ -23,6 +23,10 @@ async_engine = create_async_engine(
     db_url,
     future=True,
     poolclass=NullPool,
+    connect_args={
+        "prepared_statement_cache_size": 0,
+        "statement_cache_size": 0,
+    },
 )
 logger = structlog.get_logger("sqlalchemy.engine")
 register_query_analyzer(async_engine.sync_engine)

--- a/backend/lcfs/web/lifetime.py
+++ b/backend/lcfs/web/lifetime.py
@@ -33,6 +33,10 @@ def _setup_db(app: FastAPI) -> None:  # pragma: no cover
         pool_recycle=3600,
         pool_timeout=30,
         pool_reset_on_return="commit",
+        connect_args={
+            "prepared_statement_cache_size": 0,
+            "statement_cache_size": 0,
+        },
     )
     session_factory = async_sessionmaker(
         engine,


### PR DESCRIPTION
## Summary
- Adds `connect_args` with `prepared_statement_cache_size=0` and `statement_cache_size=0` to both async engine creation sites (`dependencies.py` and `lifetime.py`)
- This disables asyncpg's prepared statement caching, which is incompatible with pgbouncer's transaction pooling mode
- Allows pgbouncer `pool_mode` to be set back to `transaction`

## Test plan
- [ ] Verify application connects successfully through pgbouncer in transaction mode
- [ ] Confirm no prepared statement errors in logs
- [ ] Smoke test API endpoints to ensure normal DB operations work