### PR TITLE
Fix: Validate transfer permissions - 4080

### DIFF
--- a/backend/lcfs/tests/transfer/test_transfer_validation.py
+++ b/backend/lcfs/tests/transfer/test_transfer_validation.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from fastapi import HTTPException, status
+
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.db.models.transfer.TransferStatus import TransferStatusEnum
+from lcfs.web.api.transfer.schema import TransferCreateSchema
+from lcfs.web.api.transfer.validation import TransferValidation
+
+
+def _make_request(role_names):
+    request = MagicMock()
+    request.user = MagicMock()
+    request.user.role_names = role_names
+    return request
+
+
+def _make_validation():
+    org_repo = MagicMock()
+    org_repo.is_registered_for_transfer = AsyncMock(return_value=True)
+    return TransferValidation(request=None, org_repo=org_repo)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "roles",
+    [
+        pytest.param([RoleEnum.SUPPLIER], id="supplier"),
+        pytest.param([RoleEnum.ANALYST], id="analyst"),
+        pytest.param([], id="no-roles"),
+    ],
+)
+async def test_government_update_transfer_rejects_non_government(roles):
+    validation = _make_validation()
+    request = _make_request(roles)
+    transfer = TransferCreateSchema(
+        from_organization_id=1,
+        to_organization_id=2,
+        current_status=TransferStatusEnum.Recommended,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await validation.government_update_transfer(request, transfer)
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_government_update_transfer_allows_government_role():
+    validation = _make_validation()
+    request = _make_request([RoleEnum.GOVERNMENT])
+    transfer = TransferCreateSchema(
+        from_organization_id=1,
+        to_organization_id=2,
+        current_status=TransferStatusEnum.Recommended,
+    )
+
+    await validation.government_update_transfer(request, transfer)

--- a/backend/lcfs/web/api/transfer/validation.py
+++ b/backend/lcfs/web/api/transfer/validation.py
@@ -23,6 +23,12 @@ class TransferValidation:
     async def government_update_transfer(
         self, request: Request, transfer_create: TransferCreateSchema
     ):
+        # Double-check government role in validation.
+        if not user_has_roles(request.user, [RoleEnum.GOVERNMENT]):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Validation for authorization failed.",
+            )
         # Ensure only the valid statuses are passed.
         if transfer_create.current_status not in LCFS_Constants.GOV_TRANSFER_STATUSES:
             raise HTTPException(
@@ -42,7 +48,6 @@ class TransferValidation:
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Validation for authorization failed.",
                 )
-            # TODO: Ensure the logged in user has the necessary permissions and roles.
 
     async def get_transfer(self, transfer: TransferSchema):
         if not transfer:


### PR DESCRIPTION
This PR enforces permissions in transfer validation.

- Enforce supplier role in validation
- Return 403 for unauthorized users
- Add unauthorized test coverage

Closes #4080