### PR TITLE
fix: LCFS - gate FSE and charging-sites tabs on compliance_reporting role (#4292)

### DIFF
--- a/frontend/src/views/ComplianceReports/ReportsMenu.jsx
+++ b/frontend/src/views/ComplianceReports/ReportsMenu.jsx
@@ -27,9 +27,14 @@ export function ReportsMenu() {
   const location = useLocation()
   const { hasAnyRole, hasRoles } = useCurrentUser()
   const isIDIR = hasAnyRole(...govRoles)
+  const hasComplianceReporting = hasRoles(roles.compliance_reporting)
   const canAccessChargingSitesTab =
-    isIDIR || isFeatureEnabled(FEATURE_FLAGS.MANAGE_CHARGING_SITES)
-  const canAccessFseTab = isIDIR || isFeatureEnabled(FEATURE_FLAGS.MANAGE_FSE)
+    isIDIR ||
+    (hasComplianceReporting &&
+      isFeatureEnabled(FEATURE_FLAGS.MANAGE_CHARGING_SITES))
+  const canAccessFseTab =
+    isIDIR ||
+    (hasComplianceReporting && isFeatureEnabled(FEATURE_FLAGS.MANAGE_FSE))
   const isSystemAdmin = hasRoles(roles.system_admin)
 
   const tabs = useMemo(() => {
@@ -107,7 +112,7 @@ export function ReportsMenu() {
   const renderContent = () => {
     if (location.pathname.includes('/charging-sites')) {
       return (
-        <Role roles={[...govRoles, roles.supplier]}>
+        <Role roles={[...govRoles, roles.compliance_reporting]}>
           <Outlet context={{ alertRef }} />
         </Role>
       )
@@ -115,7 +120,7 @@ export function ReportsMenu() {
 
     if (location.pathname.includes('/fse')) {
       return (
-        <Role roles={[...govRoles, roles.supplier]}>
+        <Role roles={[...govRoles, roles.compliance_reporting]}>
           <Outlet context={{ alertRef }} />
         </Role>
       )

--- a/frontend/src/views/ComplianceReports/__tests__/ReportsMenu.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/ReportsMenu.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReportsMenu } from '../ReportsMenu'
+import { wrapper } from '@/tests/utils/wrapper.jsx'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+const mockLocation = { pathname: '/compliance-reporting' }
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useLocation: () => mockLocation,
+    useNavigate: () => vi.fn(),
+    Outlet: () => <div data-test="outlet" />
+  }
+})
+
+let mockUserRoles = []
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    data: { roles: mockUserRoles.map((name) => ({ name })) },
+    hasRoles: (...needed) => needed.every((r) => mockUserRoles.includes(r)),
+    hasAnyRole: (...needed) => needed.some((r) => mockUserRoles.includes(r))
+  })
+}))
+
+let mockFeatureFlags = {}
+vi.mock('@/constants/config', async () => {
+  const actual = await vi.importActual('@/constants/config')
+  return {
+    ...actual,
+    isFeatureEnabled: (flag) => !!mockFeatureFlags[flag]
+  }
+})
+
+vi.mock('../ComplianceReports', () => ({
+  ComplianceReports: () => <div data-test="compliance-reports" />
+}))
+
+describe('ReportsMenu - FSE / charging-sites tab visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLocation.pathname = '/compliance-reporting'
+    mockUserRoles = []
+    mockFeatureFlags = {
+      manageFse: true,
+      manageChargingSites: true
+    }
+  })
+
+  it('hides FSE and charging-sites tabs for BCeID signing-authority-only user', () => {
+    mockUserRoles = ['Signing Authority']
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.queryByText('tabs.manageFSE')).not.toBeInTheDocument()
+    expect(screen.queryByText('tabs.fseMap')).not.toBeInTheDocument()
+    expect(screen.queryByText('tabs.manageChargingSites')).not.toBeInTheDocument()
+  })
+
+  it('shows FSE and charging-sites tabs for BCeID compliance-reporting user when feature flags enabled', () => {
+    mockUserRoles = ['Compliance Reporting']
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.getByText('tabs.manageFSE')).toBeInTheDocument()
+    expect(screen.getByText('tabs.fseMap')).toBeInTheDocument()
+    expect(screen.getByText('tabs.manageChargingSites')).toBeInTheDocument()
+  })
+
+  it('hides FSE tabs for compliance-reporting user when feature flag is disabled', () => {
+    mockUserRoles = ['Compliance Reporting']
+    mockFeatureFlags = { manageFse: false, manageChargingSites: false }
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.queryByText('tabs.manageFSE')).not.toBeInTheDocument()
+    expect(screen.queryByText('tabs.fseMap')).not.toBeInTheDocument()
+    expect(screen.queryByText('tabs.manageChargingSites')).not.toBeInTheDocument()
+  })
+
+  it('shows FSE tabs for IDIR user regardless of feature flag', () => {
+    mockUserRoles = ['Government', 'Analyst']
+    mockFeatureFlags = { manageFse: false, manageChargingSites: false }
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.getByText('tabs.fseIndex')).toBeInTheDocument()
+    expect(screen.getByText('tabs.fseMap')).toBeInTheDocument()
+    expect(screen.getByText('tabs.chargingSites')).toBeInTheDocument()
+  })
+
+  it('blocks direct navigation to FSE content for signing-authority-only user', () => {
+    mockUserRoles = ['Signing Authority']
+    mockLocation.pathname = '/compliance-reporting/fse'
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument()
+  })
+
+  it('blocks direct navigation to charging-sites for signing-authority-only user', () => {
+    mockUserRoles = ['Signing Authority']
+    mockLocation.pathname = '/compliance-reporting/charging-sites'
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.queryByTestId('outlet')).not.toBeInTheDocument()
+  })
+
+  it('allows direct navigation to FSE content for compliance-reporting user', () => {
+    mockUserRoles = ['Compliance Reporting']
+    mockLocation.pathname = '/compliance-reporting/fse'
+    render(<ReportsMenu />, { wrapper })
+
+    expect(screen.getByTestId('outlet')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- In Test, BCeID users with only the Signing Authority role could see the three FSE-related tabs (Manage FSE, FSE map, Manage charging sites) in the compliance reporting menu — the gate in [ReportsMenu.jsx](frontend/src/views/ComplianceReports/ReportsMenu.jsx) only checked the feature flag, not the user's role (fixing [#4292](https://github.com/bcgov/lcfs/issues/4292)).
- Added a `hasRoles(roles.compliance_reporting)` check to the non-IDIR path of both `canAccessChargingSitesTab` and `canAccessFseTab` so signing-authority-only users no longer see the tabs even when the flags are on.
- Tightened the route-level `<Role>` wrapper around the FSE / charging-sites outlets from `roles.supplier` to `roles.compliance_reporting` so direct URL access is also blocked.

## Test plan
- [x] New vitest suite in `ReportsMenu.test.jsx` covers: tabs hidden for signing-authority-only; visible for compliance-reporting + flag on; hidden for compliance-reporting + flag off; visible for IDIR regardless of flag; direct URL to `/fse` and `/charging-sites` blocked for signing-authority-only and allowed for compliance-reporting.
- [x] Broader `ComplianceReports` frontend test suite passes (705 tests).
- [ ] Verify in Test env: log in as BCeID user with only Signing Authority — no FSE / charging-sites tabs visible, direct URLs redirect/null render.