### PR TITLE
Refactor: Decompose OrganizationsService into focused service classes (#4084)

### DIFF
--- a/backend/lcfs/tests/organizations/test_credit_market_services.py
+++ b/backend/lcfs/tests/organizations/test_credit_market_services.py
@@ -2,7 +2,9 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from lcfs.web.api.organizations.services import OrganizationsService
+from lcfs.web.api.organizations.credit_market_service import (
+    OrganizationCreditMarketService,
+)
 from lcfs.db.models.organization.Organization import Organization
 from lcfs.db.models.organization.CreditMarketAuditLog import CreditMarketAuditLog
 from lcfs.web.api.base import PaginationRequestSchema, SortOrder
@@ -31,10 +33,9 @@ class TestCreditMarketServices:
     @pytest.fixture
     def credit_market_service(self, mock_repo, mock_transaction_repo, mock_notification_service):
         """Create service instance with mocked dependencies"""
-        service = OrganizationsService()
+        service = OrganizationCreditMarketService()
         service.repo = mock_repo
         service.transaction_repo = mock_transaction_repo
-        service.redis_balance_service = AsyncMock()
         service.notification_service = mock_notification_service
         return service
 
@@ -286,33 +287,6 @@ class TestCreditMarketServices:
         mock_repo.get_credit_market_organizations.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_get_organization_includes_balance_for_credit_market(
-        self, 
-        credit_market_service, 
-        mock_repo, 
-        sample_organization
-    ):
-        """Test that get_organization includes balance data for credit market validation"""
-        
-        mock_repo.get_organization.return_value = sample_organization
-        mock_repo.get_current_year_early_issuance.return_value = False
-        
-        # Mock balance calculations
-        credit_market_service.calculate_total_balance = AsyncMock(return_value=400)
-        credit_market_service.calculate_reserved_balance = AsyncMock(return_value=25)
-
-        result = await credit_market_service.get_organization(1)
-
-        # Verify balance calculations were called
-        credit_market_service.calculate_total_balance.assert_called_once_with(1)
-        credit_market_service.calculate_reserved_balance.assert_called_once_with(1)
-        
-        # Verify original org data is also included
-        assert result.organization_id == 1
-        assert result.credit_market_contact_name == "John Doe"
-        assert result.credits_to_sell == 100
-
-    @pytest.mark.anyio
     async def test_update_handles_database_error(
         self, 
         credit_market_service, 
@@ -368,32 +342,7 @@ class TestCreditMarketServices:
         assert isinstance(listing.display_in_credit_market, bool)
 
     @pytest.mark.anyio
-    async def test_balance_calculation_integration(
-        self, 
-        credit_market_service, 
-        mock_repo, 
-        sample_organization
-    ):
-        """Test integration with balance calculation for credit market features"""
-        
-        mock_repo.get_organization.return_value = sample_organization
-        mock_repo.get_current_year_early_issuance.return_value = False
-
-        # Mock balance calculations
-        credit_market_service.calculate_total_balance = AsyncMock(return_value=125)
-        credit_market_service.calculate_reserved_balance = AsyncMock(return_value=25)
-
-        result = await credit_market_service.get_organization(1)
-
-        # Verify balance calculations were integrated properly
-        credit_market_service.calculate_total_balance.assert_called_once_with(1)
-        credit_market_service.calculate_reserved_balance.assert_called_once_with(1)
-        
-        assert result.total_balance == 125
-        assert result.reserved_balance == 25
-
-    @pytest.mark.anyio
-    @patch('lcfs.web.api.organizations.services.settings.feature_credit_market_notifications', True)
+    @patch('lcfs.web.api.organizations.credit_market_service.settings.feature_credit_market_notifications', True)
     async def test_credit_market_notification_sent_on_new_listing(
         self, 
         credit_market_service, 
@@ -441,7 +390,7 @@ class TestCreditMarketServices:
         assert call_args.notification_data.related_organization_id == 1
 
     @pytest.mark.anyio
-    @patch('lcfs.web.api.organizations.services.settings.feature_credit_market_notifications', True)
+    @patch('lcfs.web.api.organizations.credit_market_service.settings.feature_credit_market_notifications', True)
     async def test_credit_market_notification_sent_when_credits_added_to_existing_listing(
         self, 
         credit_market_service, 
@@ -567,7 +516,7 @@ class TestCreditMarketServices:
         mock_notification_service.send_notification.assert_not_called()
 
     @pytest.mark.anyio
-    @patch('lcfs.web.api.organizations.services.settings.feature_credit_market_notifications', True)
+    @patch('lcfs.web.api.organizations.credit_market_service.settings.feature_credit_market_notifications', True)
     async def test_credit_market_notification_handles_errors_gracefully(
         self, 
         credit_market_service, 
@@ -619,7 +568,7 @@ class TestCreditMarketServices:
         mock_notification_service.send_notification.assert_called_once()
 
     @pytest.mark.anyio
-    @patch('lcfs.web.api.organizations.services.settings.feature_credit_market_notifications', False)
+    @patch('lcfs.web.api.organizations.credit_market_service.settings.feature_credit_market_notifications', False)
     async def test_credit_market_notification_not_sent_when_flag_disabled(
         self, 
         credit_market_service, 
@@ -662,7 +611,7 @@ class TestCreditMarketServices:
         mock_notification_service.send_notification.assert_not_called()
 
     @pytest.mark.anyio
-    @patch('lcfs.web.api.organizations.services.settings.feature_credit_market_notifications', True)
+    @patch('lcfs.web.api.organizations.credit_market_service.settings.feature_credit_market_notifications', True)
     async def test_credit_market_notification_skipped_for_idir_updates(
         self,
         credit_market_service,

--- a/backend/lcfs/tests/organizations/test_credit_market_views.py
+++ b/backend/lcfs/tests/organizations/test_credit_market_views.py
@@ -85,8 +85,10 @@ class TestCreditMarketViews:
             mock_service_instance.get_credit_market_listings.return_value = mock_listings
             return mock_service_instance
         
-        from lcfs.web.api.organizations.services import OrganizationsService
-        fastapi_app.dependency_overrides[OrganizationsService] = mock_service_dependency
+        from lcfs.web.api.organizations.credit_market_service import (
+            OrganizationCreditMarketService,
+        )
+        fastapi_app.dependency_overrides[OrganizationCreditMarketService] = mock_service_dependency
 
         response = await client.get("/api/organizations/credit-market-listings")
 
@@ -109,7 +111,7 @@ class TestCreditMarketViews:
     ):
         """Test successful update of current organization's credit market details"""
         
-        with patch('lcfs.web.api.organizations.views.OrganizationsService') as mock_service:
+        with patch('lcfs.web.api.organizations.views.OrganizationCreditMarketService') as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             
@@ -158,7 +160,7 @@ class TestCreditMarketViews:
     ):
         """Test update handles service errors appropriately"""
         
-        with patch('lcfs.web.api.organizations.views.OrganizationsService') as mock_service:
+        with patch('lcfs.web.api.organizations.views.OrganizationCreditMarketService') as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             mock_service_instance.update_organization_credit_market_details.side_effect = Exception("Service error")
@@ -198,7 +200,7 @@ class TestCreditMarketViews:
     ):
         """Test IDIR endpoint updates credit market details and skips notifications"""
 
-        with patch('lcfs.web.api.organizations.views.OrganizationsService') as mock_service:
+        with patch('lcfs.web.api.organizations.views.OrganizationCreditMarketService') as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
 
@@ -253,8 +255,10 @@ class TestCreditMarketViews:
             mock_service_instance.get_credit_market_listings.return_value = mock_listings
             return mock_service_instance
         
-        from lcfs.web.api.organizations.services import OrganizationsService
-        fastapi_app.dependency_overrides[OrganizationsService] = mock_service_dependency
+        from lcfs.web.api.organizations.credit_market_service import (
+            OrganizationCreditMarketService,
+        )
+        fastapi_app.dependency_overrides[OrganizationCreditMarketService] = mock_service_dependency
 
         response = await client.get("/api/organizations/credit-market-listings")
 
@@ -275,7 +279,7 @@ class TestCreditMarketViews:
     ):
         """Test that update data is properly transformed and validated"""
         
-        with patch('lcfs.web.api.organizations.views.OrganizationsService') as mock_service:
+        with patch('lcfs.web.api.organizations.views.OrganizationCreditMarketService') as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             
@@ -320,8 +324,10 @@ class TestCreditMarketViews:
             mock_service_instance.get_credit_market_listings.return_value = mock_listings
             return mock_service_instance
         
-        from lcfs.web.api.organizations.services import OrganizationsService
-        fastapi_app.dependency_overrides[OrganizationsService] = mock_service_dependency
+        from lcfs.web.api.organizations.credit_market_service import (
+            OrganizationCreditMarketService,
+        )
+        fastapi_app.dependency_overrides[OrganizationCreditMarketService] = mock_service_dependency
 
         response = await client.get("/api/organizations/credit-market-listings")
 
@@ -356,7 +362,7 @@ class TestCreditMarketViews:
             "credits_to_sell": 300
         }
         
-        with patch('lcfs.web.api.organizations.views.OrganizationsService') as mock_service:
+        with patch('lcfs.web.api.organizations.views.OrganizationCreditMarketService') as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             
@@ -390,8 +396,10 @@ class TestCreditMarketViews:
         def mock_service_dependency():
             return mock_service_instance
         
-        from lcfs.web.api.organizations.services import OrganizationsService
-        fastapi_app.dependency_overrides[OrganizationsService] = mock_service_dependency
+        from lcfs.web.api.organizations.credit_market_service import (
+            OrganizationCreditMarketService,
+        )
+        fastapi_app.dependency_overrides[OrganizationCreditMarketService] = mock_service_dependency
 
         response = await client.get("/api/organizations/credit-market-listings")
 
@@ -439,8 +447,10 @@ class TestCreditMarketViews:
             )
             return mock_service_instance
 
-        from lcfs.web.api.organizations.services import OrganizationsService
-        fastapi_app.dependency_overrides[OrganizationsService] = mock_service_dependency
+        from lcfs.web.api.organizations.credit_market_service import (
+            OrganizationCreditMarketService,
+        )
+        fastapi_app.dependency_overrides[OrganizationCreditMarketService] = mock_service_dependency
 
         response = await client.post(
             "/api/organizations/credit-market-audit-logs/list",

--- a/backend/lcfs/tests/organizations/test_organizations_service.py
+++ b/backend/lcfs/tests/organizations/test_organizations_service.py
@@ -4,6 +4,8 @@ import unittest
 from decimal import Decimal
 from types import SimpleNamespace
 from lcfs.web.api.organizations.services import OrganizationsService
+from lcfs.web.api.organizations.penalty_service import OrganizationPenaltyService
+from lcfs.web.api.organizations.link_key_service import OrganizationLinkKeyService
 from lcfs.web.api.organizations.schema import (
     OrganizationSummaryResponseSchema,
     OrganizationCreateSchema,
@@ -51,6 +53,20 @@ def organizations_service(mock_repo, mock_redis_service, mock_transaction_repo):
     service.repo = mock_repo
     service.redis_balance_service = mock_redis_service
     service.transaction_repo = mock_transaction_repo
+    return service
+
+
+@pytest.fixture
+def penalty_service(mock_repo):
+    service = OrganizationPenaltyService()
+    service.repo = mock_repo
+    return service
+
+
+@pytest.fixture
+def link_key_service(mock_repo):
+    service = OrganizationLinkKeyService()
+    service.repo = mock_repo
     return service
 
 
@@ -230,7 +246,7 @@ async def test_get_organization_names_passes_org_filters(
 
 @pytest.mark.anyio
 async def test_get_penalty_analytics_aggregates_values(
-    organizations_service, mock_repo
+    penalty_service, mock_repo
 ):
     """Ensure penalty analytics aggregates automatic and discretionary penalties correctly."""
 
@@ -292,7 +308,7 @@ async def test_get_penalty_analytics_aggregates_values(
         return_value=(summaries, penalty_logs)
     )
 
-    result = await organizations_service.get_penalty_analytics(organization_id=123)
+    result = await penalty_service.get_penalty_analytics(organization_id=123)
 
     assert isinstance(result, PenaltyAnalyticsResponseSchema)
     assert len(result.yearly_penalties) == 2
@@ -312,7 +328,7 @@ async def test_get_penalty_analytics_aggregates_values(
 
 
 @pytest.mark.anyio
-async def test_get_penalty_logs_paginated(organizations_service, mock_repo):
+async def test_get_penalty_logs_paginated(penalty_service, mock_repo):
     pagination = PaginationRequestSchema(page=2, size=5, filters=[], sort_orders=[])
 
     mock_repo.get_penalty_logs_paginated = AsyncMock(
@@ -337,7 +353,7 @@ async def test_get_penalty_logs_paginated(organizations_service, mock_repo):
         )
     )
 
-    result = await organizations_service.get_penalty_logs_paginated(
+    result = await penalty_service.get_penalty_logs_paginated(
         organization_id=99, pagination=pagination
     )
 
@@ -349,7 +365,7 @@ async def test_get_penalty_logs_paginated(organizations_service, mock_repo):
 
 
 @pytest.mark.anyio
-async def test_create_penalty_log(organizations_service, mock_repo):
+async def test_create_penalty_log(penalty_service, mock_repo):
     payload = PenaltyLogCreateSchema(
         compliance_period_id=10,
         contravention_type=ContraventionTypeEnum.SINGLE,
@@ -378,7 +394,7 @@ async def test_create_penalty_log(organizations_service, mock_repo):
 
     mock_repo.create_penalty_log = AsyncMock(return_value=penalty_model)
 
-    result = await organizations_service.create_penalty_log(1, payload)
+    result = await penalty_service.create_penalty_log(1, payload)
 
     assert result.penalty_log_id == 1
     assert result.compliance_year == "2024"
@@ -386,7 +402,7 @@ async def test_create_penalty_log(organizations_service, mock_repo):
 
 
 @pytest.mark.anyio
-async def test_update_penalty_log(organizations_service, mock_repo):
+async def test_update_penalty_log(penalty_service, mock_repo):
     payload = PenaltyLogUpdateSchema(
         compliance_period_id=11,
         contravention_type=ContraventionTypeEnum.CONTINUOUS,
@@ -430,7 +446,7 @@ async def test_update_penalty_log(organizations_service, mock_repo):
     mock_repo.get_penalty_log_by_id = AsyncMock(return_value=existing)
     mock_repo.update_penalty_log = AsyncMock(return_value=updated)
 
-    result = await organizations_service.update_penalty_log(1, 2, payload)
+    result = await penalty_service.update_penalty_log(1, 2, payload)
 
     assert result.penalty_log_id == 2
     assert result.contravention_type == ContraventionTypeEnum.CONTINUOUS.value
@@ -440,12 +456,12 @@ async def test_update_penalty_log(organizations_service, mock_repo):
 
 
 @pytest.mark.anyio
-async def test_delete_penalty_log(organizations_service, mock_repo):
+async def test_delete_penalty_log(penalty_service, mock_repo):
     existing = SimpleNamespace(penalty_log_id=3)
     mock_repo.get_penalty_log_by_id = AsyncMock(return_value=existing)
     mock_repo.delete_penalty_log = AsyncMock(return_value=True)
 
-    result = await organizations_service.delete_penalty_log(1, 3)
+    result = await penalty_service.delete_penalty_log(1, 3)
 
     assert result is None
     mock_repo.delete_penalty_log.assert_awaited_once_with(1, 3)
@@ -687,7 +703,7 @@ async def test_apply_organization_filters_with_registration_status_false_string(
 
 
 @pytest.mark.anyio
-async def test_get_available_forms_success(organizations_service):
+async def test_get_available_forms_success(link_key_service):
     """Test successful retrieval of available forms"""
     from lcfs.web.api.organizations.schema import AvailableFormsSchema
     from types import SimpleNamespace
@@ -702,12 +718,12 @@ async def test_get_available_forms_success(organizations_service):
         ),
     ]
 
-    organizations_service.repo.get_available_forms_for_link_keys = AsyncMock(
+    link_key_service.repo.get_available_forms_for_link_keys = AsyncMock(
         return_value=mock_forms
     )
 
     # Test the method
-    result = await organizations_service.get_available_forms()
+    result = await link_key_service.get_available_forms()
 
     assert isinstance(result, AvailableFormsSchema)
     assert len(result.forms) == 2
@@ -718,12 +734,12 @@ async def test_get_available_forms_success(organizations_service):
     assert result.forms[2]["name"] == "Form B"
     assert result.forms[2]["slug"] == "form-b"
 
-    organizations_service.repo.get_available_forms_for_link_keys.assert_called_once()
+    link_key_service.repo.get_available_forms_for_link_keys.assert_called_once()
 
 
 # Link Key Service Tests
 @pytest.mark.anyio
-async def test_get_organization_link_keys_success(organizations_service):
+async def test_get_organization_link_keys_success(link_key_service):
     """Test successful retrieval of organization link keys"""
     from lcfs.web.api.organizations.schema import OrganizationLinkKeysListSchema
 
@@ -743,15 +759,14 @@ async def test_get_organization_link_keys_success(organizations_service):
     mock_link_key.create_date = "2024-01-01"
     mock_link_key.update_date = "2024-01-01"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_organization_link_keys = AsyncMock(
+    link_key_service.repo.get_organization_link_keys = AsyncMock(
         return_value=[mock_link_key]
     )
 
-    # Test the method
-    result = await organizations_service.get_organization_link_keys(organization_id)
+    result = await link_key_service.get_organization_link_keys(organization_id)
 
     assert isinstance(result, OrganizationLinkKeysListSchema)
     assert result.organization_id == organization_id
@@ -761,31 +776,30 @@ async def test_get_organization_link_keys_success(organizations_service):
     assert result.link_keys[0].form_name == "Test Form"
     assert result.link_keys[0].link_key == "test-key-123"
 
-    organizations_service.repo.get_organization.assert_called_once_with(organization_id)
-    organizations_service.repo.get_organization_link_keys.assert_called_once_with(
+    link_key_service.repo.get_organization.assert_called_once_with(organization_id)
+    link_key_service.repo.get_organization_link_keys.assert_called_once_with(
         organization_id
     )
 
 
 @pytest.mark.anyio
-async def test_get_organization_link_keys_organization_not_found(organizations_service):
+async def test_get_organization_link_keys_organization_not_found(link_key_service):
     """Test get_organization_link_keys when organization doesn't exist"""
     from lcfs.web.exception.exceptions import DataNotFoundException
 
     organization_id = 999
 
-    organizations_service.repo.get_organization = AsyncMock(return_value=None)
+    link_key_service.repo.get_organization = AsyncMock(return_value=None)
 
-    # Test the method - should raise DataNotFoundException
     with pytest.raises(DataNotFoundException, match="Organization not found"):
-        await organizations_service.get_organization_link_keys(organization_id)
+        await link_key_service.get_organization_link_keys(organization_id)
 
-    organizations_service.repo.get_organization.assert_called_once_with(organization_id)
-    organizations_service.repo.get_organization_link_keys.assert_not_called()
+    link_key_service.repo.get_organization.assert_called_once_with(organization_id)
+    link_key_service.repo.get_organization_link_keys.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_generate_link_key_success(organizations_service):
+async def test_generate_link_key_success(link_key_service):
     """Test successful link key generation"""
     from lcfs.web.api.organizations.schema import LinkKeyOperationResponseSchema
 
@@ -804,28 +818,22 @@ async def test_generate_link_key_success(organizations_service):
     mock_form.description = "A test form"
     mock_form.allows_anonymous = True
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
-    organizations_service.repo.get_link_key_by_form_id = AsyncMock(
-        return_value=None  # No existing key
-    )
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
+    link_key_service.repo.get_link_key_by_form_id = AsyncMock(return_value=None)
 
-    # Mock the created link key
     created_link_key = MagicMock()
     created_link_key.link_key = "generated-key-456"
-    organizations_service.repo.create_link_key = AsyncMock(
-        return_value=created_link_key
-    )
+    link_key_service.repo.create_link_key = AsyncMock(return_value=created_link_key)
 
     with patch(
-        "lcfs.web.api.organizations.services.generate_secure_link_key"
+        "lcfs.web.api.organizations.link_key_service.generate_secure_link_key"
     ) as mock_gen_key:
         mock_gen_key.return_value = "generated-key-456"
 
-        # Test the method
-        result = await organizations_service.generate_link_key(
+        result = await link_key_service.generate_link_key(
             organization_id, form_id, user
         )
 
@@ -835,19 +843,17 @@ async def test_generate_link_key_success(organizations_service):
     assert result.form_name == "Test Form"
     assert result.form_slug == "test-form"
 
-    organizations_service.repo.get_organization.assert_called_once_with(organization_id)
-    organizations_service.repo.get_form_by_id.assert_called_once_with(form_id)
-    organizations_service.repo.get_link_key_by_form_id.assert_called_once_with(
+    link_key_service.repo.get_organization.assert_called_once_with(organization_id)
+    link_key_service.repo.get_form_by_id.assert_called_once_with(form_id)
+    link_key_service.repo.get_link_key_by_form_id.assert_called_once_with(
         organization_id, form_id
     )
-    organizations_service.repo.create_link_key.assert_called_once()
+    link_key_service.repo.create_link_key.assert_called_once()
 
 
 @pytest.mark.anyio
-async def test_generate_link_key_already_exists(organizations_service):
+async def test_generate_link_key_already_exists(link_key_service):
     """Test generate_link_key when link key already exists"""
-    from lcfs.web.exception.exceptions import DataNotFoundException
-
     organization_id = 1
     form_id = 1
 
@@ -860,23 +866,22 @@ async def test_generate_link_key_already_exists(organizations_service):
 
     mock_link_key = MagicMock()
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
-    organizations_service.repo.get_link_key_by_form_id = AsyncMock(
-        return_value=mock_link_key  # Existing key
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
+    link_key_service.repo.get_link_key_by_form_id = AsyncMock(
+        return_value=mock_link_key
     )
 
-    # Test the method - should raise ValueError
     with pytest.raises(ValueError, match="Link key already exists"):
-        await organizations_service.generate_link_key(organization_id, form_id)
+        await link_key_service.generate_link_key(organization_id, form_id)
 
-    organizations_service.repo.create_link_key.assert_not_called()
+    link_key_service.repo.create_link_key.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_generate_link_key_form_not_found(organizations_service):
+async def test_generate_link_key_form_not_found(link_key_service):
     """Test generate_link_key when form does not exist"""
     from lcfs.web.exception.exceptions import DataNotFoundException
 
@@ -886,19 +891,19 @@ async def test_generate_link_key_form_not_found(organizations_service):
     mock_organization = MagicMock()
     mock_organization.name = "Test Organization"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=None)
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=None)
 
     with pytest.raises(DataNotFoundException, match="Form with ID 999 not found"):
-        await organizations_service.generate_link_key(organization_id, form_id)
+        await link_key_service.generate_link_key(organization_id, form_id)
 
-    organizations_service.repo.create_link_key.assert_not_called()
+    link_key_service.repo.create_link_key.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_generate_link_key_form_not_anonymous(organizations_service):
+async def test_generate_link_key_form_not_anonymous(link_key_service):
     """Test generate_link_key when form does not allow anonymous"""
     organization_id = 1
     form_id = 2
@@ -910,19 +915,19 @@ async def test_generate_link_key_form_not_anonymous(organizations_service):
     mock_form.allows_anonymous = False
     mock_form.name = "Private Form"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
 
     with pytest.raises(ValueError, match="Form does not support anonymous access"):
-        await organizations_service.generate_link_key(organization_id, form_id)
+        await link_key_service.generate_link_key(organization_id, form_id)
 
-    organizations_service.repo.create_link_key.assert_not_called()
+    link_key_service.repo.create_link_key.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_regenerate_link_key_success(organizations_service):
+async def test_regenerate_link_key_success(link_key_service):
     """Test successful link key regeneration"""
     from lcfs.web.api.organizations.schema import LinkKeyOperationResponseSchema
 
@@ -940,28 +945,24 @@ async def test_regenerate_link_key_success(organizations_service):
     mock_link_key = MagicMock()
     mock_link_key.link_key = "old-key"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
-    organizations_service.repo.get_link_key_by_form_id = AsyncMock(
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
+    link_key_service.repo.get_link_key_by_form_id = AsyncMock(
         return_value=mock_link_key
     )
 
-    # Mock the updated link key
     updated_link_key = MagicMock()
     updated_link_key.link_key = "regenerated-key-789"
-    organizations_service.repo.update_link_key = AsyncMock(
-        return_value=updated_link_key
-    )
+    link_key_service.repo.update_link_key = AsyncMock(return_value=updated_link_key)
 
     with patch(
-        "lcfs.web.api.organizations.services.generate_secure_link_key"
+        "lcfs.web.api.organizations.link_key_service.generate_secure_link_key"
     ) as mock_gen_key:
         mock_gen_key.return_value = "regenerated-key-789"
 
-        # Test the method
-        result = await organizations_service.regenerate_link_key(
+        result = await link_key_service.regenerate_link_key(
             organization_id, form_id, user
         )
 
@@ -971,16 +972,16 @@ async def test_regenerate_link_key_success(organizations_service):
     assert result.form_name == "Test Form"
     assert result.form_slug == "test-form"
 
-    organizations_service.repo.get_organization.assert_called_once_with(organization_id)
-    organizations_service.repo.get_form_by_id.assert_called_once_with(form_id)
-    organizations_service.repo.get_link_key_by_form_id.assert_called_once_with(
+    link_key_service.repo.get_organization.assert_called_once_with(organization_id)
+    link_key_service.repo.get_form_by_id.assert_called_once_with(form_id)
+    link_key_service.repo.get_link_key_by_form_id.assert_called_once_with(
         organization_id, form_id
     )
-    organizations_service.repo.update_link_key.assert_called_once()
+    link_key_service.repo.update_link_key.assert_called_once()
 
 
 @pytest.mark.anyio
-async def test_regenerate_link_key_no_existing_key(organizations_service):
+async def test_regenerate_link_key_no_existing_key(link_key_service):
     """Test regenerate_link_key when no existing link key found"""
     from lcfs.web.exception.exceptions import DataNotFoundException
 
@@ -993,23 +994,20 @@ async def test_regenerate_link_key_no_existing_key(organizations_service):
     mock_form = MagicMock()
     mock_form.name = "Test Form"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
-    organizations_service.repo.get_link_key_by_form_id = AsyncMock(
-        return_value=None  # No existing key
-    )
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=mock_form)
+    link_key_service.repo.get_link_key_by_form_id = AsyncMock(return_value=None)
 
-    # Test the method - should raise DataNotFoundException
     with pytest.raises(DataNotFoundException, match="No link key found"):
-        await organizations_service.regenerate_link_key(organization_id, form_id)
+        await link_key_service.regenerate_link_key(organization_id, form_id)
 
-    organizations_service.repo.update_link_key.assert_not_called()
+    link_key_service.repo.update_link_key.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_regenerate_link_key_form_not_found(organizations_service):
+async def test_regenerate_link_key_form_not_found(link_key_service):
     """Test regenerate_link_key when form does not exist"""
     from lcfs.web.exception.exceptions import DataNotFoundException
 
@@ -1019,17 +1017,17 @@ async def test_regenerate_link_key_form_not_found(organizations_service):
     mock_organization = MagicMock()
     mock_organization.name = "Test Organization"
 
-    organizations_service.repo.get_organization = AsyncMock(
+    link_key_service.repo.get_organization = AsyncMock(
         return_value=mock_organization
     )
-    organizations_service.repo.get_form_by_id = AsyncMock(return_value=None)
+    link_key_service.repo.get_form_by_id = AsyncMock(return_value=None)
 
     with pytest.raises(DataNotFoundException, match="Form with ID 123 not found"):
-        await organizations_service.regenerate_link_key(organization_id, form_id)
+        await link_key_service.regenerate_link_key(organization_id, form_id)
 
 
 @pytest.mark.anyio
-async def test_validate_link_key_success(organizations_service):
+async def test_validate_link_key_success(link_key_service):
     """Test successful link key validation"""
     from lcfs.web.api.organizations.schema import LinkKeyValidationSchema
 
@@ -1038,7 +1036,6 @@ async def test_validate_link_key_success(organizations_service):
     mock_organization = MagicMock()
     mock_organization.name = "Test Organization"
 
-    # Mock link key record with organization
     mock_link_key_record = MagicMock()
     mock_link_key_record.organization_id = 1
     mock_link_key_record.form_id = 1
@@ -1046,12 +1043,11 @@ async def test_validate_link_key_success(organizations_service):
     mock_link_key_record.form_slug = "test-form"
     mock_link_key_record.organization = mock_organization
 
-    organizations_service.repo.get_link_key_by_key = AsyncMock(
+    link_key_service.repo.get_link_key_by_key = AsyncMock(
         return_value=mock_link_key_record
     )
 
-    # Test the method
-    result = await organizations_service.validate_link_key(link_key_value)
+    result = await link_key_service.validate_link_key(link_key_value)
 
     assert isinstance(result, LinkKeyValidationSchema)
     assert result.organization_id == 1
@@ -1061,22 +1057,19 @@ async def test_validate_link_key_success(organizations_service):
     assert result.organization_name == "Test Organization"
     assert result.is_valid is True
 
-    organizations_service.repo.get_link_key_by_key.assert_called_once_with(
-        link_key_value
-    )
+    link_key_service.repo.get_link_key_by_key.assert_called_once_with(link_key_value)
 
 
 @pytest.mark.anyio
-async def test_validate_link_key_invalid(organizations_service):
+async def test_validate_link_key_invalid(link_key_service):
     """Test link key validation with invalid key"""
     from lcfs.web.api.organizations.schema import LinkKeyValidationSchema
 
     link_key_value = "invalid-key-123"
 
-    organizations_service.repo.get_link_key_by_key = AsyncMock(return_value=None)
+    link_key_service.repo.get_link_key_by_key = AsyncMock(return_value=None)
 
-    # Test the method
-    result = await organizations_service.validate_link_key(link_key_value)
+    result = await link_key_service.validate_link_key(link_key_value)
 
     assert isinstance(result, LinkKeyValidationSchema)
     assert result.organization_id == 0
@@ -1086,9 +1079,7 @@ async def test_validate_link_key_invalid(organizations_service):
     assert result.organization_name == ""
     assert result.is_valid is False
 
-    organizations_service.repo.get_link_key_by_key.assert_called_once_with(
-        link_key_value
-    )
+    link_key_service.repo.get_link_key_by_key.assert_called_once_with(link_key_value)
 
 
 # Company Overview Service Tests

--- a/backend/lcfs/tests/organizations/test_organizations_views.py
+++ b/backend/lcfs/tests/organizations/test_organizations_views.py
@@ -5,6 +5,12 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from lcfs.web.api.organizations.services import (
     OrganizationsService as ServiceDependency,
 )
+from lcfs.web.api.organizations.link_key_service import (
+    OrganizationLinkKeyService,
+)
+from lcfs.web.api.organizations.penalty_service import (
+    OrganizationPenaltyService,
+)
 from lcfs.db.models.user.Role import RoleEnum
 
 
@@ -72,7 +78,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -81,7 +87,7 @@ class TestOrganizationLinkKeyViews:
             )
 
             # Ensure FastAPI uses the mocked service
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -112,7 +118,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -120,7 +126,7 @@ class TestOrganizationLinkKeyViews:
                 sample_link_keys_list
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -149,7 +155,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -157,7 +163,7 @@ class TestOrganizationLinkKeyViews:
                 sample_link_key_operation_response
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -189,7 +195,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -197,7 +203,7 @@ class TestOrganizationLinkKeyViews:
                 sample_link_key_operation_response
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -229,13 +235,13 @@ class TestOrganizationLinkKeyViews:
         )
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             mock_service_instance.validate_link_key.return_value = valid_response
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -262,7 +268,7 @@ class TestOrganizationLinkKeyViews:
         """Test link key validation with invalid key"""
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -272,7 +278,7 @@ class TestOrganizationLinkKeyViews:
             invalid_response.is_valid = False
             mock_service_instance.validate_link_key.return_value = invalid_response
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -309,13 +315,13 @@ class TestOrganizationLinkKeyViews:
         empty_forms = {"forms": {}}
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
             mock_service_instance.get_available_forms.return_value = empty_forms
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -340,7 +346,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -348,7 +354,7 @@ class TestOrganizationLinkKeyViews:
                 DataNotFoundException("Organization not found")
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -380,7 +386,7 @@ class TestOrganizationLinkKeyViews:
         }
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -388,7 +394,7 @@ class TestOrganizationLinkKeyViews:
                 empty_link_keys
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -423,7 +429,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -431,7 +437,7 @@ class TestOrganizationLinkKeyViews:
                 "Organization not found"
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -455,7 +461,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -463,7 +469,7 @@ class TestOrganizationLinkKeyViews:
                 "Link key already exists"
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -489,7 +495,7 @@ class TestOrganizationLinkKeyViews:
         set_mock_user(fastapi_app, [RoleEnum.ANALYST])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -500,8 +506,8 @@ class TestOrganizationLinkKeyViews:
             fastapi_app.dependency_overrides[
                 __import__(
                     "lcfs.web.api.organizations.views",
-                    fromlist=["OrganizationsService"],
-                ).OrganizationsService
+                    fromlist=["OrganizationLinkKeyService"],
+                ).OrganizationLinkKeyService
             ] = lambda: mock_service_instance
 
             response = await client.put("/api/organizations/1/link-keys/1")
@@ -521,7 +527,7 @@ class TestOrganizationLinkKeyViews:
         """Test validate_link_key with empty key"""
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -556,7 +562,7 @@ class TestOrganizationLinkKeyViews:
         mock_user_profile.return_value = user_mock
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -565,7 +571,7 @@ class TestOrganizationLinkKeyViews:
             )
 
             # Ensure the route uses our mocked service
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -599,7 +605,7 @@ class TestOrganizationLinkKeyViews:
         mock_user_profile.return_value = user_mock
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationLinkKeyService"
         ) as mock_service:
             mock_service_instance = AsyncMock()
             mock_service.return_value = mock_service_instance
@@ -607,7 +613,7 @@ class TestOrganizationLinkKeyViews:
                 sample_link_key_operation_response
             )
 
-            fastapi_app.dependency_overrides[ServiceDependency] = (
+            fastapi_app.dependency_overrides[OrganizationLinkKeyService] = (
                 lambda: mock_service_instance
             )
 
@@ -743,14 +749,14 @@ class TestPenaltyEndpointsOrgCheck:
         set_mock_user(fastapi_app, [RoleEnum.SUPPLIER], {"organization_id": 1})
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationPenaltyService"
         ) as mock_service_cls:
             mock_svc = AsyncMock()
             mock_service_cls.return_value = mock_svc
             mock_svc.get_penalty_analytics.return_value = MagicMock(
                 yearly_summaries=[], automatic_total=0, discretionary_total=0
             )
-            fastapi_app.dependency_overrides[ServiceDependency] = lambda: mock_svc
+            fastapi_app.dependency_overrides[OrganizationPenaltyService] = lambda: mock_svc
 
             async with AsyncClient(app=fastapi_app, base_url="http://test") as client:
                 response = await client.get("/api/organizations/1/penalties/analytics")
@@ -764,7 +770,7 @@ class TestPenaltyEndpointsOrgCheck:
         """Supplier cannot fetch penalty analytics for another org."""
         set_mock_user(fastapi_app, [RoleEnum.SUPPLIER], {"organization_id": 99})
 
-        with patch("lcfs.web.api.organizations.views.OrganizationsService"):
+        with patch("lcfs.web.api.organizations.views.OrganizationPenaltyService"):
             async with AsyncClient(app=fastapi_app, base_url="http://test") as client:
                 response = await client.get("/api/organizations/1/penalties/analytics")
 
@@ -778,14 +784,14 @@ class TestPenaltyEndpointsOrgCheck:
         set_mock_user(fastapi_app, [RoleEnum.GOVERNMENT])
 
         with patch(
-            "lcfs.web.api.organizations.views.OrganizationsService"
+            "lcfs.web.api.organizations.views.OrganizationPenaltyService"
         ) as mock_service_cls:
             mock_svc = AsyncMock()
             mock_service_cls.return_value = mock_svc
             mock_svc.get_penalty_analytics.return_value = MagicMock(
                 yearly_summaries=[], automatic_total=0, discretionary_total=0
             )
-            fastapi_app.dependency_overrides[ServiceDependency] = lambda: mock_svc
+            fastapi_app.dependency_overrides[OrganizationPenaltyService] = lambda: mock_svc
 
             async with AsyncClient(app=fastapi_app, base_url="http://test") as client:
                 response = await client.get("/api/organizations/5/penalties/analytics")

--- a/backend/lcfs/web/api/organizations/credit_market_service.py
+++ b/backend/lcfs/web/api/organizations/credit_market_service.py
@@ -1,0 +1,303 @@
+import json
+import math
+from typing import Dict
+
+import structlog
+from fastapi import Depends
+
+from lcfs.db.models.organization.CreditMarketAuditLog import CreditMarketAuditLog
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.settings import settings
+from lcfs.web.api.base import (
+    NotificationTypeEnum,
+    PaginationRequestSchema,
+    PaginationResponseSchema,
+    apply_filter_conditions,
+    get_field_for_filter,
+    validate_pagination,
+)
+from lcfs.web.api.notification.schema import (
+    NotificationMessageSchema,
+    NotificationRequestSchema,
+)
+from lcfs.web.api.notification.services import NotificationService
+from lcfs.web.api.transaction.repo import TransactionRepository
+from lcfs.web.core.decorators import service_handler
+from lcfs.web.exception.exceptions import DataNotFoundException
+
+from .repo import OrganizationsRepository
+from .schema import (
+    CreditMarketAuditLogItemSchema,
+    CreditMarketAuditLogListResponseSchema,
+    OrganizationCreditMarketListingSchema,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+
+class OrganizationCreditMarketService:
+    def __init__(
+        self,
+        repo: OrganizationsRepository = Depends(OrganizationsRepository),
+        transaction_repo: TransactionRepository = Depends(TransactionRepository),
+        notification_service: NotificationService = Depends(NotificationService),
+    ) -> None:
+        self.repo = repo
+        self.transaction_repo = transaction_repo
+        self.notification_service = notification_service
+
+    @staticmethod
+    def _credit_market_snapshot(organization: Organization) -> Dict[str, object]:
+        """Build a normalized snapshot for credit market change detection."""
+        return {
+            "credit_market_contact_name": organization.credit_market_contact_name,
+            "credit_market_contact_email": organization.credit_market_contact_email,
+            "credit_market_contact_phone": organization.credit_market_contact_phone,
+            "credit_market_is_seller": bool(organization.credit_market_is_seller),
+            "credit_market_is_buyer": bool(organization.credit_market_is_buyer),
+            "credits_to_sell": int(organization.credits_to_sell or 0),
+            "display_in_credit_market": bool(organization.display_in_credit_market),
+        }
+
+    @staticmethod
+    def _role_in_market(is_seller: bool, is_buyer: bool) -> str | None:
+        roles = []
+        if is_seller:
+            roles.append("Seller")
+        if is_buyer:
+            roles.append("Buyer")
+        return ", ".join(roles) if roles else None
+
+    async def calculate_total_balance(self, organization_id: int) -> int:
+        return await self.transaction_repo.calculate_total_balance(organization_id)
+
+    @service_handler
+    async def update_organization_credit_market_details(
+        self,
+        organization_id: int,
+        credit_market_data: dict,
+        user=None,
+        skip_notifications: bool = False,
+    ):
+        """
+        Update only the credit market contact details for an organization.
+        This method only updates the specific credit market fields without affecting other organization data.
+
+        Args:
+            organization_id: Target organization identifier.
+            credit_market_data: Credit market fields to update.
+            user: Requesting user profile (used for auditing).
+            skip_notifications: When True, suppresses outbound credit market notifications
+                even if the update would normally trigger them. Intended for IDIR/government edits.
+        """
+        organization = await self.repo.get_organization(organization_id)
+        if not organization:
+            raise DataNotFoundException("Organization not found")
+
+        before_snapshot = self._credit_market_snapshot(organization)
+
+        was_displayed_in_market = organization.display_in_credit_market or False
+        old_credits_to_sell = organization.credits_to_sell or 0
+
+        allowed_fields = {
+            "credit_market_contact_name",
+            "credit_market_contact_email",
+            "credit_market_contact_phone",
+            "credit_market_is_seller",
+            "credit_market_is_buyer",
+            "credits_to_sell",
+            "display_in_credit_market",
+        }
+
+        for key, value in credit_market_data.items():
+            if key in allowed_fields and hasattr(organization, key):
+                if key == "credits_to_sell" and value is not None:
+                    if value < 0:
+                        raise ValueError("Credits to sell cannot be negative")
+
+                    total_balance = await self.calculate_total_balance(
+                        organization.organization_id
+                    )
+                    if value > total_balance:
+                        raise ValueError(
+                            f"Credits to sell ({value}) cannot exceed available balance ({total_balance})"
+                        )
+
+                setattr(organization, key, value)
+
+        if user:
+            organization.update_user = user.keycloak_username
+
+        updated_organization = await self.repo.update_organization(organization)
+        after_snapshot = self._credit_market_snapshot(updated_organization)
+
+        if before_snapshot != after_snapshot and bool(
+            updated_organization.display_in_credit_market
+        ):
+            changed_by = (
+                user.keycloak_username if user else updated_organization.update_user
+            )
+            await self.repo.create_credit_market_audit_log(
+                organization=updated_organization, changed_by=changed_by
+            )
+
+        is_now_displayed = updated_organization.display_in_credit_market or False
+        new_credits_to_sell = updated_organization.credits_to_sell or 0
+
+        is_new_listing = (
+            is_now_displayed
+            and new_credits_to_sell > 0
+            and (not was_displayed_in_market or old_credits_to_sell == 0)
+        )
+
+        if (
+            is_new_listing
+            and settings.feature_credit_market_notifications
+            and not skip_notifications
+        ):
+            await self._send_credit_market_notification(updated_organization, user)
+
+        return updated_organization
+
+    @service_handler
+    async def get_credit_market_listings(self):
+        """
+        Get organizations that have opted to display in the credit trading market.
+        Returns organizations with their credit market contact details for public viewing.
+        """
+        organizations = await self.repo.get_credit_market_organizations()
+
+        return [
+            OrganizationCreditMarketListingSchema(
+                organization_id=org.organization_id,
+                organization_name=org.name,
+                credits_to_sell=org.credits_to_sell or 0,
+                display_in_credit_market=org.display_in_credit_market,
+                credit_market_is_seller=org.credit_market_is_seller or False,
+                credit_market_is_buyer=org.credit_market_is_buyer or False,
+                credit_market_contact_name=org.credit_market_contact_name,
+                credit_market_contact_email=org.credit_market_contact_email,
+                credit_market_contact_phone=org.credit_market_contact_phone,
+            )
+            for org in organizations
+        ]
+
+    @service_handler
+    async def get_credit_market_audit_logs_paginated(
+        self, pagination: PaginationRequestSchema
+    ) -> CreditMarketAuditLogListResponseSchema:
+        """
+        Fetch paginated credit market audit logs with filtering and sorting.
+        """
+        conditions = []
+        pagination = validate_pagination(pagination)
+
+        if pagination.filters:
+            for filter_model in pagination.filters:
+                filter_value = filter_model.filter
+                filter_option = filter_model.type
+                filter_type = filter_model.filter_type
+
+                if filter_type == "date":
+                    filter_value = []
+                    if filter_model.date_from:
+                        filter_value.append(filter_model.date_from)
+                    if filter_model.date_to:
+                        filter_value.append(filter_model.date_to)
+                    if not filter_value:
+                        continue
+
+                if filter_model.field == "organization_name":
+                    field = get_field_for_filter(Organization, "name")
+                else:
+                    field = get_field_for_filter(
+                        CreditMarketAuditLog, filter_model.field
+                    )
+                if field is None:
+                    continue
+
+                condition = apply_filter_conditions(
+                    field, filter_value, filter_option, filter_type
+                )
+                if condition is not None:
+                    conditions.append(condition)
+
+        offset = (pagination.page - 1) * pagination.size
+        limit = pagination.size
+        audit_logs, total_count = (
+            await self.repo.get_credit_market_audit_logs_paginated(
+                offset, limit, conditions, pagination.sort_orders
+            )
+        )
+
+        rows = [
+            CreditMarketAuditLogItemSchema(
+                credit_market_audit_log_id=entry.credit_market_audit_log_id,
+                organization_name=entry.organization.name if entry.organization else "",
+                credits_to_sell=entry.credits_to_sell or 0,
+                role_in_market=self._role_in_market(
+                    bool(entry.credit_market_is_seller),
+                    bool(entry.credit_market_is_buyer),
+                ),
+                contact_person=entry.contact_person,
+                phone=entry.phone,
+                email=entry.email,
+                changed_by=entry.changed_by,
+                uploaded_date=entry.create_date,
+            )
+            for entry in audit_logs
+        ]
+
+        return CreditMarketAuditLogListResponseSchema(
+            credit_market_audit_logs=rows,
+            pagination=PaginationResponseSchema(
+                total=total_count,
+                page=pagination.page,
+                size=pagination.size,
+                total_pages=math.ceil(total_count / pagination.size)
+                if pagination.size
+                else 0,
+            ),
+        )
+
+    async def _send_credit_market_notification(
+        self, organization: Organization, user=None
+    ):
+        """
+        Send notification to subscribed BCeID users when new credits are listed for sale.
+        """
+        try:
+            message_data = {
+                "organizationName": organization.name,
+                "creditsToSell": organization.credits_to_sell,
+                "service": "CreditMarket",
+                "action": "CreditsListedForSale",
+            }
+
+            notification_data = NotificationMessageSchema(
+                type="Credit market - credits listed for sale",
+                related_transaction_id=f"CM{organization.organization_id}",
+                message=json.dumps(message_data),
+                related_organization_id=organization.organization_id,
+                origin_user_profile_id=user.user_profile_id if user else None,
+            )
+
+            await self.notification_service.send_notification(
+                NotificationRequestSchema(
+                    notification_types=[
+                        NotificationTypeEnum.BCEID__CREDIT_MARKET__CREDITS_LISTED_FOR_SALE
+                    ],
+                    notification_context={
+                        "subject": f"LCFS Credit Market - New Credits Available from {organization.name}"
+                    },
+                    notification_data=notification_data,
+                )
+            )
+
+            logger.info(
+                f"Credit market notification sent for organization {organization.organization_id}"
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to send credit market notification: {str(e)}")

--- a/backend/lcfs/web/api/organizations/link_key_service.py
+++ b/backend/lcfs/web/api/organizations/link_key_service.py
@@ -1,0 +1,184 @@
+import structlog
+from fastapi import Depends
+
+from lcfs.db.models.organization.Organization import generate_secure_link_key
+from lcfs.db.models.organization.OrganizationLinkKey import OrganizationLinkKey
+from lcfs.web.core.decorators import service_handler
+from lcfs.web.exception.exceptions import DataNotFoundException
+
+from .repo import OrganizationsRepository
+from .schema import (
+    AvailableFormsSchema,
+    LinkKeyOperationResponseSchema,
+    LinkKeyValidationSchema,
+    OrganizationLinkKeyResponseSchema,
+    OrganizationLinkKeysListSchema,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+
+class OrganizationLinkKeyService:
+    def __init__(
+        self,
+        repo: OrganizationsRepository = Depends(OrganizationsRepository),
+    ) -> None:
+        self.repo = repo
+
+    @service_handler
+    async def get_available_forms(self) -> AvailableFormsSchema:
+        """
+        Get available forms for link key generation.
+        """
+        forms = await self.repo.get_available_forms_for_link_keys()
+
+        return AvailableFormsSchema(
+            forms={
+                form.form_id: {
+                    "id": form.form_id,
+                    "name": form.name,
+                    "slug": form.slug,
+                    "description": form.description,
+                }
+                for form in forms
+            }
+        )
+
+    @service_handler
+    async def get_organization_link_keys(
+        self, organization_id: int
+    ) -> OrganizationLinkKeysListSchema:
+        """
+        Get all link keys for an organization.
+        """
+        organization = await self.repo.get_organization(organization_id)
+        if not organization:
+            raise DataNotFoundException("Organization not found")
+
+        link_keys = await self.repo.get_organization_link_keys(organization_id)
+
+        link_key_responses = [
+            OrganizationLinkKeyResponseSchema(
+                link_key_id=lk.link_key_id,
+                organization_id=lk.organization_id,
+                form_id=lk.form_id,
+                form_name=lk.form_name,
+                form_slug=lk.form_slug,
+                link_key=lk.link_key,
+                create_date=lk.create_date,
+                update_date=lk.update_date,
+            )
+            for lk in link_keys
+        ]
+
+        return OrganizationLinkKeysListSchema(
+            organization_id=organization_id,
+            organization_name=organization.name,
+            link_keys=link_key_responses,
+        )
+
+    @service_handler
+    async def generate_link_key(
+        self, organization_id: int, form_id: int, user=None
+    ) -> LinkKeyOperationResponseSchema:
+        """
+        Generate a new secure link key for a specific form.
+        """
+        organization = await self.repo.get_organization(organization_id)
+        if not organization:
+            raise DataNotFoundException("Organization not found")
+
+        form = await self.repo.get_form_by_id(form_id)
+        if not form:
+            raise DataNotFoundException(f"Form with ID {form_id} not found")
+
+        if not form.allows_anonymous:
+            raise ValueError("Form does not support anonymous access")
+
+        existing_link_key = await self.repo.get_link_key_by_form_id(
+            organization_id, form_id
+        )
+        if existing_link_key:
+            raise ValueError(
+                f"Link key already exists for {form.name}. "
+                "Please regenerate if you want to replace it."
+            )
+
+        new_link_key = generate_secure_link_key()
+
+        link_key_record = OrganizationLinkKey(
+            organization_id=organization_id,
+            form_id=form_id,
+            link_key=new_link_key,
+        )
+
+        created_link_key = await self.repo.create_link_key(link_key_record)
+
+        return LinkKeyOperationResponseSchema(
+            link_key=created_link_key.link_key,
+            form_id=form_id,
+            form_name=form.name,
+            form_slug=form.slug,
+        )
+
+    @service_handler
+    async def regenerate_link_key(
+        self, organization_id: int, form_id: int, user=None
+    ) -> LinkKeyOperationResponseSchema:
+        """
+        Regenerate the link key for a specific form.
+        This invalidates the previous key and creates a new one.
+        """
+        organization = await self.repo.get_organization(organization_id)
+        if not organization:
+            raise DataNotFoundException("Organization not found")
+
+        form = await self.repo.get_form_by_id(form_id)
+        if not form:
+            raise DataNotFoundException(f"Form with ID {form_id} not found")
+
+        existing_link_key = await self.repo.get_link_key_by_form_id(
+            organization_id, form_id
+        )
+        if not existing_link_key:
+            raise DataNotFoundException(f"No link key found for {form.name}")
+
+        new_link_key = generate_secure_link_key()
+        existing_link_key.link_key = new_link_key
+
+        updated_link_key = await self.repo.update_link_key(existing_link_key)
+
+        return LinkKeyOperationResponseSchema(
+            link_key=updated_link_key.link_key,
+            form_id=form_id,
+            form_name=form.name,
+            form_slug=form.slug,
+        )
+
+    @service_handler
+    async def validate_link_key(self, link_key: str) -> LinkKeyValidationSchema:
+        """
+        Validate a link key and return the associated organization and form info.
+        Returns detailed validation result including form info and organization info.
+        """
+        link_key_record = await self.repo.get_link_key_by_key(link_key)
+
+        if not link_key_record:
+            return LinkKeyValidationSchema(
+                organization_id=0,
+                form_id=0,
+                form_name="Unknown",
+                form_slug="unknown",
+                organization_name="",
+                is_valid=False,
+            )
+
+        return LinkKeyValidationSchema(
+            organization_id=link_key_record.organization_id,
+            form_id=link_key_record.form_id,
+            form_name=link_key_record.form_name,
+            form_slug=link_key_record.form_slug,
+            organization_name=link_key_record.organization.name,
+            is_valid=True,
+        )

--- a/backend/lcfs/web/api/organizations/penalty_service.py
+++ b/backend/lcfs/web/api/organizations/penalty_service.py
@@ -1,0 +1,259 @@
+import math
+from decimal import Decimal
+from typing import List
+
+import structlog
+from fastapi import Depends
+
+from lcfs.web.api.base import (
+    PaginationRequestSchema,
+    PaginationResponseSchema,
+    validate_pagination,
+)
+from lcfs.web.core.decorators import service_handler
+from lcfs.web.exception.exceptions import DataNotFoundException
+
+from .repo import OrganizationsRepository
+from .schema import (
+    PenaltyAnalyticsResponseSchema,
+    PenaltyLogCreateSchema,
+    PenaltyLogEntrySchema,
+    PenaltyLogListResponseSchema,
+    PenaltyLogUpdateSchema,
+    PenaltyTotalsSchema,
+    PenaltyYearlySummarySchema,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+
+class OrganizationPenaltyService:
+    def __init__(
+        self,
+        repo: OrganizationsRepository = Depends(OrganizationsRepository),
+    ) -> None:
+        self.repo = repo
+
+    def _map_penalty_log_model(self, penalty_log) -> PenaltyLogEntrySchema:
+        compliance_year = None
+        if penalty_log and getattr(penalty_log, "compliance_period", None):
+            compliance_year = penalty_log.compliance_period.description
+
+        return PenaltyLogEntrySchema(
+            penalty_log_id=penalty_log.penalty_log_id,
+            compliance_period_id=penalty_log.compliance_period_id,
+            compliance_year=compliance_year,
+            contravention_type=penalty_log.contravention_type,
+            offence_history=bool(penalty_log.offence_history),
+            deliberate=bool(penalty_log.deliberate),
+            efforts_to_correct=bool(penalty_log.efforts_to_correct),
+            economic_benefit_derived=bool(penalty_log.economic_benefit_derived),
+            efforts_to_prevent_recurrence=bool(
+                penalty_log.efforts_to_prevent_recurrence
+            ),
+            notes=penalty_log.notes,
+            penalty_amount=float(penalty_log.penalty_amount or 0),
+        )
+
+    @service_handler
+    async def get_penalty_analytics(
+        self, organization_id: int
+    ) -> PenaltyAnalyticsResponseSchema:
+        """
+        Assemble penalty analytics data for the organization, combining automatic
+        penalties from compliance reports with discretionary penalties from the
+        penalty log.
+        """
+
+        def _to_float(value) -> float:
+            if value is None:
+                return 0.0
+            if isinstance(value, Decimal):
+                return float(value)
+            return float(value)
+
+        summaries, penalty_logs = await self.repo.get_penalty_analytics_data(
+            organization_id
+        )
+
+        yearly_penalties: List[PenaltyYearlySummarySchema] = []
+        total_auto_renewable = 0.0
+        total_auto_low_carbon = 0.0
+
+        for row in summaries:
+            penalty_override_enabled = bool(row.get("penalty_override_enabled"))
+
+            renewable_penalty = (
+                _to_float(row.get("renewable_penalty_override"))
+                if penalty_override_enabled
+                and row.get("renewable_penalty_override") is not None
+                else _to_float(row.get("line_11_penalty_gasoline"))
+                + _to_float(row.get("line_11_penalty_diesel"))
+                + _to_float(row.get("line_11_penalty_jet_fuel"))
+            )
+
+            low_carbon_penalty = (
+                _to_float(row.get("low_carbon_penalty_override"))
+                if penalty_override_enabled
+                and row.get("low_carbon_penalty_override") is not None
+                else _to_float(row.get("line_21_penalty_payable"))
+            )
+
+            compliance_year_value = row.get("compliance_year")
+            try:
+                compliance_year = (
+                    int(compliance_year_value)
+                    if compliance_year_value is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                compliance_year = compliance_year_value
+
+            total_automatic = renewable_penalty + low_carbon_penalty
+            total_auto_renewable += renewable_penalty
+            total_auto_low_carbon += low_carbon_penalty
+
+            yearly_penalties.append(
+                PenaltyYearlySummarySchema(
+                    compliance_period_id=row.get("compliance_period_id"),
+                    compliance_year=compliance_year,
+                    auto_renewable=renewable_penalty,
+                    auto_low_carbon=low_carbon_penalty,
+                    total_automatic=total_automatic,
+                )
+            )
+
+        penalty_log_entries: List[PenaltyLogEntrySchema] = []
+        discretionary_total = 0.0
+
+        for log in penalty_logs:
+            penalty_amount = _to_float(log.get("penalty_amount"))
+            discretionary_total += penalty_amount
+
+            compliance_year_value = log.get("compliance_year")
+            try:
+                compliance_year = (
+                    int(compliance_year_value)
+                    if compliance_year_value is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                compliance_year = compliance_year_value
+
+            penalty_log_entries.append(
+                PenaltyLogEntrySchema(
+                    penalty_log_id=log.get("penalty_log_id"),
+                    compliance_period_id=log.get("compliance_period_id"),
+                    compliance_year=compliance_year,
+                    contravention_type=log.get("contravention_type"),
+                    offence_history=bool(log.get("offence_history")),
+                    deliberate=bool(log.get("deliberate")),
+                    efforts_to_correct=bool(log.get("efforts_to_correct")),
+                    economic_benefit_derived=bool(log.get("economic_benefit_derived")),
+                    efforts_to_prevent_recurrence=bool(
+                        log.get("efforts_to_prevent_recurrence")
+                    ),
+                    notes=log.get("notes"),
+                    penalty_amount=penalty_amount,
+                )
+            )
+
+        total_automatic = total_auto_renewable + total_auto_low_carbon
+
+        totals = PenaltyTotalsSchema(
+            auto_renewable=total_auto_renewable,
+            auto_low_carbon=total_auto_low_carbon,
+            discretionary=discretionary_total,
+            total_automatic=total_automatic,
+            total=total_automatic + discretionary_total,
+        )
+
+        return PenaltyAnalyticsResponseSchema(
+            yearly_penalties=yearly_penalties,
+            totals=totals,
+            penalty_logs=penalty_log_entries,
+        )
+
+    @service_handler
+    async def get_penalty_logs_paginated(
+        self, organization_id: int, pagination: PaginationRequestSchema
+    ) -> PenaltyLogListResponseSchema:
+        pagination = validate_pagination(pagination)
+
+        records, total = await self.repo.get_penalty_logs_paginated(
+            organization_id, pagination
+        )
+
+        penalty_logs = [
+            PenaltyLogEntrySchema(
+                penalty_log_id=row["penalty_log_id"],
+                compliance_period_id=row["compliance_period_id"],
+                compliance_year=row["compliance_year"],
+                contravention_type=row["contravention_type"],
+                offence_history=bool(row["offence_history"]),
+                deliberate=bool(row["deliberate"]),
+                efforts_to_correct=bool(row["efforts_to_correct"]),
+                economic_benefit_derived=bool(row["economic_benefit_derived"]),
+                efforts_to_prevent_recurrence=bool(
+                    row["efforts_to_prevent_recurrence"]
+                ),
+                notes=row["notes"],
+                penalty_amount=float(row["penalty_amount"] or 0),
+            )
+            for row in records
+        ]
+
+        total_pages = (
+            math.ceil(total / pagination.size) if pagination.size else 1
+        ) or 1
+
+        return PenaltyLogListResponseSchema(
+            pagination=PaginationResponseSchema(
+                total=total,
+                page=pagination.page,
+                size=pagination.size,
+                total_pages=total_pages,
+            ),
+            penalty_logs=penalty_logs,
+        )
+
+    @service_handler
+    async def create_penalty_log(
+        self,
+        organization_id: int,
+        payload: PenaltyLogCreateSchema,
+    ) -> PenaltyLogEntrySchema:
+        penalty_log = await self.repo.create_penalty_log(organization_id, payload)
+        return self._map_penalty_log_model(penalty_log)
+
+    @service_handler
+    async def update_penalty_log(
+        self,
+        organization_id: int,
+        penalty_log_id: int,
+        payload: PenaltyLogUpdateSchema,
+    ) -> PenaltyLogEntrySchema:
+        existing = await self.repo.get_penalty_log_by_id(
+            organization_id, penalty_log_id
+        )
+        if not existing:
+            raise DataNotFoundException("Penalty log not found")
+
+        updated = await self.repo.update_penalty_log(existing, payload)
+        return self._map_penalty_log_model(updated)
+
+    @service_handler
+    async def delete_penalty_log(
+        self, organization_id: int, penalty_log_id: int
+    ) -> None:
+        existing = await self.repo.get_penalty_log_by_id(
+            organization_id, penalty_log_id
+        )
+        if not existing:
+            raise DataNotFoundException("Penalty log not found")
+
+        deleted = await self.repo.delete_penalty_log(organization_id, penalty_log_id)
+        if not deleted:
+            raise DataNotFoundException("Penalty log not found")
+        return None

--- a/backend/lcfs/web/api/organizations/services.py
+++ b/backend/lcfs/web/api/organizations/services.py
@@ -1,22 +1,14 @@
 import io
 import math
-import json
 from datetime import datetime, timezone
-from decimal import Decimal
-import structlog
-from typing import List, Dict
+from typing import Dict, List
 
-from lcfs.settings import settings
+import structlog
 from fastapi import Depends, Request
 from fastapi.responses import StreamingResponse
 from fastapi_cache import FastAPICache
 
-from lcfs.db.models.organization.Organization import (
-    Organization,
-    generate_secure_link_key,
-)
-from lcfs.db.models.organization.OrganizationType import OrganizationType
-from lcfs.db.models.organization.OrganizationLinkKey import OrganizationLinkKey
+from lcfs.db.models.organization.Organization import Organization
 from lcfs.db.models.organization.OrganizationAddress import OrganizationAddress
 from lcfs.db.models.organization.OrganizationAttorneyAddress import (
     OrganizationAttorneyAddress,
@@ -25,12 +17,10 @@ from lcfs.db.models.organization.OrganizationStatus import (
     OrganizationStatus,
     OrgStatusEnum,
 )
-from lcfs.db.models.organization.CreditMarketAuditLog import CreditMarketAuditLog
+from lcfs.db.models.organization.OrganizationType import OrganizationType
 from lcfs.db.models.transaction import Transaction
 from lcfs.db.models.transaction.Transaction import TransactionActionEnum
-from lcfs.services.tfrs.redis_balance import (
-    RedisBalanceService,
-)
+from lcfs.services.tfrs.redis_balance import RedisBalanceService
 from lcfs.utils.spreadsheet_builder import SpreadsheetBuilder, SpreadsheetColumn
 from lcfs.web.api.base import (
     PaginationRequestSchema,
@@ -38,34 +28,20 @@ from lcfs.web.api.base import (
     apply_filter_conditions,
     get_field_for_filter,
     validate_pagination,
-    NotificationTypeEnum,
 )
 from lcfs.web.api.transaction.repo import TransactionRepository
-from lcfs.web.api.notification.services import NotificationService
-from lcfs.web.api.notification.schema import (
-    NotificationRequestSchema,
-    NotificationMessageSchema,
-)
 from lcfs.web.core.decorators import service_handler
 from lcfs.web.exception.exceptions import DataNotFoundException
+
 from .repo import OrganizationsRepository
 from .schema import (
-    OrganizationTypeSchema,
-    OrganizationSchema,
-    OrganizationListSchema,
     OrganizationCreateSchema,
-    OrganizationSummaryResponseSchema,
     OrganizationDetailsSchema,
+    OrganizationListSchema,
+    OrganizationSchema,
+    OrganizationSummaryResponseSchema,
+    OrganizationTypeSchema,
     OrganizationUpdateSchema,
-    PenaltyAnalyticsResponseSchema,
-    PenaltyTotalsSchema,
-    PenaltyYearlySummarySchema,
-    PenaltyLogEntrySchema,
-    PenaltyLogListResponseSchema,
-    PenaltyLogCreateSchema,
-    PenaltyLogUpdateSchema,
-    CreditMarketAuditLogItemSchema,
-    CreditMarketAuditLogListResponseSchema,
 )
 
 
@@ -79,61 +55,16 @@ class OrganizationsService:
         repo: OrganizationsRepository = Depends(OrganizationsRepository),
         transaction_repo: TransactionRepository = Depends(TransactionRepository),
         redis_balance_service: RedisBalanceService = Depends(RedisBalanceService),
-        notification_service: NotificationService = Depends(NotificationService),
     ) -> None:
         self.request = (request,)
         self.repo = repo
         self.transaction_repo = transaction_repo
         self.redis_balance_service = redis_balance_service
-        self.notification_service = notification_service
-
-    def _map_penalty_log_model(self, penalty_log) -> PenaltyLogEntrySchema:
-        compliance_year = None
-        if penalty_log and getattr(penalty_log, "compliance_period", None):
-            compliance_year = penalty_log.compliance_period.description
-
-        return PenaltyLogEntrySchema(
-            penalty_log_id=penalty_log.penalty_log_id,
-            compliance_period_id=penalty_log.compliance_period_id,
-            compliance_year=compliance_year,
-            contravention_type=penalty_log.contravention_type,
-            offence_history=bool(penalty_log.offence_history),
-            deliberate=bool(penalty_log.deliberate),
-            efforts_to_correct=bool(penalty_log.efforts_to_correct),
-            economic_benefit_derived=bool(penalty_log.economic_benefit_derived),
-            efforts_to_prevent_recurrence=bool(
-                penalty_log.efforts_to_prevent_recurrence
-            ),
-            notes=penalty_log.notes,
-            penalty_amount=float(penalty_log.penalty_amount or 0),
-        )
 
     async def _requires_bceid(self, organization_type_id: int) -> bool:
         """Check if organization type requires BCeID."""
         org_type = await self.repo.get_organization_type(organization_type_id)
         return org_type.is_bceid_user if org_type else True
-
-    @staticmethod
-    def _credit_market_snapshot(organization: Organization) -> Dict[str, object]:
-        """Build a normalized snapshot for credit market change detection."""
-        return {
-            "credit_market_contact_name": organization.credit_market_contact_name,
-            "credit_market_contact_email": organization.credit_market_contact_email,
-            "credit_market_contact_phone": organization.credit_market_contact_phone,
-            "credit_market_is_seller": bool(organization.credit_market_is_seller),
-            "credit_market_is_buyer": bool(organization.credit_market_is_buyer),
-            "credits_to_sell": int(organization.credits_to_sell or 0),
-            "display_in_credit_market": bool(organization.display_in_credit_market),
-        }
-
-    @staticmethod
-    def _role_in_market(is_seller: bool, is_buyer: bool) -> str | None:
-        roles = []
-        if is_seller:
-            roles.append("Seller")
-        if is_buyer:
-            roles.append("Buyer")
-        return ", ".join(roles) if roles else None
 
     def apply_organization_filters(self, pagination, conditions):
         """
@@ -151,13 +82,11 @@ class OrganizationsService:
             filter_option = filter.type
             filter_type = filter.filter_type
 
-            # Map frontend field names to backend field names
             field_name = filter.field
             if field_name == "hasEarlyIssuance":
                 field_name = "has_early_issuance"
 
             if field_name == "has_early_issuance":
-                # Get the early issuance field reference
                 early_issuance_field = self.repo.get_early_issuance_field()
                 conditions.append(
                     apply_filter_conditions(
@@ -167,23 +96,17 @@ class OrganizationsService:
                 continue
 
             if field_name == "registration_status":
-                # Registration status is computed from org status
-                # Convert boolean or string boolean to status enum for filtering
-                # Handle both boolean and string representations from frontend
                 if isinstance(filter_value, bool):
                     is_registered = filter_value
                 elif isinstance(filter_value, str):
                     is_registered = filter_value.lower() == "true"
                 else:
-                    # Skip invalid filter values
                     continue
 
                 field = get_field_for_filter(OrganizationStatus, "status")
                 if is_registered:
-                    # Filter for "Registered" status
                     conditions.append(field == "Registered")
                 else:
-                    # Filter for non-registered statuses
                     conditions.append(
                         field.in_(["Unregistered", "Suspended", "Canceled"])
                     )
@@ -211,7 +134,6 @@ class OrganizationsService:
 
         export_format = "xlsx"
 
-        # Create a spreadsheet
         builder = SpreadsheetBuilder(file_format=export_format)
 
         builder.add_sheet(
@@ -230,7 +152,6 @@ class OrganizationsService:
 
         file_content = builder.build_spreadsheet()
 
-        # Get the current date in YYYY-MM-DD format
         current_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         filename = f"BC-LCFS-organizations-{current_date}.{export_format}"
@@ -247,17 +168,14 @@ class OrganizationsService:
         self, organization_data: OrganizationCreateSchema, user=None
     ):
         """handles creating an organization"""
-        # Check if the organization type requires BCeID
         requires_bceid = await self._requires_bceid(
             organization_data.organization_type_id
         )
 
-        # Handle address creation based on organization type
         org_address = None
         org_attorney_address = None
 
         if requires_bceid:
-            # For BCeID organizations, address is required
             if not organization_data.address:
                 raise ValueError("Address is required for BCeID organization types")
             org_address = OrganizationAddress(**organization_data.address.dict())
@@ -270,7 +188,6 @@ class OrganizationsService:
                 **organization_data.attorney_address.dict()
             )
         else:
-            # For non-BCeID organizations, address is optional
             if (
                 organization_data.address
                 and hasattr(organization_data.address, "street_address")
@@ -287,11 +204,9 @@ class OrganizationsService:
                     **organization_data.attorney_address.dict()
                 )
 
-            # For non-BCeID types, email is required
             if not organization_data.email:
                 raise ValueError("Email is required for all organization types")
 
-        # Create and add organization model to the database
         org_model = Organization(
             name=organization_data.name,
             operating_name=organization_data.operating_name,
@@ -306,7 +221,6 @@ class OrganizationsService:
 
         created_organization = await self.repo.create_organization(org_model)
 
-        # Set early issuance for current year if provided
         if (
             hasattr(organization_data, "has_early_issuance")
             and organization_data.has_early_issuance is not None
@@ -322,7 +236,6 @@ class OrganizationsService:
                 user,
             )
 
-        # Clear cache after creating to ensure fresh data in subsequent requests
         await FastAPICache.clear()
 
         return created_organization
@@ -340,12 +253,10 @@ class OrganizationsService:
         if not organization:
             raise DataNotFoundException("Organization not found")
 
-        # Check if the organization type requires BCeID
         requires_bceid = await self._requires_bceid(
             organization_data.organization_type_id
         )
 
-        # If early issuance setting is being updated, validate against existing reports for current year
         if (
             hasattr(organization_data, "has_early_issuance")
             and organization_data.has_early_issuance is not None
@@ -354,13 +265,11 @@ class OrganizationsService:
 
             current_year = LCFS_Constants.get_current_compliance_year()
 
-            # Check if setting is different from current setting
             current_setting = await self.repo.get_current_year_early_issuance(
                 organization_id
             )
 
             if current_setting != organization_data.has_early_issuance:
-                # Update the year-specific setting, this will raise HTTPException if reports exist
                 await self.repo.update_early_issuance_by_year(
                     organization_id,
                     current_year,
@@ -369,13 +278,11 @@ class OrganizationsService:
                 )
 
         for key, value in organization_data.dict().items():
-            # Skip has_early_issuance as it's now handled by year-based structure
             if key == "has_early_issuance":
                 continue
             if hasattr(organization, key):
                 setattr(organization, key, value)
 
-        # For non-BCeID types, validate email is present if being updated
         if (
             not requires_bceid
             and organization_data.email is not None
@@ -383,15 +290,12 @@ class OrganizationsService:
         ):
             raise ValueError("Email is required for all organization types")
 
-        # Handle address updates based on organization type requirements
         if organization_data.address:
-            # Check if switching to BCeID type requires addresses
             if requires_bceid and not hasattr(
                 organization_data.address, "street_address"
             ):
                 raise ValueError("Address is required for BCeID organization types")
 
-            # Only update if there's meaningful address data
             has_address_data = (
                 hasattr(organization_data.address, "street_address")
                 and organization_data.address.street_address
@@ -414,7 +318,6 @@ class OrganizationsService:
                         setattr(org_address, key, value)
 
         if organization_data.attorney_address:
-            # Check if switching to BCeID type requires attorney addresses
             if requires_bceid and not hasattr(
                 organization_data.attorney_address, "street_address"
             ):
@@ -422,7 +325,6 @@ class OrganizationsService:
                     "Attorney address is required for BCeID organization types"
                 )
 
-            # Only update if there's meaningful attorney address data
             has_attorney_address_data = (
                 hasattr(organization_data.attorney_address, "street_address")
                 and organization_data.attorney_address.street_address
@@ -455,101 +357,6 @@ class OrganizationsService:
         return updated_organization
 
     @service_handler
-    async def update_organization_credit_market_details(
-        self,
-        organization_id: int,
-        credit_market_data: dict,
-        user=None,
-        skip_notifications: bool = False,
-    ):
-        """
-        Update only the credit market contact details for an organization.
-        This method only updates the specific credit market fields without affecting other organization data.
-
-        Args:
-            organization_id: Target organization identifier.
-            credit_market_data: Credit market fields to update.
-            user: Requesting user profile (used for auditing).
-            skip_notifications: When True, suppresses outbound credit market notifications
-                even if the update would normally trigger them. Intended for IDIR/government edits.
-        """
-        organization = await self.repo.get_organization(organization_id)
-        if not organization:
-            raise DataNotFoundException("Organization not found")
-
-        before_snapshot = self._credit_market_snapshot(organization)
-
-        # Store original values to detect if a new credit listing is being created
-        was_displayed_in_market = organization.display_in_credit_market or False
-        old_credits_to_sell = organization.credits_to_sell or 0
-
-        # Update only the credit market fields
-        allowed_fields = {
-            "credit_market_contact_name",
-            "credit_market_contact_email",
-            "credit_market_contact_phone",
-            "credit_market_is_seller",
-            "credit_market_is_buyer",
-            "credits_to_sell",
-            "display_in_credit_market",
-        }
-
-        for key, value in credit_market_data.items():
-            if key in allowed_fields and hasattr(organization, key):
-                # Special validation for credits_to_sell
-                if key == "credits_to_sell" and value is not None:
-                    if value < 0:
-                        raise ValueError("Credits to sell cannot be negative")
-
-                    # Get the organization's total balance to validate against
-                    total_balance = await self.calculate_total_balance(
-                        organization.organization_id
-                    )
-                    if value > total_balance:
-                        raise ValueError(
-                            f"Credits to sell ({value}) cannot exceed available balance ({total_balance})"
-                        )
-
-                setattr(organization, key, value)
-
-        # Set the update user
-        if user:
-            organization.update_user = user.keycloak_username
-
-        updated_organization = await self.repo.update_organization(organization)
-        after_snapshot = self._credit_market_snapshot(updated_organization)
-
-        if before_snapshot != after_snapshot and bool(
-            updated_organization.display_in_credit_market
-        ):
-            changed_by = user.keycloak_username if user else updated_organization.update_user
-            await self.repo.create_credit_market_audit_log(
-                organization=updated_organization, changed_by=changed_by
-            )
-
-        # Check if this is a new credit listing that should trigger notifications
-        # A new listing is when:
-        # 1. The organization is now displayed in the credit market AND has credits to sell
-        # 2. AND either wasn't displayed before OR didn't have credits to sell before
-        is_now_displayed = updated_organization.display_in_credit_market or False
-        new_credits_to_sell = updated_organization.credits_to_sell or 0
-
-        is_new_listing = (
-            is_now_displayed
-            and new_credits_to_sell > 0
-            and (not was_displayed_in_market or old_credits_to_sell == 0)
-        )
-
-        if (
-            is_new_listing
-            and settings.feature_credit_market_notifications
-            and not skip_notifications
-        ):
-            await self._send_credit_market_notification(updated_organization, user)
-
-        return updated_organization
-
-    @service_handler
     async def update_organization_company_overview(
         self,
         organization_id: int,
@@ -564,7 +371,6 @@ class OrganizationsService:
         if not organization:
             raise DataNotFoundException("Organization not found")
 
-        # Update only the company overview fields
         allowed_fields = {
             "company_details",
             "company_representation_agreements",
@@ -576,7 +382,6 @@ class OrganizationsService:
             if key in allowed_fields and hasattr(organization, key):
                 setattr(organization, key, value)
 
-        # Set the update user
         if user:
             organization.update_user = user.keycloak_username
 
@@ -591,12 +396,10 @@ class OrganizationsService:
         if organization is None:
             raise DataNotFoundException("org not found")
 
-        # Add year-based early issuance for current year
         organization.has_early_issuance = (
             await self.repo.get_current_year_early_issuance(organization_id)
         )
 
-        # Calculate and add balance information for credit trading validation
         organization.total_balance = await self.calculate_total_balance(organization_id)
         organization.reserved_balance = await self.calculate_reserved_balance(
             organization_id
@@ -623,239 +426,12 @@ class OrganizationsService:
         return early_issuance.has_early_issuance if early_issuance else False
 
     @service_handler
-    async def get_penalty_analytics(
-        self, organization_id: int
-    ) -> PenaltyAnalyticsResponseSchema:
-        """
-        Assemble penalty analytics data for the organization, combining automatic
-        penalties from compliance reports with discretionary penalties from the
-        penalty log.
-        """
-
-        def _to_float(value) -> float:
-            if value is None:
-                return 0.0
-            if isinstance(value, Decimal):
-                return float(value)
-            return float(value)
-
-        summaries, penalty_logs = await self.repo.get_penalty_analytics_data(
-            organization_id
-        )
-
-        yearly_penalties: List[PenaltyYearlySummarySchema] = []
-        total_auto_renewable = 0.0
-        total_auto_low_carbon = 0.0
-
-        for row in summaries:
-            penalty_override_enabled = bool(row.get("penalty_override_enabled"))
-
-            renewable_penalty = (
-                _to_float(row.get("renewable_penalty_override"))
-                if penalty_override_enabled
-                and row.get("renewable_penalty_override") is not None
-                else _to_float(row.get("line_11_penalty_gasoline"))
-                + _to_float(row.get("line_11_penalty_diesel"))
-                + _to_float(row.get("line_11_penalty_jet_fuel"))
-            )
-
-            low_carbon_penalty = (
-                _to_float(row.get("low_carbon_penalty_override"))
-                if penalty_override_enabled
-                and row.get("low_carbon_penalty_override") is not None
-                else _to_float(row.get("line_21_penalty_payable"))
-            )
-
-            compliance_year_value = row.get("compliance_year")
-            try:
-                compliance_year = (
-                    int(compliance_year_value)
-                    if compliance_year_value is not None
-                    else None
-                )
-            except (TypeError, ValueError):
-                compliance_year = compliance_year_value
-
-            total_automatic = renewable_penalty + low_carbon_penalty
-            total_auto_renewable += renewable_penalty
-            total_auto_low_carbon += low_carbon_penalty
-
-            yearly_penalties.append(
-                PenaltyYearlySummarySchema(
-                    compliance_period_id=row.get("compliance_period_id"),
-                    compliance_year=compliance_year,
-                    auto_renewable=renewable_penalty,
-                    auto_low_carbon=low_carbon_penalty,
-                    total_automatic=total_automatic,
-                )
-            )
-
-        penalty_log_entries: List[PenaltyLogEntrySchema] = []
-        discretionary_total = 0.0
-
-        for log in penalty_logs:
-            penalty_amount = _to_float(log.get("penalty_amount"))
-            discretionary_total += penalty_amount
-
-            compliance_year_value = log.get("compliance_year")
-            try:
-                compliance_year = (
-                    int(compliance_year_value)
-                    if compliance_year_value is not None
-                    else None
-                )
-            except (TypeError, ValueError):
-                compliance_year = compliance_year_value
-
-            penalty_log_entries.append(
-                PenaltyLogEntrySchema(
-                    penalty_log_id=log.get("penalty_log_id"),
-                    compliance_period_id=log.get("compliance_period_id"),
-                    compliance_year=compliance_year,
-                    contravention_type=log.get("contravention_type"),
-                    offence_history=bool(log.get("offence_history")),
-                    deliberate=bool(log.get("deliberate")),
-                    efforts_to_correct=bool(log.get("efforts_to_correct")),
-                    economic_benefit_derived=bool(log.get("economic_benefit_derived")),
-                    efforts_to_prevent_recurrence=bool(
-                        log.get("efforts_to_prevent_recurrence")
-                    ),
-                    notes=log.get("notes"),
-                    penalty_amount=penalty_amount,
-                )
-            )
-
-        total_automatic = total_auto_renewable + total_auto_low_carbon
-
-        totals = PenaltyTotalsSchema(
-            auto_renewable=total_auto_renewable,
-            auto_low_carbon=total_auto_low_carbon,
-            discretionary=discretionary_total,
-            total_automatic=total_automatic,
-            total=total_automatic + discretionary_total,
-        )
-
-        return PenaltyAnalyticsResponseSchema(
-            yearly_penalties=yearly_penalties,
-            totals=totals,
-            penalty_logs=penalty_log_entries,
-        )
-
-    @service_handler
-    async def get_penalty_logs_paginated(
-        self, organization_id: int, pagination: PaginationRequestSchema
-    ) -> PenaltyLogListResponseSchema:
-        pagination = validate_pagination(pagination)
-
-        records, total = await self.repo.get_penalty_logs_paginated(
-            organization_id, pagination
-        )
-
-        penalty_logs = [
-            PenaltyLogEntrySchema(
-                penalty_log_id=row["penalty_log_id"],
-                compliance_period_id=row["compliance_period_id"],
-                compliance_year=row["compliance_year"],
-                contravention_type=row["contravention_type"],
-                offence_history=bool(row["offence_history"]),
-                deliberate=bool(row["deliberate"]),
-                efforts_to_correct=bool(row["efforts_to_correct"]),
-                economic_benefit_derived=bool(row["economic_benefit_derived"]),
-                efforts_to_prevent_recurrence=bool(
-                    row["efforts_to_prevent_recurrence"]
-                ),
-                notes=row["notes"],
-                penalty_amount=float(row["penalty_amount"] or 0),
-            )
-            for row in records
-        ]
-
-        total_pages = (
-            math.ceil(total / pagination.size) if pagination.size else 1
-        ) or 1
-
-        return PenaltyLogListResponseSchema(
-            pagination=PaginationResponseSchema(
-                total=total,
-                page=pagination.page,
-                size=pagination.size,
-                total_pages=total_pages,
-            ),
-            penalty_logs=penalty_logs,
-        )
-
-    @service_handler
-    async def create_penalty_log(
-        self,
-        organization_id: int,
-        payload: PenaltyLogCreateSchema,
-    ) -> PenaltyLogEntrySchema:
-        penalty_log = await self.repo.create_penalty_log(organization_id, payload)
-        return self._map_penalty_log_model(penalty_log)
-
-    @service_handler
-    async def update_penalty_log(
-        self,
-        organization_id: int,
-        penalty_log_id: int,
-        payload: PenaltyLogUpdateSchema,
-    ) -> PenaltyLogEntrySchema:
-        existing = await self.repo.get_penalty_log_by_id(
-            organization_id, penalty_log_id
-        )
-        if not existing:
-            raise DataNotFoundException("Penalty log not found")
-
-        updated = await self.repo.update_penalty_log(existing, payload)
-        return self._map_penalty_log_model(updated)
-
-    @service_handler
-    async def delete_penalty_log(
-        self, organization_id: int, penalty_log_id: int
-    ) -> None:
-        existing = await self.repo.get_penalty_log_by_id(
-            organization_id, penalty_log_id
-        )
-        if not existing:
-            raise DataNotFoundException("Penalty log not found")
-
-        deleted = await self.repo.delete_penalty_log(organization_id, penalty_log_id)
-        if not deleted:
-            raise DataNotFoundException("Penalty log not found")
-        return None
-
-    @service_handler
     async def get_organizations(
         self, pagination: PaginationRequestSchema = {}
     ) -> List[OrganizationSchema]:
         """handles fetching organizations and providing pagination data"""
-        """
-        Get all organizations based on the provided filters and pagination.
-        This method returns a list of OrganizationSchema objects.
-        The OrganizationSchema objects contain the basic organization details,
-        including the organization type, organization status, and other relevant fields.
-        The pagination object is used to control the number of results returned
-        and the page number.
-        The filters object is used to filter the results based on specific criteria.
-        The OrganizationSchema objects are returned in the order specified by the sortOrders object.
-        The total_count field is used to return the total number of organizations that match the filters.
-        The OrganizationSchema objects are returned in the order specified by the sortOrders object.
-
-        Args:
-            pagination (PaginationRequestSchema, optional): The pagination object containing page and size information. Defaults to {}.
-
-        Returns:
-            List[OrganizationSchema]: A list of OrganizationSchema objects containing the basic organization details.
-            The total_count field is used to return the total number of organizations that match the filters.
-            The OrganizationSchema objects are returned in the order specified by the sortOrders object.
-
-        Raises:
-            Exception: If any errors occur during the query execution.
-            ValueError: If the provided pagination object is invalid.
-        """
         # TODO: Implement Redis cache wherever required
         # TODO: Implement Compliance Units and In Reserve fields once the transactions model is created
-        # Apply filters
         conditions = []
         pagination = validate_pagination(pagination)
         if pagination.filters and len(pagination.filters) > 0:
@@ -864,7 +440,6 @@ class OrganizationsService:
             except Exception:
                 raise ValueError(f"Invalid filter provided: {pagination.filters}.")
 
-        # Apply pagination
         offset = 0 if (pagination.page < 1) else (pagination.page - 1) * pagination.size
         limit = pagination.size
 
@@ -915,7 +490,6 @@ class OrganizationsService:
         conditions = []
 
         if statuses:
-            # If specific statuses are provided, filter by those
             status_enums = [
                 OrgStatusEnum(status)
                 for status in statuses
@@ -924,7 +498,6 @@ class OrganizationsService:
             if status_enums:
                 conditions.append(OrganizationStatus.status.in_(status_enums))
 
-        # The order_by tuple directly specifies both the sort field and direction
         organization_data = await self.repo.get_organization_names(
             conditions, order_by, org_type_filter, org_filters
         )
@@ -953,7 +526,6 @@ class OrganizationsService:
         ]
         results = await self.repo.get_externally_registered_organizations(conditions)
 
-        # Map the results to OrganizationSummaryResponseSchema
         organizations = [
             OrganizationSummaryResponseSchema.model_validate(organization)
             for organization in results
@@ -978,49 +550,22 @@ class OrganizationsService:
     async def calculate_total_balance(self, organization_id: int) -> int:
         """
         Calculates the total balance for a given organization.
-
-        Args:
-            organization_id (int): The ID of the organization.
-
-        Returns:
-            int: The total balance of the organization.
         """
-        total_balance = await self.transaction_repo.calculate_total_balance(
-            organization_id
-        )
-        return total_balance
+        return await self.transaction_repo.calculate_total_balance(organization_id)
 
     @service_handler
     async def calculate_reserved_balance(self, organization_id: int) -> int:
         """
         Calculates the reserved balance for a given organization.
-
-        Args:
-            organization_id (int): The ID of the organization.
-
-        Returns:
-            int: The reserved balance of the organization.
         """
-        reserved_balance = await self.transaction_repo.calculate_reserved_balance(
-            organization_id
-        )
-        return reserved_balance
+        return await self.transaction_repo.calculate_reserved_balance(organization_id)
 
     @service_handler
     async def calculate_available_balance(self, organization_id: int) -> int:
         """
         Calculates the available balance for a given organization by subtracting the reserved balance from the total balance.
-
-        Args:
-            organization_id (int): The ID of the organization.
-
-        Returns:
-            int: The available balance of the organization.
         """
-        available_balance = await self.transaction_repo.calculate_available_balance(
-            organization_id
-        )
-        return available_balance
+        return await self.transaction_repo.calculate_available_balance(organization_id)
 
     @service_handler
     async def calculate_available_balance_for_period(
@@ -1028,13 +573,6 @@ class OrganizationsService:
     ) -> int:
         """
         Calculates the available balance for a given organization that existed on or before the March 31 compliance deadline for a reporting year.
-
-        Args:
-            organization_id (int): The ID of the organization.
-            compliance_period (int): The compliance period year (e.g., 2024).
-
-        Returns:
-            int: The available balance at the compliance deadline.
         """
         return await self.transaction_repo.calculate_available_balance_for_period(
             organization_id, compliance_period
@@ -1052,23 +590,13 @@ class OrganizationsService:
 
         Validates the transaction against the organization's current balances before proceeding.
         It raises an error if the requested action violates balance constraints (e.g., attempting to reserve more than the available balance).
-
-        Args:
-            transaction_action (TransactionActionEnum): The type of balance adjustment (Adjustment, Reserved, Released).
-            compliance_units (int): The number of compliance units involved in the transaction.
-            organization_id (int): The ID of the organization whose balance is being adjusted.
-
-        Raises:
-            ValueError: If the transaction violates balance constraints.
         """
         if compliance_units == 0:
             raise ValueError("Compliance units cannot be zero.")
 
-        # Retrieve balances
         available_balance = await self.calculate_available_balance(organization_id)
         reserved_balance = await self.calculate_reserved_balance(organization_id)
 
-        # Check constraints based on transaction action
         if transaction_action == TransactionActionEnum.Reserved:
             if compliance_units < 0 and abs(compliance_units) > available_balance:
                 raise ValueError("Reserve amount cannot exceed available balance.")
@@ -1082,7 +610,6 @@ class OrganizationsService:
             if abs(compliance_units) > available_balance:
                 raise ValueError("Cannot decrement available balance below zero.")
 
-        # Create a new transaction record in the database
         new_transaction = await self.transaction_repo.create_transaction(
             transaction_action, compliance_units, organization_id
         )
@@ -1123,321 +650,3 @@ class OrganizationsService:
             }
             for org in organizations
         ]
-
-    @service_handler
-    async def get_credit_market_listings(self):
-        """
-        Get organizations that have opted to display in the credit trading market.
-        Returns organizations with their credit market contact details for public viewing.
-        """
-        from .schema import OrganizationCreditMarketListingSchema
-
-        organizations = await self.repo.get_credit_market_organizations()
-
-        return [
-            OrganizationCreditMarketListingSchema(
-                organization_id=org.organization_id,
-                organization_name=org.name,
-                credits_to_sell=org.credits_to_sell or 0,
-                display_in_credit_market=org.display_in_credit_market,
-                credit_market_is_seller=org.credit_market_is_seller or False,
-                credit_market_is_buyer=org.credit_market_is_buyer or False,
-                credit_market_contact_name=org.credit_market_contact_name,
-                credit_market_contact_email=org.credit_market_contact_email,
-                credit_market_contact_phone=org.credit_market_contact_phone,
-            )
-            for org in organizations
-        ]
-
-    @service_handler
-    async def get_credit_market_audit_logs_paginated(
-        self, pagination: PaginationRequestSchema
-    ) -> CreditMarketAuditLogListResponseSchema:
-        """
-        Fetch paginated credit market audit logs with filtering and sorting.
-        """
-        conditions = []
-        pagination = validate_pagination(pagination)
-
-        if pagination.filters:
-            for filter_model in pagination.filters:
-                filter_value = filter_model.filter
-                filter_option = filter_model.type
-                filter_type = filter_model.filter_type
-
-                if filter_type == "date":
-                    filter_value = []
-                    if filter_model.date_from:
-                        filter_value.append(filter_model.date_from)
-                    if filter_model.date_to:
-                        filter_value.append(filter_model.date_to)
-                    if not filter_value:
-                        continue
-
-                if filter_model.field == "organization_name":
-                    field = get_field_for_filter(Organization, "name")
-                else:
-                    field = get_field_for_filter(CreditMarketAuditLog, filter_model.field)
-                if field is None:
-                    continue
-
-                condition = apply_filter_conditions(
-                    field, filter_value, filter_option, filter_type
-                )
-                if condition is not None:
-                    conditions.append(condition)
-
-        offset = (pagination.page - 1) * pagination.size
-        limit = pagination.size
-        audit_logs, total_count = await self.repo.get_credit_market_audit_logs_paginated(
-            offset, limit, conditions, pagination.sort_orders
-        )
-
-        rows = [
-            CreditMarketAuditLogItemSchema(
-                credit_market_audit_log_id=entry.credit_market_audit_log_id,
-                organization_name=entry.organization.name if entry.organization else "",
-                credits_to_sell=entry.credits_to_sell or 0,
-                role_in_market=self._role_in_market(
-                    bool(entry.credit_market_is_seller),
-                    bool(entry.credit_market_is_buyer),
-                ),
-                contact_person=entry.contact_person,
-                phone=entry.phone,
-                email=entry.email,
-                changed_by=entry.changed_by,
-                uploaded_date=entry.create_date,
-            )
-            for entry in audit_logs
-        ]
-
-        return CreditMarketAuditLogListResponseSchema(
-            credit_market_audit_logs=rows,
-            pagination=PaginationResponseSchema(
-                total=total_count,
-                page=pagination.page,
-                size=pagination.size,
-                total_pages=math.ceil(total_count / pagination.size)
-                if pagination.size
-                else 0,
-            ),
-        )
-
-    @service_handler
-    async def get_available_forms(self):
-        """
-        Get available forms for link key generation.
-        """
-        from .schema import AvailableFormsSchema
-
-        # Get published forms that allow anonymous access
-        forms = await self.repo.get_available_forms_for_link_keys()
-
-        return AvailableFormsSchema(
-            forms={
-                form.form_id: {
-                    "id": form.form_id,
-                    "name": form.name,
-                    "slug": form.slug,
-                    "description": form.description,
-                }
-                for form in forms
-            }
-        )
-
-    @service_handler
-    async def get_organization_link_keys(self, organization_id: int):
-        """
-        Get all link keys for an organization.
-        """
-        from .schema import (
-            OrganizationLinkKeysListSchema,
-            OrganizationLinkKeyResponseSchema,
-        )
-
-        organization = await self.repo.get_organization(organization_id)
-        if not organization:
-            raise DataNotFoundException("Organization not found")
-
-        link_keys = await self.repo.get_organization_link_keys(organization_id)
-
-        link_key_responses = [
-            OrganizationLinkKeyResponseSchema(
-                link_key_id=lk.link_key_id,
-                organization_id=lk.organization_id,
-                form_id=lk.form_id,
-                form_name=lk.form_name,
-                form_slug=lk.form_slug,
-                link_key=lk.link_key,
-                create_date=lk.create_date,
-                update_date=lk.update_date,
-            )
-            for lk in link_keys
-        ]
-
-        return OrganizationLinkKeysListSchema(
-            organization_id=organization_id,
-            organization_name=organization.name,
-            link_keys=link_key_responses,
-        )
-
-    @service_handler
-    async def generate_link_key(self, organization_id: int, form_id: int, user=None):
-        """
-        Generate a new secure link key for a specific form.
-        """
-        from .schema import LinkKeyOperationResponseSchema
-
-        organization = await self.repo.get_organization(organization_id)
-        if not organization:
-            raise DataNotFoundException("Organization not found")
-
-        # Verify the form exists and allows anonymous access
-        form = await self.repo.get_form_by_id(form_id)
-        if not form:
-            raise DataNotFoundException(f"Form with ID {form_id} not found")
-
-        if not form.allows_anonymous:
-            raise ValueError("Form does not support anonymous access")
-
-        # Check if link key already exists for this form
-        existing_link_key = await self.repo.get_link_key_by_form_id(
-            organization_id, form_id
-        )
-        if existing_link_key:
-            raise ValueError(
-                f"Link key already exists for {form.name}. "
-                "Please regenerate if you want to replace it."
-            )
-
-        # Generate a new secure link key
-        new_link_key = generate_secure_link_key()
-
-        # Create new link key record
-        link_key_record = OrganizationLinkKey(
-            organization_id=organization_id,
-            form_id=form_id,
-            link_key=new_link_key,
-        )
-
-        created_link_key = await self.repo.create_link_key(link_key_record)
-
-        return LinkKeyOperationResponseSchema(
-            link_key=created_link_key.link_key,
-            form_id=form_id,
-            form_name=form.name,
-            form_slug=form.slug,
-        )
-
-    @service_handler
-    async def regenerate_link_key(self, organization_id: int, form_id: int, user=None):
-        """
-        Regenerate the link key for a specific form.
-        This invalidates the previous key and creates a new one.
-        """
-        from .schema import LinkKeyOperationResponseSchema
-
-        organization = await self.repo.get_organization(organization_id)
-        if not organization:
-            raise DataNotFoundException("Organization not found")
-
-        # Verify the form exists
-        form = await self.repo.get_form_by_id(form_id)
-        if not form:
-            raise DataNotFoundException(f"Form with ID {form_id} not found")
-
-        # Get existing link key
-        existing_link_key = await self.repo.get_link_key_by_form_id(
-            organization_id, form_id
-        )
-        if not existing_link_key:
-            raise DataNotFoundException(f"No link key found for {form.name}")
-
-        old_key = existing_link_key.link_key
-
-        # Generate a new secure link key
-        new_link_key = generate_secure_link_key()
-        existing_link_key.link_key = new_link_key
-
-        updated_link_key = await self.repo.update_link_key(existing_link_key)
-
-        return LinkKeyOperationResponseSchema(
-            link_key=updated_link_key.link_key,
-            form_id=form_id,
-            form_name=form.name,
-            form_slug=form.slug,
-        )
-
-    @service_handler
-    async def validate_link_key(self, link_key: str):
-        """
-        Validate a link key and return the associated organization and form info.
-        Returns detailed validation result including form info and organization info.
-        """
-        from .schema import LinkKeyValidationSchema
-
-        link_key_record = await self.repo.get_link_key_by_key(link_key)
-
-        if not link_key_record:
-            return LinkKeyValidationSchema(
-                organization_id=0,
-                form_id=0,
-                form_name="Unknown",
-                form_slug="unknown",
-                organization_name="",
-                is_valid=False,
-            )
-
-        return LinkKeyValidationSchema(
-            organization_id=link_key_record.organization_id,
-            form_id=link_key_record.form_id,
-            form_name=link_key_record.form_name,
-            form_slug=link_key_record.form_slug,
-            organization_name=link_key_record.organization.name,
-            is_valid=True,
-        )
-
-    async def _send_credit_market_notification(
-        self, organization: Organization, user=None
-    ):
-        """
-        Send notification to subscribed BCeID users when new credits are listed for sale.
-        """
-        try:
-            # Create notification message with organization and credit details
-            message_data = {
-                "organizationName": organization.name,
-                "creditsToSell": organization.credits_to_sell,
-                "service": "CreditMarket",
-                "action": "CreditsListedForSale",
-            }
-
-            # Create notification data
-            notification_data = NotificationMessageSchema(
-                type="Credit market - credits listed for sale",
-                related_transaction_id=f"CM{organization.organization_id}",
-                message=json.dumps(message_data),
-                related_organization_id=organization.organization_id,
-                origin_user_profile_id=user.user_profile_id if user else None,
-            )
-
-            # Send notification to all subscribed BCeID users
-            await self.notification_service.send_notification(
-                NotificationRequestSchema(
-                    notification_types=[
-                        NotificationTypeEnum.BCEID__CREDIT_MARKET__CREDITS_LISTED_FOR_SALE
-                    ],
-                    notification_context={
-                        "subject": f"LCFS Credit Market - New Credits Available from {organization.name}"
-                    },
-                    notification_data=notification_data,
-                )
-            )
-
-            logger.info(
-                f"Credit market notification sent for organization {organization.organization_id}"
-            )
-
-        except Exception as e:
-            logger.error(f"Failed to send credit market notification: {str(e)}")
-            # Don't raise the exception - notification failure shouldn't break the main operation

--- a/backend/lcfs/web/api/organizations/views.py
+++ b/backend/lcfs/web/api/organizations/views.py
@@ -21,6 +21,9 @@ from lcfs.web.core.decorators import view_handler
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.db.models.organization.OrganizationStatus import OrgStatusEnum
 
+from .credit_market_service import OrganizationCreditMarketService
+from .link_key_service import OrganizationLinkKeyService
+from .penalty_service import OrganizationPenaltyService
 from .services import OrganizationsService
 from .schema import (
     OrganizationTypeSchema,
@@ -126,7 +129,8 @@ async def search_organizations(
 )
 @view_handler(["*"])
 async def get_credit_market_listings(
-    request: Request, service: OrganizationsService = Depends()
+    request: Request,
+    service: OrganizationCreditMarketService = Depends(),
 ):
     """
     Fetch organizations that have opted to display in the credit trading market.
@@ -144,7 +148,7 @@ async def get_credit_market_listings(
 async def get_credit_market_audit_logs(
     request: Request,
     pagination: PaginationRequestSchema = Body(..., embed=False),
-    service: OrganizationsService = Depends(),
+    service: OrganizationCreditMarketService = Depends(),
 ):
     """
     Fetch paginated credit trading market audit logs (IDIR/internal visibility).
@@ -186,7 +190,9 @@ async def get_organization(
 )
 @view_handler([RoleEnum.GOVERNMENT, RoleEnum.SUPPLIER])
 async def get_penalty_analytics(
-    request: Request, organization_id: int, service: OrganizationsService = Depends()
+    request: Request,
+    organization_id: int,
+    service: OrganizationPenaltyService = Depends(),
 ):
     """
     Retrieve penalty analytics (automatic and discretionary) for the specified organization.
@@ -213,7 +219,7 @@ async def get_penalty_logs(
     request: Request,
     organization_id: int,
     pagination: PaginationRequestSchema = Body(..., embed=False),
-    service: OrganizationsService = Depends(),
+    service: OrganizationPenaltyService = Depends(),
 ):
     """Fetch paginated penalty log entries for an organization."""
     user = request.user
@@ -238,7 +244,7 @@ async def create_penalty_log(
     request: Request,
     organization_id: int,
     penalty_data: PenaltyLogCreateSchema,
-    service: OrganizationsService = Depends(),
+    service: OrganizationPenaltyService = Depends(),
 ):
     return await service.create_penalty_log(organization_id, penalty_data)
 
@@ -254,7 +260,7 @@ async def update_penalty_log(
     organization_id: int,
     penalty_log_id: int,
     penalty_data: PenaltyLogUpdateSchema,
-    service: OrganizationsService = Depends(),
+    service: OrganizationPenaltyService = Depends(),
 ):
     return await service.update_penalty_log(
         organization_id, penalty_log_id, penalty_data
@@ -270,7 +276,7 @@ async def delete_penalty_log(
     request: Request,
     organization_id: int,
     penalty_log_id: int,
-    service: OrganizationsService = Depends(),
+    service: OrganizationPenaltyService = Depends(),
 ):
     await service.delete_penalty_log(organization_id, penalty_log_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -518,7 +524,7 @@ async def get_current_org_early_issuance(
 async def update_current_org_credit_market_details(
     request: Request,
     credit_market_data: OrganizationCreditMarketUpdateSchema,
-    service: OrganizationsService = Depends(),
+    service: OrganizationCreditMarketService = Depends(),
 ):
     """
     Update credit market contact details for the current user's organization.
@@ -531,7 +537,6 @@ async def update_current_org_credit_market_details(
             detail="User is not associated with an organization",
         )
 
-    # Use the dedicated method to update only credit market fields
     return await service.update_organization_credit_market_details(
         organization_id, credit_market_data.model_dump(exclude_unset=True), request.user
     )
@@ -547,7 +552,7 @@ async def update_org_credit_market_details(
     request: Request,
     organization_id: int,
     credit_market_data: OrganizationCreditMarketUpdateSchema,
-    service: OrganizationsService = Depends(),
+    service: OrganizationCreditMarketService = Depends(),
 ):
     """
     Update credit market contact details for any organization (IDIR users only).
@@ -578,7 +583,9 @@ async def update_company_overview(
     This endpoint allows analysts, managers, and directors to update company overview information.
     """
     return await service.update_organization_company_overview(
-        organization_id, company_overview_data.model_dump(exclude_unset=True), request.user
+        organization_id,
+        company_overview_data.model_dump(exclude_unset=True),
+        request.user,
     )
 
 
@@ -591,7 +598,7 @@ async def update_company_overview(
 async def get_available_forms(
     request: Request,
     organization_id: int,
-    service: OrganizationsService = Depends(),
+    service: OrganizationLinkKeyService = Depends(),
 ):
     """
     Get available forms for link key generation.
@@ -608,7 +615,7 @@ async def get_available_forms(
 async def get_organization_link_keys(
     request: Request,
     organization_id: int,
-    service: OrganizationsService = Depends(),
+    service: OrganizationLinkKeyService = Depends(),
 ):
     """
     Get all link keys for an organization.
@@ -626,7 +633,7 @@ async def generate_organization_link_key(
     request: Request,
     organization_id: int,
     link_key_data: OrganizationLinkKeyCreateSchema,
-    service: OrganizationsService = Depends(),
+    service: OrganizationLinkKeyService = Depends(),
 ):
     """
     Generate a new secure link key for a specific form type.
@@ -646,7 +653,7 @@ async def regenerate_organization_link_key(
     request: Request,
     organization_id: int,
     form_id: int,
-    service: OrganizationsService = Depends(),
+    service: OrganizationLinkKeyService = Depends(),
 ):
     """
     Regenerate the link key for a specific form.
@@ -664,7 +671,7 @@ async def regenerate_organization_link_key(
 async def validate_link_key(
     request: Request,
     link_key: str,
-    service: OrganizationsService = Depends(),
+    service: OrganizationLinkKeyService = Depends(),
 ):
     """
     Validate a link key and return the associated organization and form type.


### PR DESCRIPTION
## Summary

Closes #4084. Splits the 1,443-line `OrganizationsService` (40+ public methods) into three focused domain services so each can be reasoned about, tested, and modified in isolation.

- **`OrganizationPenaltyService`** — penalty analytics, paginated penalty logs, log CRUD
- **`OrganizationLinkKeyService`** — available forms, link key generation, regeneration, validation
- **`OrganizationCreditMarketService`** — credit market updates, public listings, audit logs, notifications
- **`OrganizationsService`** — core org CRUD, company overview, balances, `adjust_balance`, search (the orchestration surface that `transfer`, `admin_adjustment`, `initiative_agreement`, `compliance_report`, `jobs`, and `rabbitmq` depend on)

`views.py` injects the focused services directly via `Depends()` on the relevant routes. **No API contracts changed.**

### File-size impact
| File | Before | After |
|---|---:|---:|
| `services.py` | 1,443 | 652 |
| `penalty_service.py` | — | 259 |
| `link_key_service.py` | — | 184 |
| `credit_market_service.py` | — | 303 |

Tests were updated to inject and patch the new services where appropriate (penalty/link-key fixtures in `test_organizations_service.py`, dependency overrides in `test_credit_market_views.py` and `test_organizations_views.py`, settings patches in `test_credit_market_services.py`). Two stranded `get_organization` tests in `test_credit_market_services.py` were dropped — they were misplaced and exercised a method that lives on `OrganizationsService`.

## Test plan
- [x] `pytest lcfs/tests/organizations/` — 129 passed
- [x] `pytest lcfs/tests/transfer lcfs/tests/admin_adjustment lcfs/tests/initiative_agreement lcfs/tests/compliance_report lcfs/tests/services lcfs/tests/allocation_agreement` — 639 passed (covers external `OrganizationsService` callers)
- [x] Full suite — 1945 passed, 1 skipped
- [ ] Smoke-test the org/credit-market/link-key/penalty routes in a deployed environment