### PR TITLE
Fix: LCFS - Neutralise penalty caused by transfer date tz bug (#4239)

### DIFF
--- a/backend/lcfs/web/api/transfer/services.py
+++ b/backend/lcfs/web/api/transfer/services.py
@@ -1,6 +1,7 @@
 import json
 import structlog
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from fastapi import Depends, HTTPException
 from typing import List, Optional
 
@@ -484,7 +485,12 @@ class TransferServices:
             updated_transfer = await self.update_category(
                 transfer.transfer_id, category
             )
-            updated_transfer.transaction_effective_date = datetime.now(timezone.utc).replace(tzinfo=None)
+            # Store the Pacific calendar date the director clicked "Record"
+            # (matches IA/admin_adjustment convention and avoids UTC→PT date shifts
+            # on late-evening records near compliance period boundaries).
+            updated_transfer.transaction_effective_date = datetime.now(
+                ZoneInfo("America/Vancouver")
+            ).date()
 
         # Create new transaction for receiving organization
         to_transaction = await self.org_service.adjust_balance(


### PR DESCRIPTION
## Summary

Fixes [#4239](https://github.com/bcgov/lcfs/issues/4239). `director_record_transfer` writes `datetime.now(timezone.utc)` (tz stripped) into `transaction_effective_date`. Late-evening Pacific recordings are stored with an early-morning-UTC timestamp, which rolls the stored date forward across the compliance period end (Mar 31 → Apr 1). Downstream penalty calculations compare this naive value against naive Pacific boundaries and silently exclude the transfer.

The sibling write paths for `initiative_agreement` and `admin_adjustment` already store a Pacific calendar date (`datetime.now(...).date()`), so this change aligns the three write paths.

## Fix

[transfer/services.py:485-491](backend/lcfs/web/api/transfer/services.py#L485):

```python
updated_transfer.transaction_effective_date = datetime.now(
    ZoneInfo(\"America/Vancouver\")
).date()
```

No read-path changes needed — existing queries compare as Pacific calendar dates, which this now stores consistently.

Existing data will be corrected manually out-of-band after deploy; report 3601's summary then recalculates on re-open via [summary_service.py:569,1451](backend/lcfs/web/api/compliance_report/summary_service.py#L569) and the penalty drops to \$0.

## Test plan

- [x] Existing \`test_transfer_services.py\` suite passes (15/15)
- [x] Local reproduction: after correcting the 3 crossover rows, Line 13 = 839 and Line 17 = 839 for org 1898/period 2025 (was 0)
- [x] Verified IA/admin-adjustment write paths already store Pacific dates, so no new divergence
- [ ] After deploy to test: record a new transfer late-evening PT, confirm stored \`transaction_effective_date\` is the Pacific date at midnight
- [ ] After manual data correction + report refresh: report 3601 shows \$0 penalty