### PR TITLE
Feat: System Admin-only configuration for logon background, report openings, notifications - 4254

### DIFF
--- a/backend/lcfs/tests/government_notification/test_government_notification_views.py
+++ b/backend/lcfs/tests/government_notification/test_government_notification_views.py
@@ -4,6 +4,9 @@ from unittest.mock import patch, MagicMock
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.government_notification.schema import GovernmentNotificationSchema
 
+# Every role except SYSTEM_ADMIN must be denied access to government
+UNAUTHORIZED_ROLES = [role for role in RoleEnum if role is not RoleEnum.SYSTEM_ADMIN]
+
 
 # Mock data for government notification
 mock_notification = GovernmentNotificationSchema(
@@ -52,16 +55,16 @@ async def test_get_current_notification_none(client, fastapi_app, set_mock_user)
 
 
 @pytest.mark.anyio
-async def test_update_notification_as_compliance_manager(
+async def test_update_notification_as_system_admin(
     client, fastapi_app, set_mock_user
 ):
-    """Test updating notification as compliance manager."""
+    """Test updating notification as system admin."""
     with patch(
         "lcfs.web.api.government_notification.views.GovernmentNotificationService.update_notification"
     ) as mock_update:
         mock_update.return_value = mock_notification
 
-        set_mock_user(fastapi_app, [RoleEnum.COMPLIANCE_MANAGER])
+        set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
 
         url = fastapi_app.url_path_for("update_notification")
         payload = {
@@ -79,9 +82,12 @@ async def test_update_notification_as_compliance_manager(
 
 
 @pytest.mark.anyio
-async def test_update_notification_unauthorized(client, fastapi_app, set_mock_user):
-    """Test that analysts cannot update notifications."""
-    set_mock_user(fastapi_app, [RoleEnum.ANALYST])
+@pytest.mark.parametrize("role", UNAUTHORIZED_ROLES)
+async def test_update_notification_unauthorized(
+    client, fastapi_app, set_mock_user, role
+):
+    """Ensure only System Admin can update; other roles are forbidden."""
+    set_mock_user(fastapi_app, [role])
 
     url = fastapi_app.url_path_for("update_notification")
     payload = {
@@ -96,34 +102,16 @@ async def test_update_notification_unauthorized(client, fastapi_app, set_mock_us
 
 
 @pytest.mark.anyio
-async def test_delete_notification_as_compliance_manager(
+async def test_delete_notification_as_system_admin(
     client, fastapi_app, set_mock_user
 ):
-    """Test deleting notification as compliance manager."""
+    """Test deleting notification as system admin."""
     with patch(
         "lcfs.web.api.government_notification.views.GovernmentNotificationService.delete_notification"
     ) as mock_delete:
         mock_delete.return_value = True
 
-        set_mock_user(fastapi_app, [RoleEnum.COMPLIANCE_MANAGER])
-
-        url = fastapi_app.url_path_for("delete_notification")
-        response = await client.delete(url)
-
-        assert response.status_code == 200
-        response_data = response.json()
-        assert response_data["message"] == "Government notification deleted successfully"
-
-
-@pytest.mark.anyio
-async def test_delete_notification_as_director(client, fastapi_app, set_mock_user):
-    """Test deleting notification as director."""
-    with patch(
-        "lcfs.web.api.government_notification.views.GovernmentNotificationService.delete_notification"
-    ) as mock_delete:
-        mock_delete.return_value = True
-
-        set_mock_user(fastapi_app, [RoleEnum.DIRECTOR])
+        set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
 
         url = fastapi_app.url_path_for("delete_notification")
         response = await client.delete(url)
@@ -141,7 +129,7 @@ async def test_delete_notification_none_exists(client, fastapi_app, set_mock_use
     ) as mock_delete:
         mock_delete.return_value = False
 
-        set_mock_user(fastapi_app, [RoleEnum.COMPLIANCE_MANAGER])
+        set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
 
         url = fastapi_app.url_path_for("delete_notification")
         response = await client.delete(url)
@@ -154,24 +142,12 @@ async def test_delete_notification_none_exists(client, fastapi_app, set_mock_use
 
 
 @pytest.mark.anyio
-async def test_delete_notification_unauthorized_analyst(
-    client, fastapi_app, set_mock_user
+@pytest.mark.parametrize("role", UNAUTHORIZED_ROLES)
+async def test_delete_notification_unauthorized(
+    client, fastapi_app, set_mock_user, role
 ):
-    """Test that analysts cannot delete notifications."""
-    set_mock_user(fastapi_app, [RoleEnum.ANALYST])
-
-    url = fastapi_app.url_path_for("delete_notification")
-    response = await client.delete(url)
-
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-async def test_delete_notification_unauthorized_supplier(
-    client, fastapi_app, set_mock_user
-):
-    """Test that suppliers cannot delete notifications."""
-    set_mock_user(fastapi_app, [RoleEnum.SUPPLIER])
+    """Ensure only System Admin can delete; other roles are forbidden."""
+    set_mock_user(fastapi_app, [role])
 
     url = fastapi_app.url_path_for("delete_notification")
     response = await client.delete(url)

--- a/backend/lcfs/tests/login_bg_image/test_login_bg_image_views.py
+++ b/backend/lcfs/tests/login_bg_image/test_login_bg_image_views.py
@@ -9,6 +9,9 @@ from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.login_bg_image.services import LoginBgImageService
 from lcfs.web.api.login_bg_image.schema import LoginBgImageSchema
 
+# Every role except SYSTEM_ADMIN must be denied access to the login background
+UNAUTHORIZED_ROLES = [role for role in RoleEnum if role is not RoleEnum.SYSTEM_ADMIN]
+
 SAMPLE_SCHEMA_DATA = {
     "login_bg_image_id": 1,
     "image_key": "login-backgrounds/abc-uuid",
@@ -85,7 +88,7 @@ async def test_get_all_images_returns_list(
     set_mock_user,
     mock_login_bg_image_service,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ADMINISTRATOR])
+    set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
     mock_login_bg_image_service.get_all = AsyncMock(
         return_value=[make_schema(is_active=True), make_schema(login_bg_image_id=2, is_active=False)]
     )
@@ -103,13 +106,18 @@ async def test_get_all_images_returns_list(
 
 
 @pytest.mark.anyio
-async def test_get_all_images_forbidden_for_non_admin(
+@pytest.mark.parametrize(
+    "role",
+    UNAUTHORIZED_ROLES,
+)
+async def test_get_all_images_forbidden_for_non_system_admin(
     client: AsyncClient,
     fastapi_app: FastAPI,
     set_mock_user,
     mock_login_bg_image_service,
+    role,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ANALYST])
+    set_mock_user(fastapi_app, [role])
     fastapi_app.dependency_overrides[LoginBgImageService] = (
         lambda: mock_login_bg_image_service
     )
@@ -132,7 +140,7 @@ async def test_upload_image_success(
     set_mock_user,
     mock_login_bg_image_service,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ADMINISTRATOR])
+    set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
     mock_login_bg_image_service.upload = AsyncMock(return_value=make_schema(is_active=False))
     fastapi_app.dependency_overrides[LoginBgImageService] = (
         lambda: mock_login_bg_image_service
@@ -152,13 +160,18 @@ async def test_upload_image_success(
 
 
 @pytest.mark.anyio
-async def test_upload_image_forbidden_for_non_admin(
+@pytest.mark.parametrize(
+    "role",
+    UNAUTHORIZED_ROLES,
+)
+async def test_upload_image_forbidden_for_non_system_admin(
     client: AsyncClient,
     fastapi_app: FastAPI,
     set_mock_user,
     mock_login_bg_image_service,
+    role,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ANALYST])
+    set_mock_user(fastapi_app, [role])
     fastapi_app.dependency_overrides[LoginBgImageService] = (
         lambda: mock_login_bg_image_service
     )
@@ -185,7 +198,7 @@ async def test_update_image_success(
     set_mock_user,
     mock_login_bg_image_service,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ADMINISTRATOR])
+    set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
     updated = make_schema(display_name="Updated Name", caption="New caption")
     mock_login_bg_image_service.update = AsyncMock(return_value=updated)
     fastapi_app.dependency_overrides[LoginBgImageService] = (
@@ -215,7 +228,7 @@ async def test_activate_image_success(
     set_mock_user,
     mock_login_bg_image_service,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ADMINISTRATOR])
+    set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
     mock_login_bg_image_service.activate = AsyncMock(
         return_value=make_schema(is_active=True)
     )
@@ -243,7 +256,7 @@ async def test_delete_image_success(
     set_mock_user,
     mock_login_bg_image_service,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ADMINISTRATOR])
+    set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
     mock_login_bg_image_service.delete = AsyncMock(return_value=None)
     fastapi_app.dependency_overrides[LoginBgImageService] = (
         lambda: mock_login_bg_image_service
@@ -257,13 +270,18 @@ async def test_delete_image_success(
 
 
 @pytest.mark.anyio
-async def test_delete_image_forbidden_for_non_admin(
+@pytest.mark.parametrize(
+    "role",
+    UNAUTHORIZED_ROLES,
+)
+async def test_delete_image_forbidden_for_non_system_admin(
     client: AsyncClient,
     fastapi_app: FastAPI,
     set_mock_user,
     mock_login_bg_image_service,
+    role,
 ):
-    set_mock_user(fastapi_app, [RoleEnum.ANALYST])
+    set_mock_user(fastapi_app, [role])
     fastapi_app.dependency_overrides[LoginBgImageService] = (
         lambda: mock_login_bg_image_service
     )

--- a/backend/lcfs/tests/report_opening/test_report_opening_views.py
+++ b/backend/lcfs/tests/report_opening/test_report_opening_views.py
@@ -1,0 +1,143 @@
+import pytest
+from unittest.mock import patch
+
+from lcfs.db.models.compliance.ReportOpening import SupplementalReportAccessRole
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.web.api.report_opening.schema import ReportOpeningSchema
+
+SUPPLIER_LIKE_ROLES = {
+    RoleEnum.SUPPLIER,
+    RoleEnum.MANAGE_USERS,
+    RoleEnum.TRANSFER,
+    RoleEnum.COMPLIANCE_REPORTING,
+    RoleEnum.SIGNING_AUTHORITY,
+    RoleEnum.READ_ONLY,
+    RoleEnum.CI_APPLICANT,
+    RoleEnum.IA_PROPONENT,
+}
+
+READ_UNAUTHORIZED_ROLES = [
+    role
+    for role in RoleEnum
+    if role is not RoleEnum.SYSTEM_ADMIN and role not in SUPPLIER_LIKE_ROLES
+]
+
+WRITE_UNAUTHORIZED_ROLES = [
+    role for role in RoleEnum if role is not RoleEnum.SYSTEM_ADMIN
+]
+
+
+mock_report_opening = ReportOpeningSchema(
+    report_opening_id=1,
+    compliance_year=2025,
+    compliance_reporting_enabled=True,
+    early_issuance_enabled=False,
+    supplemental_report_role=SupplementalReportAccessRole.BCeID,
+)
+
+
+@pytest.mark.anyio
+async def test_list_report_openings_as_system_admin(
+    client, fastapi_app, set_mock_user
+):
+    """System Admin can read report openings."""
+    with patch(
+        "lcfs.web.api.report_opening.views.ReportOpeningService.get_report_openings"
+    ) as mock_get:
+        mock_get.return_value = [mock_report_opening]
+
+        set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
+
+        url = fastapi_app.url_path_for("list_report_openings")
+        response = await client.get(url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert data[0]["complianceYear"] == 2025
+
+
+@pytest.mark.anyio
+async def test_list_report_openings_as_supplier(client, fastapi_app, set_mock_user):
+    """Suppliers can read report openings."""
+    with patch(
+        "lcfs.web.api.report_opening.views.ReportOpeningService.get_report_openings"
+    ) as mock_get:
+        mock_get.return_value = [mock_report_opening]
+
+        set_mock_user(fastapi_app, [RoleEnum.SUPPLIER])
+
+        url = fastapi_app.url_path_for("list_report_openings")
+        response = await client.get(url)
+
+        assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("role", READ_UNAUTHORIZED_ROLES)
+async def test_list_report_openings_unauthorized(
+    client, fastapi_app, set_mock_user, role
+):
+    """Other roles cannot read report openings."""
+    set_mock_user(fastapi_app, [role])
+
+    url = fastapi_app.url_path_for("list_report_openings")
+    response = await client.get(url)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_update_report_openings_as_system_admin(
+    client, fastapi_app, set_mock_user
+):
+    """System Admin can update report openings."""
+    with patch(
+        "lcfs.web.api.report_opening.views.ReportOpeningService.update_report_openings"
+    ) as mock_update:
+        mock_update.return_value = [mock_report_opening]
+
+        set_mock_user(fastapi_app, [RoleEnum.SYSTEM_ADMIN])
+
+        url = fastapi_app.url_path_for("update_report_openings")
+        response = await client.put(
+            url,
+            json={
+                "reportOpenings": [
+                    {
+                        "complianceYear": 2025,
+                        "complianceReportingEnabled": True,
+                        "earlyIssuanceEnabled": False,
+                        "supplementalReportRole": "BCeID",
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("role", WRITE_UNAUTHORIZED_ROLES)
+async def test_update_report_openings_unauthorized(
+    client, fastapi_app, set_mock_user, role
+):
+    """Only System Admin can update report openings."""
+    set_mock_user(fastapi_app, [role])
+
+    url = fastapi_app.url_path_for("update_report_openings")
+    response = await client.put(
+        url,
+        json={
+            "reportOpenings": [
+                {
+                    "complianceYear": 2025,
+                    "complianceReportingEnabled": True,
+                    "earlyIssuanceEnabled": False,
+                    "supplementalReportRole": "BCeID",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 403

--- a/backend/lcfs/web/api/government_notification/views.py
+++ b/backend/lcfs/web/api/government_notification/views.py
@@ -38,7 +38,7 @@ async def get_current_notification(
     response_model=GovernmentNotificationSchema,
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def update_notification(
     request: Request,
     notification_data: GovernmentNotificationUpdateSchema = Body(..., embed=False),
@@ -46,7 +46,7 @@ async def update_notification(
 ):
     """
     Updates the government notification.
-    Only Compliance Manager and Director IDIR users can perform this action.
+    Only System Admin users can perform this action.
     If no notification exists, it will be created.
     """
     return await service.update_notification(notification_data)
@@ -56,14 +56,14 @@ async def update_notification(
     "/",
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def delete_notification(
     request: Request,
     service: GovernmentNotificationService = Depends(),
 ):
     """
     Deletes the government notification.
-    Only Compliance Manager and Director IDIR users can perform this action.
+    Only System Admin users can perform this action.
     Returns a message indicating success or if no notification existed.
     """
     deleted = await service.delete_notification()

--- a/backend/lcfs/web/api/login_bg_image/views.py
+++ b/backend/lcfs/web/api/login_bg_image/views.py
@@ -54,12 +54,12 @@ async def stream_image(
     response_model=List[LoginBgImageSchema],
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def get_all_images(
     request: Request,
     service: LoginBgImageService = Depends(),
 ) -> List[LoginBgImageSchema]:
-    """List all login background images. Administrator only."""
+    """List all login background images. System Admin only."""
     return await service.get_all()
 
 
@@ -68,7 +68,7 @@ async def get_all_images(
     response_model=LoginBgImageSchema,
     status_code=status.HTTP_201_CREATED,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def upload_image(
     request: Request,
     file: UploadFile = File(...),
@@ -76,7 +76,7 @@ async def upload_image(
     caption: Optional[str] = Form(None),
     service: LoginBgImageService = Depends(),
 ) -> LoginBgImageSchema:
-    """Upload a new login background image. Administrator only."""
+    """Upload a new login background image. System Admin only."""
     return await service.upload(file, display_name, caption)
 
 
@@ -85,14 +85,14 @@ async def upload_image(
     response_model=LoginBgImageSchema,
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def update_image(
     request: Request,
     image_id: int,
     data: LoginBgImageUpdateSchema,
     service: LoginBgImageService = Depends(),
 ) -> LoginBgImageSchema:
-    """Update image display name and caption. Administrator only."""
+    """Update image display name and caption. System Admin only."""
     return await service.update(image_id, data)
 
 
@@ -101,13 +101,13 @@ async def update_image(
     response_model=LoginBgImageSchema,
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def activate_image(
     request: Request,
     image_id: int,
     service: LoginBgImageService = Depends(),
 ) -> LoginBgImageSchema:
-    """Set an image as the active login background. Administrator only."""
+    """Set an image as the active login background. System Admin only."""
     return await service.activate(image_id)
 
 
@@ -115,12 +115,12 @@ async def activate_image(
     "/{image_id}",
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def delete_image(
     request: Request,
     image_id: int,
     service: LoginBgImageService = Depends(),
 ):
-    """Delete a login background image. Administrator only."""
+    """Delete a login background image. System Admin only."""
     await service.delete(image_id)
     return {"message": "Image deleted successfully"}

--- a/backend/lcfs/web/api/report_opening/views.py
+++ b/backend/lcfs/web/api/report_opening/views.py
@@ -18,7 +18,7 @@ router = APIRouter()
     response_model=List[ReportOpeningSchema],
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR, RoleEnum.SUPPLIER])
+@view_handler([RoleEnum.SYSTEM_ADMIN, RoleEnum.SUPPLIER])
 async def list_report_openings(
     request: Request,
     service: ReportOpeningService = Depends(),
@@ -31,7 +31,7 @@ async def list_report_openings(
     response_model=List[ReportOpeningSchema],
     status_code=status.HTTP_200_OK,
 )
-@view_handler([RoleEnum.ADMINISTRATOR])
+@view_handler([RoleEnum.SYSTEM_ADMIN])
 async def update_report_openings(
     request: Request,
     payload: ReportOpeningUpdateRequest,

--- a/frontend/src/layouts/MainLayout/components/Navbar.tsx
+++ b/frontend/src/layouts/MainLayout/components/Navbar.tsx
@@ -16,13 +16,13 @@ type NavItem = {
 
 export const Navbar = () => {
   const { t } = useTranslation()
-  const { data: currentUser, hasRoles, hasAnyRole } = useCurrentUser()
+  const { data: currentUser, hasAnyRole } = useCurrentUser()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('xl'))
 
   // Nav Links
   const navMenuItems = useMemo<NavItem[]>(() => {
-    const isAdmin = hasRoles(roles.administrator)
+    const isAdmin = hasAnyRole(roles.administrator, roles.system_admin)
     const canSeeComplianceReports = hasAnyRole(
       roles.government,
       roles.signing_authority,
@@ -84,7 +84,7 @@ export const Navbar = () => {
       activeRoutes.push(...mobileRoutes)
     }
     return activeRoutes
-  }, [currentUser, t, isMobileView, hasRoles, hasAnyRole])
+  }, [currentUser, t, isMobileView, hasAnyRole])
 
   return (
     <BCNavbar

--- a/frontend/src/routes/__tests__/index.test.jsx
+++ b/frontend/src/routes/__tests__/index.test.jsx
@@ -53,9 +53,8 @@ vi.mock('@/views/Dashboard', () => ({
 }))
 
 vi.mock('@/views/Admin/AdminMenu', () => ({
-  AdminMenu: ({ tabIndex }) => (
-    <div data-test={`admin-menu-${tabIndex}`}>Admin Menu {tabIndex}</div>
-  )
+  AdminMenu: () => <div data-test="admin-menu">Admin Menu</div>,
+  AdminLanding: () => <div data-test="admin-landing">Admin Landing</div>
 }))
 
 vi.mock('@/views/Admin/AdminMenu/components/ViewAuditLog', () => ({
@@ -380,7 +379,7 @@ describe('Router Configuration', () => {
       await waitFor(() => {
         expect(screen.getByTestId('main-layout')).toBeInTheDocument()
         // Note: Authentication redirect testing would require more complex integration setup
-        expect(screen.getByTestId('admin-menu-0')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
       })
     })
 
@@ -482,10 +481,9 @@ describe('Router Configuration', () => {
       mockKeycloak.authenticated = true
     })
 
-    it('should redirect /admin to /admin/users', () => {
-      // Verify the /admin route exists and is configured as a redirect
-      // Note: Full navigation testing requires integration test setup due to
-      // AbortSignal compatibility issues between MSW and react-router data router
+    it('should resolve /admin to a role-aware landing page', () => {
+      // The /admin route delegates to a landing component that redirects
+      // based on whether the current user is an Administrator or System Admin.
       const mainLayoutRoute = router.routes.find(
         (route) => route.element?.type?.name === 'MainLayout'
       )
@@ -493,7 +491,7 @@ describe('Router Configuration', () => {
         (route) => route.path === '/admin'
       )
       expect(adminRoute).toBeDefined()
-      expect(adminRoute.element?.type?.name).toBe('Navigate')
+      expect(adminRoute.element).toBeDefined()
     })
 
     it('should render admin users tab', async () => {
@@ -501,7 +499,7 @@ describe('Router Configuration', () => {
       renderRouterWithProviders(testRouter)
 
       await waitFor(() => {
-        expect(screen.getByTestId('admin-menu-0')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
       })
     })
 
@@ -510,7 +508,7 @@ describe('Router Configuration', () => {
       renderRouterWithProviders(testRouter)
 
       await waitFor(() => {
-        expect(screen.getByTestId('admin-menu-1')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
       })
     })
 
@@ -519,7 +517,7 @@ describe('Router Configuration', () => {
       renderRouterWithProviders(testRouter)
 
       await waitFor(() => {
-        expect(screen.getByTestId('admin-menu-3')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
       })
     })
 

--- a/frontend/src/routes/__tests__/navigation.test.jsx
+++ b/frontend/src/routes/__tests__/navigation.test.jsx
@@ -199,13 +199,13 @@ vi.mock('@/views/FuelCodes', () => ({
 }))
 
 vi.mock('@/views/Admin/AdminMenu', () => ({
-  AdminMenu: ({ tabIndex }) => {
+  AdminMenu: () => {
     const location = useLocation()
-    return (
-      <div data-test={`admin-menu-${tabIndex}`}>
-        Admin Menu {tabIndex} - {location.pathname}
-      </div>
-    )
+    return <div data-test="admin-menu">Admin Menu - {location.pathname}</div>
+  },
+  AdminLanding: () => {
+    const location = useLocation()
+    return <div data-test="admin-landing">Admin Landing - {location.pathname}</div>
   }
 }))
 

--- a/frontend/src/routes/__tests__/routeGuards.test.jsx
+++ b/frontend/src/routes/__tests__/routeGuards.test.jsx
@@ -89,7 +89,8 @@ vi.mock('@/views/Transactions', () => ({
 }))
 
 vi.mock('@/views/Admin/AdminMenu', () => ({
-  AdminMenu: ({ tabIndex }) => <div data-test={`admin-menu-${tabIndex}`}>Admin Menu {tabIndex}</div>
+  AdminMenu: () => <div data-test="admin-menu">Admin Menu</div>,
+  AdminLanding: () => <div data-test="admin-landing">Admin Landing</div>
 }))
 
 // Mock authentication
@@ -212,7 +213,7 @@ describe('Route Guards and Authentication', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('main-layout')).toBeInTheDocument()
-        expect(screen.getByTestId('admin-menu-0')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
       })
     })
 
@@ -295,7 +296,7 @@ describe('Route Guards and Authentication', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('main-layout')).toBeInTheDocument()
-        expect(screen.getByTestId('admin-menu-0')).toBeInTheDocument()
+        expect(screen.getByTestId('admin-menu')).toBeInTheDocument()
         expect(screen.queryByTestId('redirect-to-login')).not.toBeInTheDocument()
       })
     })

--- a/frontend/src/routes/routeConfig/adminRoutes.tsx
+++ b/frontend/src/routes/routeConfig/adminRoutes.tsx
@@ -1,6 +1,5 @@
-import { AdminMenu } from '@/views/Admin/AdminMenu'
+import { AdminMenu, AdminLanding } from '@/views/Admin/AdminMenu'
 import ROUTES from '../routes'
-import { Navigate } from 'react-router-dom'
 import { ViewAuditLog } from '@/views/Admin/AdminMenu/components/ViewAuditLog'
 import UserDetailsCard from '@/views/Admin/AdminMenu/components/UserDetailsCard'
 import { AppRouteObject } from '../types'
@@ -14,7 +13,7 @@ const seededRoute: AppRouteObject[] = isNonProdEnvironment
   ? [
       {
         path: ROUTES.ADMIN.SEEDED_USER_ASSOCIATION,
-        element: <AdminMenu tabIndex={5} />,
+        element: <AdminMenu />,
         handle: { title: 'Seeded user association' }
       }
     ]
@@ -23,27 +22,27 @@ const seededRoute: AppRouteObject[] = isNonProdEnvironment
 export const adminRoutes: AppRouteObject[] = [
   {
     path: ROUTES.ADMIN.MAIN,
-    element: <Navigate to={ROUTES.ADMIN.USERS.LIST} replace />,
+    element: <AdminLanding />,
     handle: { title: 'Administration' }
   },
   {
     path: ROUTES.ADMIN.USERS.LIST,
-    element: <AdminMenu tabIndex={0} />,
+    element: <AdminMenu />,
     handle: { title: 'Users' }
   },
   {
     path: ROUTES.ADMIN.USER_ACTIVITY,
-    element: <AdminMenu tabIndex={1} />,
+    element: <AdminMenu />,
     handle: { title: 'User activity' }
   },
   {
     path: ROUTES.ADMIN.USER_LOGIN_HISTORY,
-    element: <AdminMenu tabIndex={2} />,
+    element: <AdminMenu />,
     handle: { title: 'User login history' }
   },
   {
     path: ROUTES.ADMIN.AUDIT_LOG.LIST,
-    element: <AdminMenu tabIndex={3} />,
+    element: <AdminMenu />,
     handle: { title: 'Audit log' }
   },
   ...seededRoute,
@@ -64,7 +63,7 @@ export const adminRoutes: AppRouteObject[] = [
   },
   {
     path: ROUTES.ADMIN.LOGIN_SCREEN_BACKGROUND,
-    element: <AdminMenu tabIndex={4} />,
+    element: <AdminMenu />,
     handle: { title: 'Login screen background' }
   }
 ]

--- a/frontend/src/views/Admin/AdminMenu/AdminLanding.jsx
+++ b/frontend/src/views/Admin/AdminMenu/AdminLanding.jsx
@@ -1,0 +1,27 @@
+import { Navigate } from 'react-router-dom'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { roles } from '@/constants/roles'
+import { ROUTES } from '@/routes/routes'
+import Loading from '@/components/Loading'
+
+// Redirects /admin to the first tab the user can access.
+// Admins go to users list, System Admins go to logon screen background.
+export const AdminLanding = () => {
+  const { data: currentUser, isLoading, hasRoles } = useCurrentUser()
+
+  if (isLoading || !currentUser) {
+    return <Loading />
+  }
+
+  if (hasRoles(roles.administrator)) {
+    return <Navigate to={ROUTES.ADMIN.USERS.LIST} replace />
+  }
+
+  if (hasRoles(roles.system_admin)) {
+    return <Navigate to={ROUTES.ADMIN.LOGIN_SCREEN_BACKGROUND} replace />
+  }
+
+  return <Navigate to={ROUTES.DASHBOARD} replace />
+}
+
+export default AdminLanding

--- a/frontend/src/views/Admin/AdminMenu/Menu.jsx
+++ b/frontend/src/views/Admin/AdminMenu/Menu.jsx
@@ -3,10 +3,9 @@ import { ROUTES } from '@/routes/routes'
 import breakpoints from '@/themes/base/breakpoints'
 import { AdminTabPanel } from '@/views/Admin/AdminMenu/components/AdminTabPanel'
 import { AppBar, Tab, Tabs } from '@mui/material'
-import { PropTypes } from 'prop-types'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import {
   Users,
   SeededUserAssociation,
@@ -15,7 +14,6 @@ import {
   AuditLog,
   LoginScreenBackground
 } from '.'
-import { Role } from '@/components/Role'
 import { roles } from '@/constants/roles'
 import { CONFIG } from '@/constants/config'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
@@ -27,11 +25,16 @@ function a11yProps(index) {
   }
 }
 
-export function AdminMenu({ tabIndex }) {
+export function AdminMenu() {
   const { t } = useTranslation(['admin'])
   const [tabsOrientation, setTabsOrientation] = useState('horizontal')
   const navigate = useNavigate()
+  const location = useLocation()
   const { hasRoles } = useCurrentUser()
+
+  const isAdmin = hasRoles(roles.administrator)
+  const isSystemAdmin = hasRoles(roles.system_admin)
+
   const normalizedEnvironment = (CONFIG.ENVIRONMENT || '').toLowerCase()
   const showSeededAssociation = [
     'local',
@@ -39,45 +42,90 @@ export function AdminMenu({ tabIndex }) {
     'dev',
     'test'
   ].includes(normalizedEnvironment)
-  const showSeededAssociationAdminOnly =
-    showSeededAssociation && hasRoles(roles.administrator)
-  const paths = useMemo(
-    () => {
-      const base = [
-        ROUTES.ADMIN.USERS.LIST,
-        ROUTES.ADMIN.USER_ACTIVITY,
-        ROUTES.ADMIN.USER_LOGIN_HISTORY,
-        ROUTES.ADMIN.AUDIT_LOG.LIST,
-        ROUTES.ADMIN.LOGIN_SCREEN_BACKGROUND
-      ]
-      if (showSeededAssociationAdminOnly) {
-        base.push(ROUTES.ADMIN.SEEDED_USER_ASSOCIATION)
-      }
-      return base
-    },
-    [showSeededAssociationAdminOnly]
-  )
+  const showSeededAssociationAdminOnly = showSeededAssociation && isAdmin
+
+  const tabs = useMemo(() => {
+    const list = []
+    if (isAdmin) {
+      list.push(
+        {
+          key: 'users',
+          label: t('Users'),
+          path: ROUTES.ADMIN.USERS.LIST,
+          component: <Users />,
+          wrapped: true
+        },
+        {
+          key: 'userActivity',
+          label: t('UserActivity'),
+          path: ROUTES.ADMIN.USER_ACTIVITY,
+          component: <UserActivity />
+        },
+        {
+          key: 'userLoginHistory',
+          label: t('UserLoginHistory'),
+          path: ROUTES.ADMIN.USER_LOGIN_HISTORY,
+          component: <UserLoginHistory />
+        },
+        {
+          key: 'auditLog',
+          label: t('AuditLog'),
+          path: ROUTES.ADMIN.AUDIT_LOG.LIST,
+          component: <AuditLog />
+        }
+      )
+    }
+    if (isSystemAdmin) {
+      list.push({
+        key: 'loginScreenBackground',
+        label: t('LoginScreenBackground'),
+        path: ROUTES.ADMIN.LOGIN_SCREEN_BACKGROUND,
+        component: <LoginScreenBackground />
+      })
+    }
+    if (showSeededAssociationAdminOnly) {
+      list.push({
+        key: 'seededUserAssociation',
+        label: t('SeededUserAssociation'),
+        path: ROUTES.ADMIN.SEEDED_USER_ASSOCIATION,
+        component: <SeededUserAssociation />,
+        wrapped: true
+      })
+    }
+    return list
+  }, [isAdmin, isSystemAdmin, showSeededAssociationAdminOnly, t])
+
+  const tabIndex = useMemo(() => {
+    const index = tabs.findIndex(
+      (tab) =>
+        location.pathname === tab.path ||
+        location.pathname === `${tab.path}/`
+    )
+    return index === -1 ? false : index
+  }, [location.pathname, tabs])
 
   useEffect(() => {
-    // A function that sets the orientation state of the tabs.
     function handleTabsOrientation() {
       return window.innerWidth < breakpoints.values.lg
         ? setTabsOrientation('vertical')
         : setTabsOrientation('horizontal')
     }
 
-    // The event listener that's calling the handleTabsOrientation function when resizing the window.
     window.addEventListener('resize', handleTabsOrientation)
-
-    // Call the handleTabsOrientation function to set the state with the initial value.
     handleTabsOrientation()
 
-    // Remove event listener on cleanup
     return () => window.removeEventListener('resize', handleTabsOrientation)
   }, [tabsOrientation])
 
   const handleSetTabValue = (event, newValue) => {
-    navigate(paths[newValue])
+    const next = tabs[newValue]
+    if (next) {
+      navigate(next.path)
+    }
+  }
+
+  if (tabs.length === 0) {
+    return null
   }
 
   return (
@@ -90,42 +138,27 @@ export function AdminMenu({ tabIndex }) {
           aria-label="Tabs for selection of administration options"
           onChange={handleSetTabValue}
         >
-          <Tab label={t('Users')} wrapped {...a11yProps(0)} />
-          <Tab label={t('UserActivity')} {...a11yProps(1)} />
-          <Tab label={t('UserLoginHistory')} {...a11yProps(2)} />
-          <Tab label={t('AuditLog')} {...a11yProps(3)} />
-          <Tab label={t('LoginScreenBackground')} {...a11yProps(4)} />
-          {showSeededAssociationAdminOnly && (
-            <Tab label={t('SeededUserAssociation')} wrapped {...a11yProps(5)} />
-          )}
+          {tabs.map((tab, index) => (
+            <Tab
+              key={tab.key}
+              label={tab.label}
+              wrapped={tab.wrapped}
+              {...a11yProps(index)}
+            />
+          ))}
         </Tabs>
       </AppBar>
-      <AdminTabPanel value={tabIndex} index={0} component="div" mx={-3}>
-        <Users />
-      </AdminTabPanel>
-      <Role roles={[roles.administrator]}>
-        <AdminTabPanel value={tabIndex} index={1} component="div" mx={-3}>
-          <UserActivity />
+      {tabs.map((tab, index) => (
+        <AdminTabPanel
+          key={tab.key}
+          value={tabIndex}
+          index={index}
+          component="div"
+          mx={-3}
+        >
+          {tab.component}
         </AdminTabPanel>
-        <AdminTabPanel value={tabIndex} index={2} component="div" mx={-3}>
-          <UserLoginHistory />
-        </AdminTabPanel>
-        <AdminTabPanel value={tabIndex} index={3} component="div" mx={-3}>
-          <AuditLog />
-        </AdminTabPanel>
-        <AdminTabPanel value={tabIndex} index={4} component="div" mx={-3}>
-          <LoginScreenBackground />
-        </AdminTabPanel>
-        {showSeededAssociationAdminOnly && (
-          <AdminTabPanel value={tabIndex} index={5} component="div" mx={-3}>
-            <SeededUserAssociation />
-          </AdminTabPanel>
-        )}
-      </Role>
+      ))}
     </BCBox>
   )
-}
-
-AdminMenu.propTypes = {
-  tabIndex: PropTypes.number.isRequired
 }

--- a/frontend/src/views/Admin/AdminMenu/__tests__/AdminLanding.test.jsx
+++ b/frontend/src/views/Admin/AdminMenu/__tests__/AdminLanding.test.jsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import { AdminLanding } from '../AdminLanding'
+
+vi.mock('react-router-dom', () => ({
+  Navigate: vi.fn(({ to }) => <div data-test="navigate" data-to={to} />)
+}))
+
+vi.mock('@/components/Loading', () => ({
+  default: vi.fn(() => <div data-test="loading">Loading...</div>)
+}))
+
+vi.mock('@/routes/routes', () => ({
+  ROUTES: {
+    ADMIN: {
+      USERS: { LIST: '/admin/users' },
+      LOGIN_SCREEN_BACKGROUND: '/admin/login-screen-background'
+    },
+    DASHBOARD: '/'
+  }
+}))
+
+vi.mock('@/constants/roles', () => ({
+  roles: {
+    administrator: 'Administrator',
+    system_admin: 'System Admin'
+  }
+}))
+
+const mockUseCurrentUser = vi.fn()
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser()
+}))
+
+const makeUser = ({ hasRoles = () => false, isLoading = false, data = {} } = {}) => ({
+  data,
+  isLoading,
+  hasRoles
+})
+
+describe('AdminLanding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a loading indicator while the current user is being fetched', () => {
+    mockUseCurrentUser.mockReturnValue(
+      makeUser({ isLoading: true, data: null })
+    )
+
+    const { getByTestId, queryByTestId } = render(<AdminLanding />)
+
+    expect(getByTestId('loading')).toBeInTheDocument()
+    expect(queryByTestId('navigate')).not.toBeInTheDocument()
+  })
+
+  it('redirects administrators to the users list', () => {
+    mockUseCurrentUser.mockReturnValue(
+      makeUser({ hasRoles: (role) => role === 'Administrator' })
+    )
+
+    const { getByTestId } = render(<AdminLanding />)
+
+    expect(getByTestId('navigate')).toHaveAttribute('data-to', '/admin/users')
+  })
+
+  it('redirects system admins (without administrator) to the login screen background page', () => {
+    mockUseCurrentUser.mockReturnValue(
+      makeUser({ hasRoles: (role) => role === 'System Admin' })
+    )
+
+    const { getByTestId } = render(<AdminLanding />)
+
+    expect(getByTestId('navigate')).toHaveAttribute(
+      'data-to',
+      '/admin/login-screen-background'
+    )
+  })
+
+  it('prefers the administrator destination when the user has both roles', () => {
+    mockUseCurrentUser.mockReturnValue(
+      makeUser({
+        hasRoles: (role) => role === 'Administrator' || role === 'System Admin'
+      })
+    )
+
+    const { getByTestId } = render(<AdminLanding />)
+
+    expect(getByTestId('navigate')).toHaveAttribute('data-to', '/admin/users')
+  })
+
+  it('falls back to the dashboard for users without any admin privilege', () => {
+    mockUseCurrentUser.mockReturnValue(makeUser())
+
+    const { getByTestId } = render(<AdminLanding />)
+
+    expect(getByTestId('navigate')).toHaveAttribute('data-to', '/')
+  })
+})

--- a/frontend/src/views/Admin/AdminMenu/__tests__/Menu.test.jsx
+++ b/frontend/src/views/Admin/AdminMenu/__tests__/Menu.test.jsx
@@ -6,8 +6,11 @@ import { AdminMenu } from '../Menu'
 const mockNavigate = vi.fn()
 const mockT = vi.fn((key) => key)
 
+const mockLocation = { pathname: '/admin/users' }
+
 vi.mock('react-router-dom', () => ({
-  useNavigate: () => mockNavigate
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation
 }))
 
 vi.mock('react-i18next', () => ({
@@ -21,7 +24,8 @@ vi.mock('@/routes/routes', () => ({
       USER_ACTIVITY: '/admin/user-activity',
       USER_LOGIN_HISTORY: '/admin/user-login-history',
       AUDIT_LOG: { LIST: '/admin/audit-log' },
-      LOGIN_SCREEN_BACKGROUND: '/admin/login-screen-background'
+      LOGIN_SCREEN_BACKGROUND: '/admin/login-screen-background',
+      SEEDED_USER_ASSOCIATION: '/admin/seeded-user-association'
     }
   }
 }))
@@ -49,8 +53,8 @@ vi.mock('@mui/material', () => ({
     </div>
   )),
   Tabs: vi.fn(({ children, onChange, ...props }) => (
-    <div 
-      data-test="tabs" 
+    <div
+      data-test="tabs"
       data-orientation={props.orientation}
       data-value={props.value}
       onClick={(e) => onChange && onChange(e, 1)}
@@ -68,7 +72,7 @@ vi.mock('@mui/material', () => ({
 
 vi.mock('@/views/Admin/AdminMenu/components/AdminTabPanel', () => ({
   AdminTabPanel: vi.fn(({ children, value, index, ...props }) => (
-    <div 
+    <div
       data-test="admin-tab-panel"
       data-value={value}
       data-index={index}
@@ -80,31 +84,34 @@ vi.mock('@/views/Admin/AdminMenu/components/AdminTabPanel', () => ({
   ))
 }))
 
-vi.mock('@/components/Role', () => ({
-  Role: vi.fn(({ children, roles }) => (
-    <div data-test="role" data-roles={roles?.join(',')}>
-      {children}
-    </div>
-  ))
-}))
-
 vi.mock('@/views/Admin/AdminMenu', () => ({
   Users: vi.fn(() => <div data-test="users">Users Component</div>),
-  UserActivity: vi.fn(() => <div data-test="user-activity">UserActivity Component</div>),
-  UserLoginHistory: vi.fn(() => <div data-test="user-login-history">UserLoginHistory Component</div>),
+  UserActivity: vi.fn(() => (
+    <div data-test="user-activity">UserActivity Component</div>
+  )),
+  UserLoginHistory: vi.fn(() => (
+    <div data-test="user-login-history">UserLoginHistory Component</div>
+  )),
   AuditLog: vi.fn(() => <div data-test="audit-log">AuditLog Component</div>),
-  LoginScreenBackground: vi.fn(() => <div data-test="login-screen-background">LoginScreenBackground Component</div>)
+  LoginScreenBackground: vi.fn(() => (
+    <div data-test="login-screen-background">LoginScreenBackground Component</div>
+  )),
+  SeededUserAssociation: vi.fn(() => (
+    <div data-test="seeded-user-association">SeededUserAssociation Component</div>
+  ))
 }))
 
 vi.mock('@/constants/roles', () => ({
   roles: {
-    administrator: 'administrator'
+    administrator: 'Administrator',
+    system_admin: 'System Admin'
   }
 }))
 
+const mockHasRoles = vi.fn()
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
-    hasRoles: vi.fn(() => false),
+    hasRoles: mockHasRoles,
     hasAnyRole: vi.fn(() => false),
     data: null,
     isLoading: false
@@ -124,6 +131,10 @@ describe('AdminMenu Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLocation.pathname = '/admin/users'
+    mockHasRoles.mockImplementation(
+      (role) => role === 'Administrator' || role === 'System Admin'
+    )
     Object.defineProperty(window, 'innerWidth', {
       writable: true,
       configurable: true,
@@ -139,132 +150,149 @@ describe('AdminMenu Component', () => {
     })
   })
 
-  describe('Accessibility', () => {
-    it('renders tabs with correct accessibility attributes', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
+  describe('Component Rendering', () => {
+    it('renders without crashing', () => {
+      const { container } = render(<AdminMenu />)
+      expect(container.querySelector('[data-test="bc-box"]')).toBeTruthy()
+    })
+
+    it('renders tabs for both administrator and system admin when user has both roles', () => {
+      const { container } = render(<AdminMenu />)
+
       const tabs = container.querySelectorAll('[data-test="tab"]')
       expect(tabs).toHaveLength(5)
+    })
 
+    it('renders a tab panel for each visible tab', () => {
+      const { container } = render(<AdminMenu />)
+
+      const panels = container.querySelectorAll('[data-test="admin-tab-panel"]')
+      expect(panels).toHaveLength(5)
+    })
+
+    it('returns nothing when the user has no admin-related roles', () => {
+      mockHasRoles.mockReturnValue(false)
+      const { container } = render(<AdminMenu />)
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('assigns sequential a11y ids to the rendered tabs', () => {
+      const { container } = render(<AdminMenu />)
+
+      const tabs = container.querySelectorAll('[data-test="tab"]')
       tabs.forEach((tab, index) => {
         expect(tab).toHaveAttribute('id', `full-width-tab-${index}`)
-        expect(tab).toHaveAttribute('aria-controls', `full-width-admin-tabs-${index}`)
+        expect(tab).toHaveAttribute(
+          'aria-controls',
+          `full-width-admin-tabs-${index}`
+        )
       })
     })
   })
 
-  describe('Component Rendering', () => {
-    it('renders without crashing', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      expect(container.querySelector('[data-test="bc-box"]')).toBeTruthy()
-    })
+  describe('Role-based tab visibility', () => {
+    it('shows only admin tabs for administrators without system admin', () => {
+      mockHasRoles.mockImplementation((role) => role === 'Administrator')
+      const { container } = render(<AdminMenu />)
 
-    it('renders with different tabIndex values', () => {
-      const { rerender, container } = render(<AdminMenu tabIndex={0} />)
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-value', '0')
-
-      rerender(<AdminMenu tabIndex={1} />)
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-value', '1')
-
-      rerender(<AdminMenu tabIndex={2} />)
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-value', '2')
-
-      rerender(<AdminMenu tabIndex={3} />)
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-value', '3')
-    })
-
-    it('renders all tab components', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
       const tabs = container.querySelectorAll('[data-test="tab"]')
-      expect(tabs).toHaveLength(5)
+      expect(tabs).toHaveLength(4)
+
+      expect(
+        container.querySelector('[data-test="login-screen-background"]')
+      ).toBeNull()
     })
 
-    it('renders all admin tab panels', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
-      const panels = container.querySelectorAll('[data-test="admin-tab-panel"]')
-      expect(panels).toHaveLength(5)
+    it('shows only the login screen background tab for system admins', () => {
+      mockLocation.pathname = '/admin/login-screen-background'
+      mockHasRoles.mockImplementation((role) => role === 'System Admin')
+      const { container } = render(<AdminMenu />)
+
+      const tabs = container.querySelectorAll('[data-test="tab"]')
+      expect(tabs).toHaveLength(1)
+
+      expect(
+        container.querySelector('[data-test="login-screen-background"]')
+      ).toBeTruthy()
+      expect(container.querySelector('[data-test="users"]')).toBeNull()
     })
   })
 
   describe('Responsive Behavior', () => {
     it('sets horizontal orientation for large screens', async () => {
-      Object.defineProperty(window, 'innerWidth', { value: 1300, configurable: true })
-      
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
+      Object.defineProperty(window, 'innerWidth', {
+        value: 1300,
+        configurable: true
+      })
+
+      const { container } = render(<AdminMenu />)
+
       await act(async () => {
         fireEvent(window, new Event('resize'))
       })
-      
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-orientation', 'horizontal')
+
+      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute(
+        'data-orientation',
+        'horizontal'
+      )
     })
 
     it('sets vertical orientation for small screens', async () => {
-      Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
-      
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
+      Object.defineProperty(window, 'innerWidth', {
+        value: 800,
+        configurable: true
+      })
+
+      const { container } = render(<AdminMenu />)
+
       await act(async () => {
         fireEvent(window, new Event('resize'))
       })
-      
-      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute('data-orientation', 'vertical')
+
+      expect(container.querySelector('[data-test="tabs"]')).toHaveAttribute(
+        'data-orientation',
+        'vertical'
+      )
     })
   })
 
   describe('Event Handling', () => {
     it('adds and removes resize event listener', () => {
-      const { unmount } = render(<AdminMenu tabIndex={0} />)
-      
-      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
-      
+      const { unmount } = render(<AdminMenu />)
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        'resize',
+        expect.any(Function)
+      )
+
       unmount()
-      
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'resize',
+        expect.any(Function)
+      )
     })
 
-    it('calls navigate when tab value changes', async () => {
+    it('navigates to the second tab when its index is selected', async () => {
       const user = userEvent.setup()
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
+      const { container } = render(<AdminMenu />)
+
       const tabs = container.querySelector('[data-test="tabs"]')
       await user.click(tabs)
-      
+
       expect(mockNavigate).toHaveBeenCalledWith('/admin/user-activity')
     })
   })
 
   describe('Translation Integration', () => {
     it('uses translation function for tab labels', () => {
-      render(<AdminMenu tabIndex={0} />)
-      
+      render(<AdminMenu />)
+
       expect(mockT).toHaveBeenCalledWith('Users')
       expect(mockT).toHaveBeenCalledWith('UserActivity')
       expect(mockT).toHaveBeenCalledWith('UserLoginHistory')
       expect(mockT).toHaveBeenCalledWith('AuditLog')
       expect(mockT).toHaveBeenCalledWith('LoginScreenBackground')
-    })
-  })
-
-  describe('Role-based Rendering', () => {
-    it('renders role component with administrator role', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
-      const roleComponent = container.querySelector('[data-test="role"]')
-      expect(roleComponent).toBeTruthy()
-      expect(roleComponent).toHaveAttribute('data-roles', 'administrator')
-    })
-
-    it('renders all child components within role-protected panels', () => {
-      const { container } = render(<AdminMenu tabIndex={0} />)
-      
-      expect(container.querySelector('[data-test="users"]')).toBeTruthy()
-      expect(container.querySelector('[data-test="user-activity"]')).toBeTruthy()
-      expect(container.querySelector('[data-test="user-login-history"]')).toBeTruthy()
-      expect(container.querySelector('[data-test="audit-log"]')).toBeTruthy()
-      expect(container.querySelector('[data-test="login-screen-background"]')).toBeTruthy()
     })
   })
 })

--- a/frontend/src/views/Admin/AdminMenu/index.js
+++ b/frontend/src/views/Admin/AdminMenu/index.js
@@ -1,4 +1,5 @@
 export { AdminMenu } from './Menu'
+export { AdminLanding } from './AdminLanding'
 export { Users } from './components/Users'
 export { SeededUserAssociation } from './components/SeededUserAssociation'
 export { UserActivity } from './components/UserActivity'

--- a/frontend/src/views/ComplianceReports/ReportsMenu.jsx
+++ b/frontend/src/views/ComplianceReports/ReportsMenu.jsx
@@ -30,7 +30,7 @@ export function ReportsMenu() {
   const canAccessChargingSitesTab =
     isIDIR || isFeatureEnabled(FEATURE_FLAGS.MANAGE_CHARGING_SITES)
   const canAccessFseTab = isIDIR || isFeatureEnabled(FEATURE_FLAGS.MANAGE_FSE)
-  const isAdministrator = hasRoles(roles.administrator)
+  const isSystemAdmin = hasRoles(roles.system_admin)
 
   const tabs = useMemo(() => {
     const baseTabs = [
@@ -62,7 +62,7 @@ export function ReportsMenu() {
       })
     }
 
-    if (isAdministrator) {
+    if (isSystemAdmin) {
       baseTabs.push({
         key: 'reportOpenings',
         label: t('tabs.reportOpenings'),
@@ -71,7 +71,7 @@ export function ReportsMenu() {
     }
 
     return baseTabs
-  }, [canAccessChargingSitesTab, canAccessFseTab, isAdministrator, isIDIR, t])
+  }, [canAccessChargingSitesTab, canAccessFseTab, isSystemAdmin, isIDIR, t])
 
   const tabIndex = useMemo(() => {
     // Only select tab when on the exact index route, not on detail/nested pages
@@ -123,7 +123,7 @@ export function ReportsMenu() {
 
     if (location.pathname.includes('/report-openings')) {
       return (
-        <Role roles={[roles.administrator]}>
+        <Role roles={[roles.system_admin]}>
           <Outlet />
         </Role>
       )

--- a/frontend/src/views/Dashboard/components/cards/GovernmentNotificationsCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/GovernmentNotificationsCard.jsx
@@ -68,8 +68,8 @@ const getTextContent = (html) => {
 const GovernmentNotificationsCard = () => {
   const { t } = useTranslation(['dashboard'])
   const { enqueueSnackbar } = useSnackbar()
-  const { hasRoles, hasAnyRole } = useCurrentUser()
-  const canEdit = hasAnyRole(roles.compliance_manager, roles.director)
+  const { hasRoles } = useCurrentUser()
+  const canEdit = hasRoles(roles.system_admin)
 
   const { data: notification, isLoading } = useCurrentGovernmentNotification()
   const updateMutation = useUpdateGovernmentNotification({

--- a/frontend/src/views/Dashboard/components/cards/__tests__/GovernmentNotificationsCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/__tests__/GovernmentNotificationsCard.test.jsx
@@ -20,10 +20,11 @@ vi.mock('notistack', async () => {
   }
 })
 
+const mockHasRoles = vi.fn()
 const mockHasAnyRole = vi.fn()
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
-    hasRoles: vi.fn(),
+    hasRoles: mockHasRoles,
     hasAnyRole: mockHasAnyRole
   })
 }))
@@ -78,7 +79,7 @@ const createWrapper = () => {
 describe('GovernmentNotificationsCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockHasAnyRole.mockReturnValue(false)
+    mockHasRoles.mockReturnValue(false)
     mockUseCurrentGovernmentNotification.mockReturnValue({
       data: null,
       isLoading: false
@@ -108,7 +109,7 @@ describe('GovernmentNotificationsCard', () => {
 
   describe('Access Control', () => {
     it('should not render card when no notification exists and user cannot edit', () => {
-      mockHasAnyRole.mockReturnValue(false)
+      mockHasRoles.mockReturnValue(false)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -122,7 +123,7 @@ describe('GovernmentNotificationsCard', () => {
     })
 
     it('should render empty state when no notification exists but user can edit', () => {
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -135,8 +136,8 @@ describe('GovernmentNotificationsCard', () => {
       ).toBeInTheDocument()
     })
 
-    it('should show edit button for compliance managers and directors', () => {
-      mockHasAnyRole.mockReturnValue(true)
+    it('should show edit button for system admins', () => {
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: {
           notificationTitle: 'Test Notification',
@@ -152,7 +153,7 @@ describe('GovernmentNotificationsCard', () => {
     })
 
     it('should not show edit button for regular users', () => {
-      mockHasAnyRole.mockReturnValue(false)
+      mockHasRoles.mockReturnValue(false)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: {
           notificationTitle: 'Test Notification',
@@ -316,7 +317,7 @@ describe('GovernmentNotificationsCard', () => {
 
   describe('Edit Mode', () => {
     beforeEach(() => {
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
     })
 
     it('should enter edit mode when edit button is clicked', async () => {
@@ -358,7 +359,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should show all notification type pills in edit mode', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -381,7 +382,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should select notification type when pill is clicked', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: {
           notificationTitle: 'Test',
@@ -405,7 +406,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should update form fields when user types', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -433,7 +434,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should disable save button when title is empty', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -450,7 +451,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should disable save button when message is empty', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -470,7 +471,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should enable save button when both title and message are filled', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: null,
         isLoading: false
@@ -495,7 +496,7 @@ describe('GovernmentNotificationsCard', () => {
 
     it('should exit edit mode when cancel button is clicked', async () => {
       const user = userEvent.setup()
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: {
           notificationTitle: 'Test',
@@ -529,7 +530,7 @@ describe('GovernmentNotificationsCard', () => {
 
   describe('Save Confirmation Dialog', () => {
     beforeEach(() => {
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
     })
 
     it('should show confirmation dialog when save button is clicked', async () => {
@@ -692,7 +693,7 @@ describe('GovernmentNotificationsCard', () => {
 
   describe('Success and Error Handling', () => {
     beforeEach(() => {
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
     })
 
     it('should show success snackbar on successful save', async () => {
@@ -928,7 +929,7 @@ describe('GovernmentNotificationsCard', () => {
 
   describe('Delete Functionality', () => {
     beforeEach(() => {
-      mockHasAnyRole.mockReturnValue(true)
+      mockHasRoles.mockReturnValue(true)
     })
 
     it('should show delete button when user can edit and notification exists', () => {
@@ -949,7 +950,7 @@ describe('GovernmentNotificationsCard', () => {
     })
 
     it('should not show delete button when user cannot edit', () => {
-      mockHasAnyRole.mockReturnValue(false)
+      mockHasRoles.mockReturnValue(false)
       mockUseCurrentGovernmentNotification.mockReturnValue({
         data: {
           notificationTitle: 'Test Notification',

--- a/frontend/src/views/Dashboard/components/cards/idir/AdminLinksCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/AdminLinksCard.jsx
@@ -7,35 +7,52 @@ import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
 import BCTypography from '@/components/BCTypography'
 import { List, ListItemButton } from '@mui/material'
 import { roles } from '@/constants/roles'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 
 const AdminLinksCard = () => {
   const { t } = useTranslation(['dashboard'])
+  const { hasRoles } = useCurrentUser()
+  const isAdmin = hasRoles(roles.administrator)
+  const isSystemAdmin = hasRoles(roles.system_admin)
+
   const getLinkDataTest = (route) => {
     const sanitizedRoute = route?.replace(/^\//, '').replace(/\//g, '-') || ''
     return `admin-link-${sanitizedRoute || 'root'}`
   }
-  const adminLinks = useMemo(
-    () => [
-      {
-        title: t('dashboard:adminLinks.mngGovUsrsLabel'),
-        route: ROUTES.ADMIN.USERS.LIST
-      },
-      {
-        title: t('dashboard:adminLinks.addEditOrgsLabel'),
-        route: ROUTES.ORGANIZATIONS.LIST
-      },
-      {
-        title: t('dashboard:adminLinks.usrActivity'),
-        route: ROUTES.ADMIN.USER_ACTIVITY
-      },
-      {
+
+  const adminLinks = useMemo(() => {
+    const links = []
+    if (isAdmin) {
+      links.push(
+        {
+          title: t('dashboard:adminLinks.mngGovUsrsLabel'),
+          route: ROUTES.ADMIN.USERS.LIST
+        },
+        {
+          title: t('dashboard:adminLinks.addEditOrgsLabel'),
+          route: ROUTES.ORGANIZATIONS.LIST
+        },
+        {
+          title: t('dashboard:adminLinks.usrActivity'),
+          route: ROUTES.ADMIN.USER_ACTIVITY
+        }
+      )
+    }
+    // Logon screen background is a System Admin-only responsibility.
+    if (isSystemAdmin) {
+      links.push({
         title: t('dashboard:adminLinks.loginScreenBackground'),
         route: ROUTES.ADMIN.LOGIN_SCREEN_BACKGROUND
-      }
-    ],
-    [t]
-  )
+      })
+    }
+    return links
+  }, [isAdmin, isSystemAdmin, t])
+
   const navigate = useNavigate()
+
+  if (adminLinks.length === 0) {
+    return null
+  }
 
   return (
     <BCWidgetCard
@@ -73,7 +90,7 @@ const AdminLinksCard = () => {
   )
 }
 
-const AllowedRoles = [roles.administrator, roles.government]
+const AllowedRoles = [roles.administrator, roles.government, roles.system_admin]
 const IDIRAdminLinksWithRole = withRole(AdminLinksCard, AllowedRoles)
 
 export default IDIRAdminLinksWithRole

--- a/frontend/src/views/Dashboard/components/cards/idir/__tests__/AdminLinksCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/__tests__/AdminLinksCard.test.jsx
@@ -21,6 +21,13 @@ vi.mock('@/utils/withRole', () => ({
   default: vi.fn((Component) => Component)
 }))
 
+const mockHasRoles = vi.fn()
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    hasRoles: mockHasRoles
+  })
+}))
+
 // Mock components
 vi.mock('@/components/BCWidgetCard/BCWidgetCard', () => ({
   __esModule: true,
@@ -90,6 +97,11 @@ describe('AdminLinksCard Component', () => {
     vi.resetAllMocks()
     useNavigate.mockReturnValue(mockNavigate)
     useTranslation.mockReturnValue({ t: mockT })
+    // Default: user has both Administrator and System Admin roles so all
+    // admin links (including the System Admin-only login background) show.
+    mockHasRoles.mockImplementation(
+      (role) => role === roles.administrator || role === roles.system_admin
+    )
   })
 
   it('renders the component with correct structure', () => {
@@ -235,5 +247,49 @@ describe('AdminLinksCard Component', () => {
 
     // Translation should be called again since component re-rendered
     expect(mockT).toHaveBeenCalled()
+  })
+
+  describe('Role-based link visibility', () => {
+    it('hides the login screen background link from administrators without system admin', () => {
+      mockHasRoles.mockImplementation((role) => role === roles.administrator)
+
+      render(<AdminLinksCard />, { wrapper })
+
+      expect(screen.getByText('Manage Government Users')).toBeInTheDocument()
+      expect(screen.getByText('Add/Edit Organizations')).toBeInTheDocument()
+      expect(screen.getByText('User Activity')).toBeInTheDocument()
+      expect(
+        screen.queryByText('Login Screen Background')
+      ).not.toBeInTheDocument()
+
+      const listItemButtons = screen.getAllByTestId('mui-list-item-button')
+      expect(listItemButtons).toHaveLength(3)
+    })
+
+    it('shows only the login screen background link for system admins', () => {
+      mockHasRoles.mockImplementation((role) => role === roles.system_admin)
+
+      render(<AdminLinksCard />, { wrapper })
+
+      expect(
+        screen.queryByText('Manage Government Users')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('Add/Edit Organizations')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText('User Activity')).not.toBeInTheDocument()
+      expect(screen.getByText('Login Screen Background')).toBeInTheDocument()
+
+      const listItemButtons = screen.getAllByTestId('mui-list-item-button')
+      expect(listItemButtons).toHaveLength(1)
+    })
+
+    it('renders nothing for government users without admin privileges', () => {
+      mockHasRoles.mockReturnValue(false)
+
+      const { container } = render(<AdminLinksCard />, { wrapper })
+
+      expect(container).toBeEmptyDOMElement()
+    })
   })
 })


### PR DESCRIPTION
This PR makes System Admin the only role that can manage logon background, report openings, and dashboard notifications.

- API: Enforce System Admin on protected actions.
- Routes: Add role-aware `/admin` landing.
- Tabs: Admin and Reports tabs by role.
- Dashboard: Update the admin links card.
- Nav / tests: Update navbar visibility and role coverage.

Closes #4254