### PR TITLE
Fix: LCFS - Credit transfers missing from Credit Market Report due to timezone bug (#4215)

### DIFF
--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -103,7 +103,7 @@ CREATE OR REPLACE VIEW vw_transfer_base AS
 SELECT
     transfer.transfer_id,
     transfer_status.status,
-    (coalesce(transfer.transaction_effective_date, transfer_history.update_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date calculated_effective_date,
+    (coalesce(transfer.transaction_effective_date AT TIME ZONE 'UTC', transfer_history.update_date) AT TIME ZONE 'America/Vancouver')::date AS calculated_effective_date,
     from_organization.name AS from_organization,
     to_organization.name AS to_organization,
     price_per_unit,


### PR DESCRIPTION
## Summary

Fixes [#4215](https://github.com/bcgov/lcfs/issues/4215). Credit transfers recorded in the evening Pacific time were appearing one day later in the Metabase Credit Market Report (e.g. transfers recorded Mar 31 PT showing as Apr 1).

## Root cause

In `vw_transfer_base` ([metabase.sql:106](backend/lcfs/db/sql/views/metabase.sql#L106)):

```sql
(coalesce(transfer.transaction_effective_date, transfer_history.update_date)
   AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
```

- `transfer.transaction_effective_date` is `TIMESTAMP` (naive, stored as UTC).
- `transfer_history.update_date` is `TIMESTAMPTZ`.
- `COALESCE` promotes the naive value to `TIMESTAMPTZ` using the **session tz** (UTC) before picking.

Once the COALESCE result is `TIMESTAMPTZ`, `AT TIME ZONE 'UTC'` strips tz to naive-UTC, then `AT TIME ZONE 'America/Vancouver'` re-adds tz treating the naive as Vancouver — landing 7h forward, which then casts back to date using the session UTC. Net effect: dates shifted forward by a day for any evening-PT timestamp.

The sibling `mv_transaction_aggregate`, which doesn't COALESCE across types, was already returning the correct date — the two views disagreed.

## Fix

Apply `AT TIME ZONE 'UTC'` to the naive column **before** the COALESCE so both args are `TIMESTAMPTZ`, then convert to Vancouver after:

```sql
(coalesce(transfer.transaction_effective_date AT TIME ZONE 'UTC', transfer_history.update_date)
   AT TIME ZONE 'America/Vancouver')::date AS calculated_effective_date
```

No migration needed — `prestart.sh` runs `manage_views.py` on every startup, which re-reads `metabase.sql` and recreates views. Existing data is stored correctly (UTC-naive); **no DB data change required**.

## Test plan

- [x] Reproduced locally: transfers 5322, 5324, 5325 showed `calculated_effective_date = 2026-04-01` before the fix
- [x] After applying fix, all three correctly show `2026-03-31`
- [x] Spot-checked 15 recent recorded transfers — `vw_transfer_base.calculated_effective_date` now matches `mv_transaction_aggregate.transaction_effective_date` exactly
- [ ] Verify in test environment: confirm Credit Market Report in Metabase shows the missing transfers under March after deploy