### PR TITLE
Hotfix: Enable analyst assignment for compliance managers and directors

### DIFF
--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -89,7 +89,7 @@ async def get_compliance_report_statuses(
     response_model=List[AssignedAnalystSchema],
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.GOVERNMENT, RoleEnum.ANALYST])
+@view_handler([RoleEnum.GOVERNMENT, RoleEnum.ANALYST, RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR])
 async def get_available_analysts(
     request: Request,
     service: ComplianceReportServices = Depends(),
@@ -339,7 +339,7 @@ async def get_changelog(
     response_model=ChainedComplianceReportSchema,
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.GOVERNMENT, RoleEnum.ANALYST])
+@view_handler([RoleEnum.GOVERNMENT, RoleEnum.ANALYST, RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR])
 async def assign_analyst_to_report(
     request: Request,
     report_id: int,

--- a/frontend/src/views/ComplianceReports/components/AssignedAnalystCell.jsx
+++ b/frontend/src/views/ComplianceReports/components/AssignedAnalystCell.jsx
@@ -54,7 +54,10 @@ export const AssignedAnalystCell = ({ data, onRefresh }) => {
   })
 
   // Check if user can assign analysts (IDIR users only)
-  const canAssign = hasRoles('Government', 'Analyst')
+  const canAssign =
+    hasRoles('Government', 'Analyst') ||
+    hasRoles('Government', 'Compliance Manager') ||
+    hasRoles('Government', 'Director')
 
   const handleAssignment = (analystId) => {
     assignAnalyst({


### PR DESCRIPTION
## Summary
- Allow Compliance Manager and Director IDIR roles to assign analysts to compliance reports from the list view, previously restricted to Analyst role only.

## Test plan
- [ ] Verify compliance managers can assign analysts from the report list view
- [ ] Verify directors can assign analysts from the report list view
- [ ] Verify analyst role assignment still works as before