### PR TITLE
Fix: Resolve FSE kWh save server error - 4319

### DIFF
--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -972,3 +972,43 @@ async def test_bulk_update_deactivate_takes_precedence_over_activate(repo, fake_
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "is_active" in compiled
     assert "false" in compiled.lower()
+
+
+@pytest.mark.anyio
+async def test_get_latest_equipment_status_returns_status(repo, fake_db):
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = "Submitted"
+    fake_db.execute.return_value = result_mock
+
+    status_value = await repo.get_latest_equipment_status(charging_equipment_id=42)
+
+    assert status_value == "Submitted"
+    fake_db.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_get_latest_equipment_status_returns_none_when_not_found(repo, fake_db):
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    fake_db.execute.return_value = result_mock
+
+    status_value = await repo.get_latest_equipment_status(charging_equipment_id=999)
+
+    assert status_value is None
+
+
+@pytest.mark.anyio
+async def test_get_latest_equipment_status_query_compiles(repo, fake_db):
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    fake_db.execute.return_value = result_mock
+
+    await repo.get_latest_equipment_status(charging_equipment_id=1)
+
+    stmt = fake_db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "charging_equipment" in compiled
+    assert "charging_equipment_status" in compiled
+    assert "FROM charging_equipment JOIN charging_equipment_status" in compiled
+    assert "ORDER BY charging_equipment.version DESC" in compiled

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -1073,6 +1073,7 @@ class FinalSupplyEquipmentRepository:
 
         stmt = (
             select(ChargingEquipmentStatus.status)
+            .select_from(ChargingEquipment)
             .join(
                 ChargingEquipmentStatus,
                 ChargingEquipment.status_id


### PR DESCRIPTION
This PR fixes FSE save failure when entering kWh.

- Fix SQL join ambiguity in save endpoint
- Allow kWh values to persist correctly

Closes #4319