### PR TITLE
fix: enable change-log toggle for delete-only supplementals (#3864)

### DIFF
--- a/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_services.py
+++ b/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_services.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models.compliance.AllocationAgreement import AllocationAgreement
@@ -7,6 +7,7 @@ from lcfs.web.api.allocation_agreement.schema import (
     AllocationAgreementCreateSchema,
 )
 from lcfs.web.api.allocation_agreement.services import AllocationAgreementServices
+from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 from lcfs.web.api.compliance_report.services import ComplianceReportServices
 from lcfs.web.api.compliance_report.dtos import ChangelogAllocationAgreementsDTO
 
@@ -65,8 +66,12 @@ def quarterly_allocation_agreement_schema():
 @pytest.fixture
 def service(mock_repo_full, mock_fuel_repo_full):
     """Create a service with mocked repositories for testing."""
+    mock_compliance_report_repo = MagicMock(spec=ComplianceReportRepository)
+    mock_compliance_report_repo.has_supplemental_changes = AsyncMock(return_value=False)
     return AllocationAgreementServices(
-        repo=mock_repo_full, fuel_repo=mock_fuel_repo_full
+        repo=mock_repo_full,
+        fuel_repo=mock_fuel_repo_full,
+        compliance_report_repo=mock_compliance_report_repo,
     )
 
 

--- a/backend/lcfs/tests/fuel_supply/test_fuel_supplies_services.py
+++ b/backend/lcfs/tests/fuel_supply/test_fuel_supplies_services.py
@@ -12,6 +12,7 @@ from lcfs.db.models import (
 )
 from lcfs.db.models.compliance.FuelSupply import FuelSupply
 from lcfs.db.models.user.Role import RoleEnum
+from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 from lcfs.web.api.fuel_code.repo import FuelCodeRepository
 from lcfs.web.api.fuel_supply.actions_service import FuelSupplyActionService
 from lcfs.web.api.fuel_supply.repo import FuelSupplyRepository
@@ -58,9 +59,12 @@ def fuel_supply_action_service():
 def fuel_supply_service():
     mock_repo = MagicMock(spec=FuelSupplyRepository)
     mock_fuel_code_repo = MagicMock(spec=FuelCodeRepository)
+    mock_compliance_report_repo = MagicMock(spec=ComplianceReportRepository)
+    mock_compliance_report_repo.has_supplemental_changes = AsyncMock(return_value=False)
     service = FuelSupplyServices(
         repo=mock_repo,
         fuel_repo=mock_fuel_code_repo,
+        compliance_report_repo=mock_compliance_report_repo,
     )
     return service, mock_repo, mock_fuel_code_repo
 

--- a/backend/lcfs/tests/notional_transfer/test_notional_transfer_services.py
+++ b/backend/lcfs/tests/notional_transfer/test_notional_transfer_services.py
@@ -7,6 +7,7 @@ from lcfs.db.models.compliance.NotionalTransfer import (
     ReceivedOrTransferredEnum,
 )
 from lcfs.tests.notional_transfer.conftest import create_mock_schema, create_mock_entity
+from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 from lcfs.web.api.notional_transfer.repo import NotionalTransferRepository
 from lcfs.web.api.notional_transfer.schema import (
     NotionalTransferSchema,
@@ -20,7 +21,13 @@ from lcfs.web.exception.exceptions import ServiceException
 def notional_transfer_service():
     mock_repo = MagicMock(spec=NotionalTransferRepository)
     mock_fuel_repo = MagicMock()
-    service = NotionalTransferServices(repo=mock_repo, fuel_repo=mock_fuel_repo)
+    mock_compliance_report_repo = MagicMock(spec=ComplianceReportRepository)
+    mock_compliance_report_repo.has_supplemental_changes = AsyncMock(return_value=False)
+    service = NotionalTransferServices(
+        repo=mock_repo,
+        fuel_repo=mock_fuel_repo,
+        compliance_report_repo=mock_compliance_report_repo,
+    )
     return service, mock_repo, mock_fuel_repo
 
 

--- a/backend/lcfs/tests/other_uses/test_other_uses_services.py
+++ b/backend/lcfs/tests/other_uses/test_other_uses_services.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, AsyncMock
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.tests.other_uses.conftest import create_mock_schema, create_mock_entity
+from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 from lcfs.web.api.other_uses.repo import OtherUsesRepository
 from lcfs.web.api.other_uses.schema import OtherUsesSchema
 from lcfs.web.api.other_uses.schema import (
@@ -15,7 +16,13 @@ from lcfs.web.api.other_uses.services import OtherUsesServices
 def other_uses_service():
     mock_repo = MagicMock(spec=OtherUsesRepository)
     mock_fuel_repo = MagicMock()
-    service = OtherUsesServices(repo=mock_repo, fuel_repo=mock_fuel_repo)
+    mock_compliance_report_repo = MagicMock(spec=ComplianceReportRepository)
+    mock_compliance_report_repo.has_supplemental_changes = AsyncMock(return_value=False)
+    service = OtherUsesServices(
+        repo=mock_repo,
+        fuel_repo=mock_fuel_repo,
+        compliance_report_repo=mock_compliance_report_repo,
+    )
     return service, mock_repo, mock_fuel_repo
 
 

--- a/backend/lcfs/web/api/allocation_agreement/schema.py
+++ b/backend/lcfs/web/api/allocation_agreement/schema.py
@@ -193,6 +193,7 @@ class AllocationAgreementSchema(AllocationAgreementCreateSchema):
 class AllocationAgreementAllSchema(BaseSchema):
     allocation_agreements: List[AllocationAgreementResponseSchema]
     pagination: Optional[PaginationResponseSchema] = {}
+    was_edited: bool = False
 
 
 class AllocationAgreementListSchema(BaseSchema):

--- a/backend/lcfs/web/api/allocation_agreement/services.py
+++ b/backend/lcfs/web/api/allocation_agreement/services.py
@@ -190,8 +190,12 @@ class AllocationAgreementServices:
                 updated=None,  # Assuming this is not mapped
             )
             allocation_agreements_response.append(aa_response)
+        was_edited = await self.compliance_report_repo.has_supplemental_changes(
+            compliance_report_id, AllocationAgreement
+        )
         return AllocationAgreementAllSchema(
-            allocation_agreements=allocation_agreements_response
+            allocation_agreements=allocation_agreements_response,
+            was_edited=was_edited,
         )
 
     @service_handler

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -686,6 +686,60 @@ class ComplianceReportRepository:
         return ComplianceReportBaseSchema.model_validate(compliance_report)
 
     @repo_handler
+    async def has_supplemental_changes(
+        self, compliance_report_id: int, model: Type
+    ) -> bool:
+        """
+        Returns True if any record of the given activity model belongs to a
+        supplemental report (version > 0) in this report's chain. Detects
+        edits even when the only change was a deletion (which is filtered
+        out of normal VIEW responses).
+        """
+        supplemental_ids = await self.get_supplemental_report_ids_in_chain(
+            compliance_report_id
+        )
+        if not supplemental_ids:
+            return False
+        result = await self.db.execute(
+            select(model.compliance_report_id)
+            .where(model.compliance_report_id.in_(supplemental_ids))
+            .limit(1)
+        )
+        return result.scalar() is not None
+
+    @repo_handler
+    async def get_supplemental_report_ids_in_chain(
+        self, compliance_report_id: int
+    ) -> List[int]:
+        """
+        Return ids of compliance reports in the same chain (up to and including
+        this report's version) whose version > 0 — i.e. supplemental reports
+        that may have edited this chain. Used to flag activity sections as
+        edited even when the only change was a deletion.
+        """
+        anchor = await self.db.execute(
+            select(
+                ComplianceReport.compliance_report_group_uuid,
+                ComplianceReport.version,
+            ).where(ComplianceReport.compliance_report_id == compliance_report_id)
+        )
+        row = anchor.first()
+        if not row or not row[0]:
+            return []
+        group_uuid, version = row
+
+        result = await self.db.execute(
+            select(ComplianceReport.compliance_report_id).where(
+                and_(
+                    ComplianceReport.compliance_report_group_uuid == group_uuid,
+                    ComplianceReport.version > 0,
+                    ComplianceReport.version <= version,
+                )
+            )
+        )
+        return [r[0] for r in result.all()]
+
+    @repo_handler
     async def get_compliance_report_chain(self, group_uuid: str):
         # Build base query with all necessary joins
         query = (

--- a/backend/lcfs/web/api/fuel_export/schema.py
+++ b/backend/lcfs/web/api/fuel_export/schema.py
@@ -212,3 +212,4 @@ class FuelExportsSchema(BaseSchema):
     fuel_exports: Optional[List[FuelExportSchema]] = []
     pagination: Optional[PaginationResponseSchema] = None
     total_compliance_units: Optional[int] = None
+    was_edited: bool = False

--- a/backend/lcfs/web/api/fuel_export/services.py
+++ b/backend/lcfs/web/api/fuel_export/services.py
@@ -27,6 +27,7 @@ from lcfs.web.core.decorators import service_handler
 from lcfs.web.api.role.schema import user_has_roles
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.db.base import ActionTypeEnum
+from lcfs.db.models.compliance.FuelExport import FuelExport
 
 logger = structlog.get_logger(__name__)
 
@@ -266,9 +267,14 @@ class FuelExportServices:
             )
         )
 
+        was_edited = await self.compliance_report_repo.has_supplemental_changes(
+            compliance_report_id, FuelExport
+        )
+
         return FuelExportsSchema(
             fuel_exports=fs_list if fs_list else [],
             total_compliance_units=total_compliance_units,
+            was_edited=was_edited,
         )
 
     @service_handler

--- a/backend/lcfs/web/api/fuel_supply/schema.py
+++ b/backend/lcfs/web/api/fuel_supply/schema.py
@@ -206,6 +206,7 @@ class FuelSuppliesSchema(BaseSchema):
     fuel_supplies: Optional[List[FuelSupplyResponseSchema]] = []
     pagination: Optional[PaginationResponseSchema] = {}
     total_compliance_units: Optional[int] = None
+    was_edited: bool = False
 
 
 # Organization Fuel Supply Schemas

--- a/backend/lcfs/web/api/fuel_supply/services.py
+++ b/backend/lcfs/web/api/fuel_supply/services.py
@@ -259,9 +259,14 @@ class FuelSupplyServices:
             )
         )
 
+        was_edited = await self.compliance_report_repo.has_supplemental_changes(
+            compliance_report_id, FuelSupply
+        )
+
         return FuelSuppliesSchema(
             fuel_supplies=fs_list if fs_list else [],
             total_compliance_units=total_compliance_units,
+            was_edited=was_edited,
         )
 
     def map_entity_to_schema(self, fuel_supply: FuelSupply):

--- a/backend/lcfs/web/api/notional_transfer/schema.py
+++ b/backend/lcfs/web/api/notional_transfer/schema.py
@@ -98,6 +98,7 @@ class NotionalTransfersSchema(BaseSchema):
 
 class NotionalTransfersAllSchema(BaseSchema):
     notional_transfers: List[NotionalTransferSchema]
+    was_edited: bool = False
 
 
 class NotionalTransferFuelCategorySchema(BaseSchema):

--- a/backend/lcfs/web/api/notional_transfer/services.py
+++ b/backend/lcfs/web/api/notional_transfer/services.py
@@ -121,7 +121,13 @@ class NotionalTransferServices:
         notional_transfers = await self.repo.get_notional_transfers(
             compliance_report_id, changelog
         )
-        return NotionalTransfersAllSchema(notional_transfers=notional_transfers)
+        was_edited = await self.compliance_report_repo.has_supplemental_changes(
+            compliance_report_id, NotionalTransfer
+        )
+        return NotionalTransfersAllSchema(
+            notional_transfers=notional_transfers,
+            was_edited=was_edited,
+        )
 
     @service_handler
     async def get_notional_transfers_paginated(

--- a/backend/lcfs/web/api/other_uses/schema.py
+++ b/backend/lcfs/web/api/other_uses/schema.py
@@ -191,6 +191,7 @@ class OtherUsesListSchema(BaseSchema):
 
 class OtherUsesAllSchema(BaseSchema):
     other_uses: List[OtherUsesSchema]
+    was_edited: bool = False
 
 
 class DeleteOtherUsesSchema(BaseSchema):

--- a/backend/lcfs/web/api/other_uses/services.py
+++ b/backend/lcfs/web/api/other_uses/services.py
@@ -160,8 +160,12 @@ class OtherUsesServices:
         Gets the list of other uses for a specific compliance report.
         """
         other_uses = await self.repo.get_other_uses(compliance_report_id, changelog)
+        was_edited = await self.compliance_report_repo.has_supplemental_changes(
+            compliance_report_id, OtherUses
+        )
         return OtherUsesAllSchema(
-            other_uses=[OtherUsesSchema.model_validate(ou) for ou in other_uses]
+            other_uses=[OtherUsesSchema.model_validate(ou) for ou in other_uses],
+            was_edited=was_edited,
         )
 
     @service_handler

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -135,27 +135,10 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
     [editSupportingDocs, canEdit, t]
   )
 
-  const crMap = useMemo(() => {
-    if (!complianceReportData?.chain) return {}
-
-    const mapSet = {}
-    complianceReportData.chain.forEach((complianceReport) => {
-      mapSet[complianceReport.complianceReportId] = complianceReport.version
-    })
-    return mapSet
-  }, [complianceReportData?.chain])
-
-  const wasEdited = useCallback(
-    (data) => {
-      if (!data || !Array.isArray(data)) return false
-      return data.some(
-        (row) =>
-          crMap[row.complianceReportId] !== 0 &&
-          Object.prototype.hasOwnProperty.call(row, 'version')
-      )
-    },
-    [crMap]
-  )
+  // Backend-computed flag on the activity list response. Detects edits even
+  // when the only change was a deletion in a supplemental — those rows are
+  // filtered out of VIEW responses so we can't infer this client-side.
+  const wasEdited = useCallback((data) => Boolean(data?.wasEdited), [])
 
   const navigationHandlers = useMemo(
     () => ({
@@ -249,7 +232,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
               label="Change log"
               disabled={
                 !(reportInfo.hasVersions || reportInfo.isSupplemental) ||
-                !wasEdited(data.fuelSupplies)
+                !wasEdited(data)
               }
               onComponent={
                 <FuelSupplyChangelog
@@ -296,7 +279,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
               label="Change log"
               disabled={
                 !(reportInfo.hasVersions || reportInfo.isSupplemental) ||
-                !wasEdited(data.allocationAgreements)
+                !wasEdited(data)
               }
               onComponent={
                 <AllocationAgreementChangelog
@@ -325,7 +308,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
               label="Change log"
               disabled={
                 !(reportInfo.hasVersions || reportInfo.isSupplemental) ||
-                !wasEdited(data.notionalTransfers)
+                !wasEdited(data)
               }
               onComponent={<NotionalTransferChangelog canEdit={canEdit} />}
               offComponent={
@@ -345,7 +328,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
               label="Change log"
               disabled={
                 !(reportInfo.hasVersions || reportInfo.isSupplemental) ||
-                !wasEdited(data.otherUses)
+                !wasEdited(data)
               }
               onComponent={<OtherUsesChangelog canEdit={canEdit} />}
               offComponent={
@@ -365,7 +348,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
               label="Change log"
               disabled={
                 !(reportInfo.hasVersions || reportInfo.isSupplemental) ||
-                !wasEdited(data.fuelExports)
+                !wasEdited(data)
               }
               onComponent={<FuelExportChangelog canEdit={canEdit} />}
               offComponent={
@@ -688,7 +671,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
                     </IconButton>
                   </Role>
                 )}{' '}
-                {wasEdited(data?.[activity.key]) && !allRecordsDeleted && (
+                {wasEdited(data) && !allRecordsDeleted && (
                   <Chip
                     aria-label="changes were made since original report"
                     icon={<NewReleasesOutlined fontSize="small" />}

--- a/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
@@ -414,12 +414,13 @@ describe('ReportDetails', () => {
       }
     })
 
-    // Mock data with version indicating it was edited
+    // Mock data with backend-set wasEdited flag
     mockUseGetFuelSupplies.mockReturnValue({
       data: {
         fuelSupplies: [
           { fuelSupplyId: 24, complianceReportId: '12346', version: 1 }
-        ]
+        ],
+        wasEdited: true
       },
       isLoading: false,
       error: null


### PR DESCRIPTION
## Summary

Closes part of [#3864](https://github.com/bcgov/lcfs/issues/3864): the change-log toggle was disabled on Fuel Supply (and other activity sections) for historical TFRS reports 370 and 755 even though both have a real supplemental version in the chain.

**Root cause** — the toggle's enabled state was inferred client-side from rows in the activity response. \`mode=view\` filters out any group whose latest action is \`DELETE\`, so for supplementals whose only edits were deletions, every surviving row mapped back to the base report (\`version=0\`) and \`wasEdited\` returned false. Reports 370/755 fall into this case (the supplemental only deleted rows from the original).

**Fix** — compute the flag server-side. New \`ComplianceReportRepository.has_supplemental_changes(report_id, model)\` returns true if any record of the given activity model belongs to a chain entry with \`version > 0\`. Each of the 5 activity list schemas now exposes \`was_edited\`, and the frontend reads \`data.wasEdited\` instead of inferring from row contents. Per-section accuracy is preserved — toggles still enable only on sections that actually have edits in the chain.

DB sanity check on local data:

| report_id | fuel_supply_was_edited |
|---|---|
| 370 (supp.) | t |
| 755 (supp.) | t |
| 754 (base)  | f |
| 3657 (base) | f |

## Test plan

- [ ] Open compliance report 755 → expand Fuel Supply → "Change log" toggle is enabled and shows the deletion history when clicked
- [ ] Open compliance report 370 → same behaviour
- [ ] Open a non-supplemental report (e.g. 754) → "Change log" toggle is disabled (no chain)
- [ ] Open a non-TFRS supplemental that *did* edit Fuel Supply (CREATE/UPDATE) → toggle still enables (existing behaviour preserved)
- [ ] Open a non-TFRS supplemental that *did not* edit Allocation Agreement → that section's toggle stays disabled (per-section accuracy preserved)
- [x] Backend: \`pytest lcfs/tests/{fuel_supply,fuel_export,notional_transfer,other_uses,allocation_agreement,compliance_report}/\` — 657 passed
- [x] Frontend: \`vitest run ReportDetails.test.jsx\` — 22 passed