### PR TITLE
Feat: Add Allocating organization to charging site card - 4243

### DIFF
--- a/frontend/src/assets/locales/en/chargingSite.json
+++ b/frontend/src/assets/locales/en/chargingSite.json
@@ -86,6 +86,7 @@
   "cardTitle": "Charging site",
   "cardLabels": {
     "organization": "Organization",
+    "allocatingOrganization": "Allocating organization",
     "coordinates": "Coordinates",
     "status": "Status",
     "version": "Version number",

--- a/frontend/src/views/ChargingSite/__tests__/components/ChargingSiteProfile.test.jsx
+++ b/frontend/src/views/ChargingSite/__tests__/components/ChargingSiteProfile.test.jsx
@@ -41,7 +41,9 @@ describe('ChargingSiteProfile', () => {
     city: 'Vancouver',
     postalCode: 'V6B 1A1',
     notes: 'Test notes',
-    organization: { name: 'Test Organization' }
+    organization: { name: 'Test Organization' },
+    allocatingOrganization: { name: 'Allocating Org Ltd' },
+    allocatingOrganizationName: null
   }
 
   beforeEach(() => {
@@ -67,6 +69,46 @@ describe('ChargingSiteProfile', () => {
     render(<ChargingSiteProfile data={mockData} />, { wrapper })
     
     expect(screen.getByText('Test notes')).toBeInTheDocument()
+  })
+
+  it('displays allocating organization name when available', () => {
+    render(<ChargingSiteProfile data={mockData} />, { wrapper })
+
+    expect(screen.getByText('Allocating Org Ltd')).toBeInTheDocument()
+  })
+
+  it('falls back to allocatingOrganizationName string when nested object is absent', () => {
+    const dataWithNameOnly = {
+      ...mockData,
+      allocatingOrganization: null,
+      allocatingOrganizationName: 'Fallback Org'
+    }
+    render(<ChargingSiteProfile data={dataWithNameOnly} />, { wrapper })
+
+    expect(screen.getByText('Fallback Org')).toBeInTheDocument()
+  })
+
+  it('displays N/A when allocating organization is null', () => {
+    const dataWithoutAllocating = {
+      ...mockData,
+      allocatingOrganization: null,
+      allocatingOrganizationName: null
+    }
+    render(<ChargingSiteProfile data={dataWithoutAllocating} />, { wrapper })
+
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  it('renders allocating organization below site address', () => {
+    render(<ChargingSiteProfile data={mockData} />, { wrapper })
+
+    const addressText = screen.getByText('123 Main St, Vancouver, V6B 1A1')
+    const allocatingText = screen.getByText('Allocating Org Ltd')
+
+    expect(
+      addressText.compareDocumentPosition(allocatingText) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it('shows organization for government users', () => {

--- a/frontend/src/views/ChargingSite/components/ChargingSiteProfile.jsx
+++ b/frontend/src/views/ChargingSite/components/ChargingSiteProfile.jsx
@@ -125,6 +125,15 @@ export const ChargingSiteProfile = ({
 
           <BCTypography variant="body4">
             <BCTypography variant="label">
+              {t('cardLabels.allocatingOrganization')}:
+            </BCTypography>{' '}
+            {data?.allocatingOrganization?.name ||
+              data?.allocatingOrganizationName ||
+              'N/A'}
+          </BCTypography>
+
+          <BCTypography variant="body4">
+            <BCTypography variant="label">
               {t('cardLabels.notes')}:
             </BCTypography>{' '}
             {data?.notes}
@@ -140,6 +149,7 @@ export const ChargingSiteProfile = ({
           {data?.organization?.name || ''}
         </BCTypography>
       </Role>
+
 
       {(canSetValidated || canSubmitSite) && (
         <BCBox sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>


### PR DESCRIPTION
This PR adds Allocating organization field to Charging site display card.

- Displays allocating organization field
- Shows NA when value missing

Closes #4243