### PR TITLE
Feat: Remove exporting fuel for pre-2024 reports - 4244

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_compliance_report_export.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_export.py
@@ -409,6 +409,59 @@ class TestComplianceReportExporter:
         exporter.fse_repo.get_fse_reporting_list_paginated.assert_called()
 
     @pytest.mark.anyio
+    async def test_export_excludes_fuel_export_sheet_for_pre_2024_reports(
+        self,
+        compliance_report_exporter,
+        mock_annual_report,
+    ):
+        """Test that fuel export sheet is excluded from export for compliance years before 2024."""
+        period_2023 = Mock()
+        period_2023.description = "2023"
+        mock_report_2023 = Mock()
+        mock_report_2023.compliance_report_id = 1
+        mock_report_2023.compliance_report_group_uuid = "test-uuid"
+        mock_report_2023.version = 0
+        mock_report_2023.reporting_frequency = ReportingFrequency.ANNUAL
+        mock_report_2023.organization = mock_annual_report.organization
+        mock_report_2023.current_status = mock_annual_report.current_status
+        mock_report_2023.compliance_period = period_2023
+
+        exporter = compliance_report_exporter
+        exporter.cr_repo.get_compliance_report_by_id.return_value = mock_report_2023
+        exporter.summary_service.calculate_fuel_supply_compliance_units = AsyncMock(
+            return_value=1000
+        )
+        exporter.summary_service.calculate_fuel_export_compliance_units = AsyncMock(
+            return_value=-500
+        )
+
+        await exporter.export(1)
+
+        # Fuel export loader is skipped for pre-2024 reports
+        exporter.ef_repo.get_effective_fuel_exports.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_export_includes_fuel_export_sheet_for_2024_and_later_reports(
+        self,
+        compliance_report_exporter,
+        mock_annual_report,
+    ):
+        """Test that fuel export loader is called for compliance years 2024 and later."""
+        exporter = compliance_report_exporter
+        exporter.cr_repo.get_compliance_report_by_id.return_value = mock_annual_report
+        exporter.summary_service.calculate_fuel_supply_compliance_units = AsyncMock(
+            return_value=1000
+        )
+        exporter.summary_service.calculate_fuel_export_compliance_units = AsyncMock(
+            return_value=-500
+        )
+
+        await exporter.export(1)
+
+        # Fuel export loader is called for 2024+ reports
+        exporter.ef_repo.get_effective_fuel_exports.assert_called()
+
+    @pytest.mark.anyio
     async def test_load_fuel_supply_data_annual(
         self,
         compliance_report_exporter,

--- a/backend/lcfs/web/api/compliance_report/export.py
+++ b/backend/lcfs/web/api/compliance_report/export.py
@@ -132,8 +132,8 @@ class ComplianceReportExporter:
 
         # Add all schedule data sheets - run sequentially to avoid DB connection issues
         for sheet_name, loader in self.data_loaders.items():
-            # FSE is not applicable for compliance periods before 2024
-            if sheet_name == FSE_EXPORT_SHEET and compliance_year < 2024:
+            # FSE and Fuel Exports are not applicable for compliance periods before 2024
+            if sheet_name in (FSE_EXPORT_SHEET, EXPORT_FUEL_SHEET) and compliance_year < 2024:
                 continue
             if sheet_name == FSE_EXPORT_SHEET:
                 data = await loader(cid, is_quarterly, is_government)

--- a/frontend/src/views/ComplianceReports/components/ActivityLinksList.jsx
+++ b/frontend/src/views/ComplianceReports/components/ActivityLinksList.jsx
@@ -79,12 +79,16 @@ export const ActivityLinksList = ({
         ROUTES.REPORTS.ADD.OTHER_USE_FUELS,
         false
       ),
-      createActivity(
-        'report:activityLists.exportFuels',
-        'report:activityLabels.exportFuels',
-        ROUTES.REPORTS.ADD.FUEL_EXPORTS,
-        false
-      )
+      ...(parseInt(compliancePeriod) >= LEGISLATION_TRANSITION_YEAR
+        ? [
+            createActivity(
+              'report:activityLists.exportFuels',
+              'report:activityLabels.exportFuels',
+              ROUTES.REPORTS.ADD.FUEL_EXPORTS,
+              false
+            )
+          ]
+        : [])
     ],
     [t, navigate, compliancePeriod, complianceReportId]
   )

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -436,6 +436,11 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         activity.key === 'finalSupplyEquipments' &&
         parseInt(compliancePeriod) < LEGISLATION_TRANSITION_YEAR
 
+      // Fuel exports are not applicable for compliance periods before 2024
+      const isFuelExportHiddenByYear =
+        activity.key === 'fuelExports' &&
+        parseInt(compliancePeriod) < LEGISLATION_TRANSITION_YEAR
+
       // For FSE section: show if organization has any charging equipment,
       // not just if there's FSE linked to the current report group.
       // This ensures users can add FSE to supplemental reports even when
@@ -449,6 +454,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
       // OR (for FSE) if organization has charging equipment
       const shouldShow =
         !isFSEHiddenByYear &&
+        !isFuelExportHiddenByYear &&
         (hasRealData ||
           hasFSECapability ||
           activity.key === 'supportingDocs' ||

--- a/frontend/src/views/ComplianceReports/components/__tests__/ActivityLinksList.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/ActivityLinksList.test.jsx
@@ -180,6 +180,62 @@ describe('ActivityLinksList', () => {
     })
   })
 
+  describe('Export fuels link visibility by compliance year', () => {
+    it('shows export fuels link when compliance period is 2024 or later', () => {
+      useParams.mockReturnValue({
+        compliancePeriod: '2024',
+        complianceReportId: '123'
+      })
+      render(
+        <ActivityLinksList
+          currentStatus="Draft"
+          isQuarterlyReport={false}
+          reportQuarter={null}
+        />,
+        { wrapper }
+      )
+      expect(
+        screen.getByText('report:activityLists.exportFuels')
+      ).toBeInTheDocument()
+    })
+
+    it('hides export fuels link when compliance period is before 2024', () => {
+      useParams.mockReturnValue({
+        compliancePeriod: '2023',
+        complianceReportId: '123'
+      })
+      render(
+        <ActivityLinksList
+          currentStatus="Draft"
+          isQuarterlyReport={false}
+          reportQuarter={null}
+        />,
+        { wrapper }
+      )
+      expect(
+        screen.queryByText('report:activityLists.exportFuels')
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides export fuels link for 2022 compliance period', () => {
+      useParams.mockReturnValue({
+        compliancePeriod: '2022',
+        complianceReportId: '456'
+      })
+      render(
+        <ActivityLinksList
+          currentStatus="Draft"
+          isQuarterlyReport={false}
+          reportQuarter={null}
+        />,
+        { wrapper }
+      )
+      expect(
+        screen.queryByText('report:activityLists.exportFuels')
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe('FSE link visibility by compliance year', () => {
     it('shows FSE link when compliance period is 2024 or later', () => {
       useParams.mockReturnValue({

--- a/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
@@ -694,6 +694,74 @@ describe('ReportDetails', () => {
     })
   })
 
+  describe('Fuel export section visibility by compliance year', () => {
+    it('shows fuel export accordion when compliance period is 2024 or later and has data', async () => {
+      mockUseParams.mockReturnValue({
+        compliancePeriod: '2024',
+        complianceReportId: '12345'
+      })
+      mockUseGetFuelExports.mockReturnValue({
+        data: { fuelExports: [{ fuelExportId: 1 }] },
+        isLoading: false,
+        error: null
+      })
+
+      render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
+        wrapper
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('fuelExport:fuelExportTitle')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('hides fuel export accordion when compliance period is before 2024 even with data', async () => {
+      mockUseParams.mockReturnValue({
+        compliancePeriod: '2023',
+        complianceReportId: '12345'
+      })
+      mockUseGetFuelExports.mockReturnValue({
+        data: { fuelExports: [{ fuelExportId: 1 }] },
+        isLoading: false,
+        error: null
+      })
+
+      render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
+        wrapper
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('fuelExport:fuelExportTitle')
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('hides fuel export accordion for 2022 compliance period', async () => {
+      mockUseParams.mockReturnValue({
+        compliancePeriod: '2022',
+        complianceReportId: '12345'
+      })
+      mockUseGetFuelExports.mockReturnValue({
+        data: { fuelExports: [{ fuelExportId: 1 }] },
+        isLoading: false,
+        error: null
+      })
+
+      render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
+        wrapper
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('fuelExport:fuelExportTitle')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('FSE section visibility by compliance year', () => {
     it('shows FSE accordion when compliance period is 2024 or later and org has charging equipment', async () => {
       mockUseParams.mockReturnValue({


### PR DESCRIPTION
This PR removes Exporting Fuel for pre-2024 reports.

- remove exporting fuel nav link
- remove exporting fuel schedule section
- applies to bceid and idir roles
- pdf exports exclude exporting fuel

Closes #4244