### PR TITLE
Fix Excel paste crash on allocation agreements

### DIFF
--- a/frontend/src/components/BCDataGrid/BCGridEditor.jsx
+++ b/frontend/src/components/BCDataGrid/BCGridEditor.jsx
@@ -224,13 +224,18 @@ export const BCGridEditor = ({
 
   const handleExcelPaste = useCallback(
     (params) => {
+      const gridApi = ref.current?.api
+      if (!gridApi) return
+
       const newData = []
       const clipboardData = params.clipboardData || window.clipboardData
       const pastedData = clipboardData.getData('text/plain')
-      const headerRow = ref.current.api
-        .getAllDisplayedColumns()
+      const displayedColumns = gridApi.getAllDisplayedColumns()
+      const editableColumns = displayedColumns.filter(
+        (col) => col.colDef.field && col.colDef.field !== 'action'
+      )
+      const headerRow = editableColumns
         .map((column) => column.colDef.field)
-        .filter((col) => col)
         .join('\t')
       const parsedData = Papa.parse(headerRow + '\n' + pastedData, {
         delimiter: '\t',
@@ -241,26 +246,39 @@ export const BCGridEditor = ({
         },
         skipEmptyLines: true
       })
-      if (parsedData.data.length < 0 || parsedData.data[1].length < 2) {
+      if (
+        parsedData.data.length <= 0 ||
+        Object.keys(parsedData.data[0]).length < 2
+      ) {
         return
       }
       parsedData.data.forEach((row) => {
         const newRow = { ...row }
         newRow.id = uuid()
+        newRow.modified = true
         newData.push(newRow)
       })
-      const transactions = ref.current.api.applyTransaction({ add: newData })
-      // Trigger onCellEditingStopped event to update the row in backend.
+      const transactions = gridApi.applyTransaction({ add: newData })
+
+      // Build a proper params-like object for each pasted row so downstream
+      // handlers (which expect AG Grid CellEditingStopped params) don't crash.
+      const firstEditableCol = findFirstEditableColumn()
+      const colDef = firstEditableCol?.colDef || { field: editableColumns[0]?.colDef?.field }
+      const column = firstEditableCol || editableColumns[0]
+
       transactions.add.forEach((node) => {
         onCellEditingStopped({
           node,
+          data: node.data,
           oldValue: '',
-          newValue: node.data[findFirstEditableColumn()],
-          ...props
+          newValue: node.data[colDef.field],
+          colDef,
+          column,
+          api: gridApi
         })
       })
     },
-    [findFirstEditableColumn, onCellEditingStopped, props, ref]
+    [findFirstEditableColumn, onCellEditingStopped, ref]
   )
 
   useEffect(() => {

--- a/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
@@ -128,7 +128,7 @@ export const AddEditAllocationAgreements = () => {
   ) => {
     const value = field ? params.node?.data[field] : params
 
-    if (field && params.colDef.field !== field) {
+    if (field && params.colDef?.field !== field) {
       return true
     }
 
@@ -334,8 +334,10 @@ export const AddEditAllocationAgreements = () => {
     async (params) => {
       if (params.oldValue === params.newValue) return
 
+      const fieldName = params.colDef?.field
+
       // User cannot select their own organization as the transaction partner
-      if (params.colDef.field === 'transactionPartner') {
+      if (fieldName === 'transactionPartner') {
         const orgName = currentReport?.report?.organization?.name
         if (
           params.newValue === orgName ||


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading 'field')` when pasting Excel data into allocation agreements grid
- `handleExcelPaste` was calling `onCellEditingStopped` with a fabricated params object missing `colDef`, `column`, `api`, and `data`
- Also fixes validation guard logic and adds defensive optional chaining

## Test plan
- [ ] Paste multiple rows from Excel into the allocation agreements grid
- [ ] Verify rows appear and save without console errors
- [ ] Verify normal cell editing still works as expected