### PR TITLE
fix: LCFS - hide penalties on reports recommended for exemption (#4269)

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -3093,3 +3093,156 @@ async def test_line_15_16_uses_assessed_report_values(
     # Line 16 should use assessed report's Line 19 value
     line_16 = next(row for row in result.low_carbon_fuel_target_summary if row.line == 16)
     assert line_16.value == 1000, f"Line 16 should be 1000 from assessed report, got {line_16.value}"
+
+
+def _make_summary_schema_with_penalties():
+    """Build a ComplianceReportSummarySchema with non-zero penalty rows for exemption tests."""
+    return ComplianceReportSummarySchema(
+        renewable_fuel_target_summary=[
+            ComplianceReportSummaryRowSchema(line=4, gasoline=100, diesel=200, jet_fuel=50),
+            ComplianceReportSummaryRowSchema(line=11, gasoline=300, diesel=400, jet_fuel=100, total_value=800),
+        ],
+        low_carbon_fuel_target_summary=[
+            ComplianceReportSummaryRowSchema(line=17, value=250),
+            ComplianceReportSummaryRowSchema(line=18, value=100),
+            ComplianceReportSummaryRowSchema(line=20, value=-500),
+            ComplianceReportSummaryRowSchema(
+                line=21,
+                value=300000,
+                description="Non-compliance penalty payable (500 units * $600 CAD per unit)",
+            ),
+            ComplianceReportSummaryRowSchema(line=22, value=-200),
+        ],
+        non_compliance_penalty_summary=[
+            ComplianceReportSummaryRowSchema(line=11, total_value=800),
+            ComplianceReportSummaryRowSchema(line=21, total_value=300000),
+            ComplianceReportSummaryRowSchema(line=None, total_value=300800),
+        ],
+    )
+
+
+def test_apply_exemption_overrides_zeros_renewable_penalty(
+    compliance_report_summary_service,
+):
+    summary = _make_summary_schema_with_penalties()
+    report = SimpleNamespace(
+        is_renewable_fuel_exempted=True, is_low_carbon_fuel_exempted=False
+    )
+
+    compliance_report_summary_service._apply_exemption_overrides(summary, report)
+
+    line_11_renewable = next(
+        r for r in summary.renewable_fuel_target_summary if r.line == 11
+    )
+    assert line_11_renewable.gasoline == 0
+    assert line_11_renewable.diesel == 0
+    assert line_11_renewable.jet_fuel == 0
+    assert line_11_renewable.total_value == 0
+
+    line_4_renewable = next(
+        r for r in summary.renewable_fuel_target_summary if r.line == 4
+    )
+    assert line_4_renewable.gasoline == 0
+
+    line_11_penalty = next(
+        r for r in summary.non_compliance_penalty_summary if r.line == 11
+    )
+    assert line_11_penalty.total_value == 0
+
+    total_row = next(
+        r for r in summary.non_compliance_penalty_summary if r.line is None
+    )
+    assert total_row.total_value == 300000
+
+    # Low-carbon rows should be untouched
+    line_21_low = next(
+        r for r in summary.low_carbon_fuel_target_summary if r.line == 21
+    )
+    assert line_21_low.value == 300000
+    assert "units" in line_21_low.description
+
+
+def test_apply_exemption_overrides_zeros_low_carbon_penalty_and_strips_description(
+    compliance_report_summary_service,
+):
+    summary = _make_summary_schema_with_penalties()
+    report = SimpleNamespace(
+        is_renewable_fuel_exempted=False, is_low_carbon_fuel_exempted=True
+    )
+
+    compliance_report_summary_service._apply_exemption_overrides(summary, report)
+
+    line_18 = next(r for r in summary.low_carbon_fuel_target_summary if r.line == 18)
+    line_20 = next(r for r in summary.low_carbon_fuel_target_summary if r.line == 20)
+    line_21 = next(r for r in summary.low_carbon_fuel_target_summary if r.line == 21)
+    line_22 = next(r for r in summary.low_carbon_fuel_target_summary if r.line == 22)
+
+    assert line_18.value == 0
+    assert line_20.value == 0
+    assert line_21.value == 0
+    assert line_22.value == 250  # max(line_17, 0)
+    assert "units" not in line_21.description
+    assert "CAD" not in line_21.description
+    assert line_21.description == "Non-compliance penalty payable"
+
+    line_21_penalty = next(
+        r for r in summary.non_compliance_penalty_summary if r.line == 21
+    )
+    assert line_21_penalty.total_value == 0
+
+    total_row = next(
+        r for r in summary.non_compliance_penalty_summary if r.line is None
+    )
+    assert total_row.total_value == 800  # only line 11 remains
+
+    # Renewable rows should be untouched
+    line_11_renewable = next(
+        r for r in summary.renewable_fuel_target_summary if r.line == 11
+    )
+    assert line_11_renewable.gasoline == 300
+
+
+def test_apply_exemption_overrides_zeros_total_when_both_exempted(
+    compliance_report_summary_service,
+):
+    summary = _make_summary_schema_with_penalties()
+    report = SimpleNamespace(
+        is_renewable_fuel_exempted=True, is_low_carbon_fuel_exempted=True
+    )
+
+    compliance_report_summary_service._apply_exemption_overrides(summary, report)
+
+    total_row = next(
+        r for r in summary.non_compliance_penalty_summary if r.line is None
+    )
+    assert total_row.total_value == 0
+
+
+def test_apply_exemption_overrides_no_op_without_flags(
+    compliance_report_summary_service,
+):
+    summary = _make_summary_schema_with_penalties()
+    report = SimpleNamespace(
+        is_renewable_fuel_exempted=False, is_low_carbon_fuel_exempted=False
+    )
+
+    compliance_report_summary_service._apply_exemption_overrides(summary, report)
+
+    total_row = next(
+        r for r in summary.non_compliance_penalty_summary if r.line is None
+    )
+    assert total_row.total_value == 300800
+
+
+def test_apply_exemption_overrides_handles_missing_report(
+    compliance_report_summary_service,
+):
+    summary = _make_summary_schema_with_penalties()
+
+    # Should not raise and should not mutate when no report is provided
+    compliance_report_summary_service._apply_exemption_overrides(summary, None)
+
+    total_row = next(
+        r for r in summary.non_compliance_penalty_summary if r.line is None
+    )
+    assert total_row.total_value == 300800

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -227,6 +227,8 @@ class ComplianceReportSummaryService:
         # DB Columns are not in the same order as display, so sort them
         summary.low_carbon_fuel_target_summary.sort(key=lambda row: row.line)
 
+        self._apply_exemption_overrides(summary, compliance_report)
+
         return summary
 
     def _extract_line_number(self, column_key: str) -> Optional[int]:
@@ -458,6 +460,81 @@ class ComplianceReportSummaryService:
             units="{:,}".format(int(penalty_value / penalty_rate)),
             rate=penalty_rate,
         )
+
+    def _apply_exemption_overrides(
+        self,
+        summary: ComplianceReportSummarySchema,
+        compliance_report: Optional[ComplianceReport],
+    ) -> None:
+        """
+        Zero out penalty-related summary rows when exemption flags are set on the
+        compliance report. This mirrors the zeroing performed by
+        `handle_exempted_status` but also applies when the report is in
+        "Recommended by analyst/manager" with exemption flags selected, so
+        penalties do not leak into the summary tables, descriptions, or exports
+        before the report reaches the Exempted status.
+        """
+        if not compliance_report:
+            return
+
+        # Compare against True explicitly — MagicMock-backed tests can make the
+        # attribute present but return a Mock object that is truthy by default.
+        is_renewable_exempted = (
+            getattr(compliance_report, "is_renewable_fuel_exempted", False) is True
+        )
+        is_low_carbon_exempted = (
+            getattr(compliance_report, "is_low_carbon_fuel_exempted", False) is True
+        )
+        if not (is_renewable_exempted or is_low_carbon_exempted):
+            return
+
+        def _line_num(row) -> Optional[int]:
+            try:
+                return int(row.line) if row.line is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        if is_renewable_exempted:
+            for row in summary.renewable_fuel_target_summary or []:
+                if _line_num(row) in (4, 11):
+                    row.gasoline = 0
+                    row.diesel = 0
+                    row.jet_fuel = 0
+                    row.total_value = 0
+
+        if is_low_carbon_exempted:
+            low_carbon_rows = summary.low_carbon_fuel_target_summary or []
+            line_17_value = 0
+            for row in low_carbon_rows:
+                if _line_num(row) == 17:
+                    line_17_value = row.value or 0
+                    break
+            for row in low_carbon_rows:
+                line_num = _line_num(row)
+                if line_num in (18, 20, 21):
+                    row.value = 0
+                if line_num == 21:
+                    row.description = LOW_CARBON_FUEL_TARGET_DESCRIPTIONS[21][
+                        "description"
+                    ].split(" (")[0]
+                if line_num == 22:
+                    row.value = max(line_17_value, 0)
+
+        line_11_total = 0.0
+        line_21_total = 0.0
+        for row in summary.non_compliance_penalty_summary or []:
+            line_num = _line_num(row)
+            if line_num == 11:
+                if is_renewable_exempted:
+                    row.total_value = 0
+                line_11_total = row.total_value or 0
+            elif line_num == 21:
+                if is_low_carbon_exempted:
+                    row.total_value = 0
+                line_21_total = row.total_value or 0
+        for row in summary.non_compliance_penalty_summary or []:
+            if row.line is None:
+                row.total_value = float(line_11_total) + float(line_21_total)
 
     @service_handler
     async def update_compliance_report_summary(
@@ -907,6 +984,8 @@ class ComplianceReportSummaryService:
             can_sign,
             early_issuance_summary,
         )
+
+        self._apply_exemption_overrides(summary, compliance_report)
 
         # Check if Lines 7 and 9 should be locked (for draft/editable reports)
         lines_7_and_9_locked = await self._should_lock_lines_7_and_9(compliance_report)


### PR DESCRIPTION
## Summary
- When an analyst recommends a report for exemption, exemption flags are set on the report but `calculate_compliance_report_summary` / `convert_summary_to_dict` never consulted them — so the non-compliance penalty total, the line 21 "(X units * \$Y CAD per unit)" description, and Excel exports kept surfacing the penalty throughout the Recommended by analyst/manager workflow (fixing [#4269](https://github.com/bcgov/lcfs/issues/4269)).
- Added `_apply_exemption_overrides` helper that zeros lines 4/11 (renewable), 18/20/21 (low carbon), recomputes line 22 from line 17, and rebuilds the non-compliance penalty total + line 11/21 rows based on exemption flags. It also strips the unit/rate breakdown from line 21's description when low-carbon-exempted.
- Helper is invoked at the end of both summary paths, so summary tables, descriptive text, and `/export` Excel output stay consistent from the moment exemption is selected — not just once the report hits Exempted.

## Test plan
- [x] New unit tests in `test_summary_service.py` cover renewable-only, low-carbon-only (description stripped + line 22 recalc), both exemptions, no-op without flags, and defensive null-report handling.
- [x] Full `backend/lcfs/tests/compliance_report/` unit suite passes (382 tests).
- [ ] Verify in a running env: on report 3472 (Recommended for Exemption), "Total non-compliance penalty payable" shows \$0, line 21 description has no debit-in-brackets, and the Excel export reflects the zeros.