### PR TITLE
fix: LCFS - Line 21/22 ignore prior-assessed credits when tx finalized post-deadline (#4235)

### DIFF
--- a/backend/lcfs/tests/compliance_report/conftest.py
+++ b/backend/lcfs/tests/compliance_report/conftest.py
@@ -173,6 +173,7 @@ def mock_trxn_repo():
     repo = AsyncMock(spec=TransactionRepository)
     repo.calculate_available_balance_for_period = AsyncMock(return_value=2000)
     repo.delete_transaction = AsyncMock()
+    repo.get_group_adjustments_excluded_from_line_17 = AsyncMock(return_value=0)
     return repo
 
 

--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -1129,6 +1129,88 @@ async def test_supplemental_report_uses_existing_summary_line_17(
 
 
 @pytest.mark.anyio
+async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
+    compliance_report_summary_service, mock_trxn_repo, mock_summary_repo, mock_repo
+):
+    """
+    Regression test for bug #4235.
+
+    When a prior supplemental was assessed AFTER the compliance period end
+    (March 31, year + 1), its Adjustment transaction is excluded from Line 17.
+    However, the organization still holds those credits, so a new supplemental
+    that reduces the supply must not wipe the balance to zero or apply a
+    penalty as long as units remain.
+
+    Scenario (based on prod report 3400):
+      - Prior assessed v1 issued 795 credits (post-deadline -> NOT in Line 17).
+      - Current v2 proposes Line 18 = 567 -> Line 20 = -228.
+      - Expected Line 22 = 567 (remaining issued credits), Line 21 = 0.
+    """
+    compliance_period_start = datetime(2024, 1, 1)
+    compliance_period_end = datetime(2024, 12, 31)
+    organization_id = 1
+
+    compliance_report = MagicMock(spec=ComplianceReport)
+    compliance_report.version = 2
+    compliance_report.organization_id = organization_id
+    compliance_report.compliance_period = MagicMock(description="2024")
+    compliance_report.compliance_report_group_uuid = "bug-4235-group"
+    compliance_report.compliance_report_id = 3400
+
+    mock_cr_summary = MagicMock(spec=ComplianceReportSummary)
+    mock_cr_summary.line_17_non_banked_units_used = None
+    mock_cr_summary.is_locked = False
+    compliance_report.summary = mock_cr_summary
+
+    mock_summary_repo.get_transferred_out_compliance_units.return_value = 0
+    mock_summary_repo.get_received_compliance_units.return_value = 0
+    mock_summary_repo.get_issued_compliance_units.return_value = 0
+
+    mock_assessed_report = MagicMock()
+    mock_assessed_summary = MagicMock()
+    mock_assessed_summary.line_18_units_to_be_banked = 795
+    mock_assessed_summary.line_19_units_to_be_exported = 0
+    mock_assessed_report.summary = mock_assessed_summary
+    mock_repo.get_assessed_compliance_report_by_period.return_value = (
+        mock_assessed_report
+    )
+
+    # Line 17 excludes the prior issuance because the prior assessment was
+    # finalized after the period deadline.
+    mock_trxn_repo.calculate_line_17_available_balance_for_period.return_value = 0
+    # The new helper surfaces that post-deadline prior issuance (795).
+    mock_trxn_repo.get_group_adjustments_excluded_from_line_17.return_value = 795
+
+    compliance_report_summary_service.calculate_fuel_supply_compliance_units = (
+        AsyncMock(return_value=567)
+    )
+    compliance_report_summary_service.calculate_fuel_export_compliance_units = (
+        AsyncMock(return_value=0)
+    )
+
+    summary, penalty_units = (
+        await compliance_report_summary_service.calculate_low_carbon_fuel_target_summary(
+            compliance_period_start,
+            compliance_period_end,
+            organization_id,
+            compliance_report,
+        )
+    )
+
+    line_values = _get_line_values(summary)
+    assert line_values[15] == 795
+    assert line_values[17] == 0
+    assert line_values[18] == 567
+    assert line_values[20] == -228  # 567 - 795
+    assert line_values[21] == 0  # no penalty: credits remain
+    assert line_values[22] == 567  # 0 + 795 (deferred) + (-228)
+
+    mock_trxn_repo.get_group_adjustments_excluded_from_line_17.assert_called_once_with(
+        "bug-4235-group", organization_id, 3400, compliance_period_start.year
+    )
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "penalty_payable, exp_row1, exp_row2, exp_row3",
     [

--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -1133,18 +1133,15 @@ async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
     compliance_report_summary_service, mock_trxn_repo, mock_summary_repo, mock_repo
 ):
     """
-    Regression test for bug #4235.
+    Regression test: when a prior supplemental was assessed AFTER the
+    compliance period end (March 31, year + 1), its Adjustment transaction is
+    excluded from Line 17. The organization still holds those credits, so a
+    new supplemental that reduces the supply must not wipe the balance to
+    zero or apply a penalty as long as units remain.
 
-    When a prior supplemental was assessed AFTER the compliance period end
-    (March 31, year + 1), its Adjustment transaction is excluded from Line 17.
-    However, the organization still holds those credits, so a new supplemental
-    that reduces the supply must not wipe the balance to zero or apply a
-    penalty as long as units remain.
-
-    Scenario (based on prod report 3400):
-      - Prior assessed v1 issued 795 credits (post-deadline -> NOT in Line 17).
-      - Current v2 proposes Line 18 = 567 -> Line 20 = -228.
-      - Expected Line 22 = 567 (remaining issued credits), Line 21 = 0.
+      - Prior assessed v1 issued 1000 credits (post-deadline -> NOT in Line 17).
+      - Current v2 proposes Line 18 = 800 -> Line 20 = -200.
+      - Expected Line 22 = 800 (remaining issued credits), Line 21 = 0.
     """
     compliance_period_start = datetime(2024, 1, 1)
     compliance_period_end = datetime(2024, 12, 31)
@@ -1154,8 +1151,8 @@ async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
     compliance_report.version = 2
     compliance_report.organization_id = organization_id
     compliance_report.compliance_period = MagicMock(description="2024")
-    compliance_report.compliance_report_group_uuid = "bug-4235-group"
-    compliance_report.compliance_report_id = 3400
+    compliance_report.compliance_report_group_uuid = "post-deadline-group"
+    compliance_report.compliance_report_id = 999
 
     mock_cr_summary = MagicMock(spec=ComplianceReportSummary)
     mock_cr_summary.line_17_non_banked_units_used = None
@@ -1168,7 +1165,7 @@ async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
 
     mock_assessed_report = MagicMock()
     mock_assessed_summary = MagicMock()
-    mock_assessed_summary.line_18_units_to_be_banked = 795
+    mock_assessed_summary.line_18_units_to_be_banked = 1000
     mock_assessed_summary.line_19_units_to_be_exported = 0
     mock_assessed_report.summary = mock_assessed_summary
     mock_repo.get_assessed_compliance_report_by_period.return_value = (
@@ -1178,11 +1175,11 @@ async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
     # Line 17 excludes the prior issuance because the prior assessment was
     # finalized after the period deadline.
     mock_trxn_repo.calculate_line_17_available_balance_for_period.return_value = 0
-    # The new helper surfaces that post-deadline prior issuance (795).
-    mock_trxn_repo.get_group_adjustments_excluded_from_line_17.return_value = 795
+    # The new helper surfaces that post-deadline prior issuance.
+    mock_trxn_repo.get_group_adjustments_excluded_from_line_17.return_value = 1000
 
     compliance_report_summary_service.calculate_fuel_supply_compliance_units = (
-        AsyncMock(return_value=567)
+        AsyncMock(return_value=800)
     )
     compliance_report_summary_service.calculate_fuel_export_compliance_units = (
         AsyncMock(return_value=0)
@@ -1198,15 +1195,15 @@ async def test_reassessment_after_deadline_retains_prior_issuance_for_line_22(
     )
 
     line_values = _get_line_values(summary)
-    assert line_values[15] == 795
+    assert line_values[15] == 1000
     assert line_values[17] == 0
-    assert line_values[18] == 567
-    assert line_values[20] == -228  # 567 - 795
+    assert line_values[18] == 800
+    assert line_values[20] == -200  # 800 - 1000
     assert line_values[21] == 0  # no penalty: credits remain
-    assert line_values[22] == 567  # 0 + 795 (deferred) + (-228)
+    assert line_values[22] == 800  # 0 + 1000 (deferred) + (-200)
 
     mock_trxn_repo.get_group_adjustments_excluded_from_line_17.assert_called_once_with(
-        "bug-4235-group", organization_id, 3400, compliance_period_start.year
+        "post-deadline-group", organization_id, 999, compliance_period_start.year
     )
 
 

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -1466,8 +1466,29 @@ class ComplianceReportSummaryService:
             - compliance_units_prev_issued_for_fuel_export
         )  # line 20 = line 18 + line 19 - line 15 - line 16
 
+        # Prior assessed supplementals in this group may have been finalized
+        # after the compliance period end date. Their Adjustment transactions
+        # are intentionally excluded from Line 17 (which is a period-end
+        # snapshot), but the organization still holds those credits. Include
+        # them when deriving Line 21/22 so the penalty and remaining balance
+        # reflect what the organization will actually hold after reassessment.
+        deferred_prior_issuance = 0
+        if compliance_report.version > 0 and compliance_report.compliance_report_group_uuid:
+            deferred_prior_issuance = int(
+                await self.trxn_repo.get_group_adjustments_excluded_from_line_17(
+                    compliance_report.compliance_report_group_uuid,
+                    organization_id,
+                    compliance_report.compliance_report_id,
+                    compliance_year,
+                )
+            )
+
+        effective_available_balance = (
+            available_balance_for_period + deferred_prior_issuance
+        )
+
         calculated_penalty_units = int(
-            available_balance_for_period
+            effective_available_balance
             + compliance_unit_balance_change_from_assessment
         )
         non_compliance_penalty_payable_units = (
@@ -1486,9 +1507,9 @@ class ComplianceReportSummaryService:
             else 0
         )  # line 21
 
-        available_balance_for_period_after_assessment = (  # line 22 = line 17 + line 20
+        available_balance_for_period_after_assessment = (  # line 22
             max(
-                available_balance_for_period
+                effective_available_balance
                 + compliance_unit_balance_change_from_assessment,
                 0,
             )

--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -681,6 +681,57 @@ class TransactionRepository:
         return max(available_balance, 0)
 
     @repo_handler
+    async def get_group_adjustments_excluded_from_line_17(
+        self,
+        compliance_report_group_uuid: str,
+        organization_id: int,
+        exclude_report_id: int,
+        compliance_period: int,
+    ) -> int:
+        """
+        Sum Adjustment transactions that are linked to other compliance reports
+        in the same report group but are excluded from the Line 17 available
+        balance because their transaction was finalized (Reserved -> Adjustment)
+        after the compliance period end date (March 31, year + 1).
+
+        These represent compliance units the organization actually holds from
+        prior assessments that Line 17 does not capture because of the period-
+        end cutoff. They must be added back when deriving Line 21/22 so the
+        summary reflects the organization's true remaining balance.
+        """
+        vancouver_timezone = zoneinfo.ZoneInfo("America/Vancouver")
+        compliance_period_end_local = datetime.strptime(
+            f"{str(compliance_period + 1)}-03-31", "%Y-%m-%d"
+        ).replace(
+            hour=23,
+            minute=59,
+            second=59,
+            microsecond=999999,
+            tzinfo=vancouver_timezone,
+        )
+
+        result = await self.db.scalar(
+            select(func.coalesce(func.sum(Transaction.compliance_units), 0))
+            .select_from(Transaction)
+            .join(
+                ComplianceReport,
+                Transaction.transaction_id == ComplianceReport.transaction_id,
+            )
+            .where(
+                and_(
+                    ComplianceReport.compliance_report_group_uuid
+                    == compliance_report_group_uuid,
+                    ComplianceReport.compliance_report_id != exclude_report_id,
+                    Transaction.organization_id == organization_id,
+                    Transaction.transaction_action
+                    == TransactionActionEnum.Adjustment,
+                    Transaction.update_date > compliance_period_end_local,
+                )
+            )
+        )
+        return int(result or 0)
+
+    @repo_handler
     async def create_transaction(
         self,
         transaction_action: TransactionActionEnum,


### PR DESCRIPTION
## Summary
- Fixes [#4235](https://github.com/bcgov/lcfs/issues/4235). In a multi-supplemental scenario, if a prior version's assessment was finalized **after** the compliance period end (March 31, year + 1), its Adjustment transaction is intentionally excluded from Line 17's period-end snapshot. The organisation still holds those credits, but `Line 22 = max(line_17 + line_20, 0)` then zeros out the balance and `Line 21` applies a false non-compliance penalty on the reassessment's Line 20 deficit.
- New repo helper `TransactionRepository.get_group_adjustments_excluded_from_line_17` sums Adjustment transactions in the same report group with `update_date > compliance_period_end`. `summary_service.calculate_low_carbon_fuel_target_summary` folds that amount into an `effective_available_balance` used **only** for Line 21 and Line 22. Lines 15, 17, and 20 are unchanged (they were already correct per the bug report).
- Handles multi-level supplemental chains — any combination of pre- or post-deadline assessments along the chain resolves correctly.

## Affected production reports
Two Reports (identified via the detection query below). Manual data patch for both is provided separately to the analyst applying the prod fix — not included in this PR.

## Test plan
- [x] New regression test `test_reassessment_after_deadline_retains_prior_issuance_for_line_22` covers the reassessment-after-deadline scenario.
- [x] Full backend suite green locally (`pytest lcfs/tests` — 1441 passed, 1 skipped).
- [ ] Verify report 3400 summary in dev: Line 21 = 0, Line 22 reflects remaining issued balance after pulling the branch.
- [ ] Verify report 3546 summary in dev: Line 21 = 0, Line 22 reflects remaining issued balance.
- [ ] Confirm an original (v0) report and a pre-deadline supplemental chain are unaffected (no change in Line 21/22).
- [ ] Run the detection query on prod and review any additional candidates before applying the data patch.
