### PR TITLE
Fix: LCFS – Draft transfer comments not displayed for BCeID users when reopening draft

### DIFF
--- a/frontend/src/views/Transfers/AddEditViewTransfer.jsx
+++ b/frontend/src/views/Transfers/AddEditViewTransfer.jsx
@@ -132,7 +132,10 @@ export const AddEditViewTransfer = () => {
         recommendation:
           prevValues.recommendation ?? transferData.recommendation,
         signingAuthorityDeclaration:
-          prevValues.signingAuthorityDeclaration ?? false
+          prevValues.signingAuthorityDeclaration ?? false,
+        fromOrgComment:
+          transferData?.comments?.find((c) => c.commentSource === 'FROM_ORG')
+            ?.comment || '',
       }))
     }
     if (isLoadingError || queryState?.status === 'error') {


### PR DESCRIPTION
Fixes #4173