### PR TITLE
Hotfix: Return to supplier button hidden on March 31 deadline day

### DIFF
--- a/frontend/src/views/ComplianceReports/buttonConfigs.jsx
+++ b/frontend/src/views/ComplianceReports/buttonConfigs.jsx
@@ -594,7 +594,7 @@ function isPastMarch31Deadline(compliancePeriod) {
     year: compliancePeriodYear + 1,
     month: 3,
     day: 31
-  })
+  }).endOf('day')
   return DateTime.now() > deadline
 }
 


### PR DESCRIPTION
## Summary
- The `isPastMarch31Deadline` function compared against midnight (00:00) on March 31, causing the Return to Supplier button to disappear for the entire day
- Added `.endOf('day')` so the deadline includes the full day, keeping the button visible until April 1

## Test plan
- [ ] Log in as IDIR Analyst, open a submitted original compliance report for CP 2025
- [ ] Verify "Return to Supplier" button is visible on March 31
- [ ] Verify button is hidden starting April 1