### PR TITLE
fix: prevent duplicate fuel code expiry notification emails

### DIFF
--- a/backend/lcfs/scripts/tasks/fuel_code_expiry.py
+++ b/backend/lcfs/scripts/tasks/fuel_code_expiry.py
@@ -117,6 +117,10 @@ async def notify_expiring_fuel_code(db_session: AsyncSession):
                 f"Marking {len(notified_fuel_code_ids)} fuel codes as notified"
             )
             await fuel_code_repo.mark_fuel_codes_notified(notified_fuel_code_ids)
+            # Commit so the notification timestamps are persisted — without this,
+            # the session closes uncommitted and the same codes are re-selected
+            # on the next scheduler run, causing duplicate emails.
+            await db_session.commit()
 
         logger.info(
             f"Sent fuel code expiry notifications to {success_count}/{total_emails} contacts"

--- a/backend/lcfs/scripts/tests/test_fuel_code_expiry.py
+++ b/backend/lcfs/scripts/tests/test_fuel_code_expiry.py
@@ -130,6 +130,9 @@ class TestNotifyExpiringFuelCode:
             notified_ids = mock_repo.mark_fuel_codes_notified.call_args[0][0]
             assert sorted(notified_ids) == [1, 2, 3]
 
+            # Verify the session is committed so notification timestamps persist
+            mock_db_session.commit.assert_called_once()
+
     @pytest.mark.anyio
     @patch(
         "lcfs.scripts.tasks.fuel_code_expiry.settings.feature_fuel_code_expiry_email",
@@ -222,6 +225,8 @@ class TestNotifyExpiringFuelCode:
             assert result is False
             # No fuel codes should be marked as notified when all emails fail
             mock_repo.mark_fuel_codes_notified.assert_not_called()
+            # No commit should happen when no emails were sent
+            mock_db_session.commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_notify_expiring_fuel_code_partial_success(
@@ -261,6 +266,9 @@ class TestNotifyExpiringFuelCode:
             notified_ids = mock_repo.mark_fuel_codes_notified.call_args[0][0]
             # Only codes 1 and 3 (Company A) should be marked since that email succeeded
             assert sorted(notified_ids) == [1, 3]
+
+            # Verify commit is called to persist the notification timestamps
+            mock_db_session.commit.assert_called_once()
 
     @pytest.mark.anyio
     @patch(

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -1209,8 +1209,9 @@ class FuelCodeRepository:
         """
         query = (
             select(FuelCode)
+            .join(FuelCode.fuel_code_status)
             .options(
-                joinedload(FuelCode.fuel_code_status),
+                contains_eager(FuelCode.fuel_code_status),
                 joinedload(FuelCode.fuel_code_prefix),
             )
             .where(


### PR DESCRIPTION
## Summary
- **Root cause**: The scheduler's db session runs outside the FastAPI request lifecycle (no auto-commit). `mark_fuel_codes_notified()` updated `expiry_notification_sent_at` but the change was never committed, so every daily cron run re-selected the same fuel codes and re-sent emails.
- Added explicit `db_session.commit()` after marking codes as notified
- Fixed `get_expiring_fuel_codes` query to use explicit `.join()` on `FuelCodeStatus` instead of `joinedload` for the WHERE filter (prevents potential cartesian product)
- Updated tests to verify commit behavior

Closes #4131

## Test plan
- [ ] Verify no duplicate emails are sent for the same fuel code across consecutive scheduler runs
- [ ] Verify `expiry_notification_sent_at` is persisted in the database after notifications are sent
- [ ] Verify fuel codes with existing `expiry_notification_sent_at` are excluded from subsequent runs
- [ ] Run existing unit tests