### PR TITLE
chore: LCFS - remove TFRS-only compliance-report write paths (#4299)

### DIFF
--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -850,17 +850,6 @@ class ComplianceReportRepository:
         )
         return result.scalars().first()
 
-    async def get_compliance_report_by_legacy_id(self, legacy_id):
-        """
-        Retrieve a compliance report from the database by ID
-        """
-        result = await self.db.execute(
-            select(ComplianceReport)
-            .options(*self._get_base_report_options())
-            .where(ComplianceReport.legacy_id == legacy_id)
-        )
-        return result.scalars().unique().first()
-
     @repo_handler
     async def delete_compliance_report(self, compliance_report_id: int) -> bool:
         """

--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -292,7 +292,6 @@ class ComplianceReportCreateSchema(BaseSchema):
     compliance_period: str
     organization_id: int
     status: str
-    legacy_id: Optional[int] = None
     nickname: Optional[str] = None
 
 

--- a/backend/lcfs/web/api/compliance_report/services.py
+++ b/backend/lcfs/web/api/compliance_report/services.py
@@ -203,7 +203,6 @@ class ComplianceReportServices:
                 else "Early Issuance Report"
             ),
             summary=ComplianceReportSummary(),  # Create an empty summary object
-            legacy_id=report_data.legacy_id,
             create_user=user.keycloak_username,
         )
 
@@ -315,7 +314,7 @@ class ComplianceReportServices:
 
     @service_handler
     async def create_supplemental_report(
-        self, original_report_id: int, user: UserProfile = None, legacy_id: int = None
+        self, original_report_id: int, user: UserProfile = None
     ) -> ComplianceReportBaseSchema:
         """
         Creates a new supplemental compliance report.
@@ -344,15 +343,6 @@ class ComplianceReportServices:
             raise ServiceException(
                 "You do not have permission to create a supplemental report for this organization."
             )
-
-        # TODO this logic to be re-instated once TFRS is shutdown
-        # TFRS allows supplementals on previously un-accepted reports
-        # so we have to support this until LCFS and TFRS are no longer synced
-        # Validate that the status of the current report is 'Assessed'
-        # if current_report.current_status.status != ComplianceReportStatusEnum.Assessed:
-        #     raise ServiceException(
-        #         "A supplemental report can only be created if the current report's status is 'Assessed'."
-        #     )
 
         new_version = latest_report.version + 1
 
@@ -394,7 +384,6 @@ class ComplianceReportServices:
         # Create the new supplemental compliance report
         new_report = ComplianceReport(
             compliance_period_id=current_report.compliance_period_id,
-            legacy_id=legacy_id,
             organization_id=current_report.organization_id,
             current_status_id=draft_status.compliance_report_status_id,
             reporting_frequency=current_report.reporting_frequency,


### PR DESCRIPTION
## Summary
- Closes [#4299](https://github.com/bcgov/lcfs/issues/4299). Stacked on [#4323](https://github.com/bcgov/lcfs/pull/4323) → [#4322](https://github.com/bcgov/lcfs/pull/4322); merge in that order, then this rebases cleanly to `develop`.
- With the TFRS RabbitMQ consumer gone, the `legacy_id`-driven write APIs have zero production callers. This PR removes them.

## Changes
- **`ComplianceReportRepository.get_compliance_report_by_legacy_id`** — deleted; its only callers lived in the (now-removed) `ReportConsumer`.
- **`ComplianceReportServices.create_supplemental_report`** — drop the `legacy_id: int = None` parameter and the `legacy_id=legacy_id` assignment on the new `ComplianceReport`. No caller (backend, frontend, or tests) passes it.
- **`ComplianceReportServices.create_compliance_report`** — drop `legacy_id=report_data.legacy_id,` on the new `ComplianceReport`.
- **`ComplianceReportCreateSchema`** — drop the `legacy_id: Optional[int] = None` field. Confirmed by grep that no request body, test fixture, or frontend submission ever populates it.
- **Stale TODO** in `create_supplemental_report` — the multi-line `# TODO this logic to be re-instated once TFRS is shutdown ...` block that commented out the Assessed-status guard is removed; whether to re-enable that business rule is a separate product decision and out of scope here.

## Kept intentionally
- `ComplianceReport.legacy_id` **column** stays — `backend/lcfs/db/sql/views/metabase.sql` references it in 10+ places.
- `legacy_id` stays on **read-side** `ComplianceReportBaseSchema` (line 176) and `ComplianceReportViewSchema` (line 226) so clients that render historical reports still see the value.

## Test plan
- [x] `lcfs/tests/compliance_report/`, `lcfs/tests/organizations/`, `lcfs/tests/organization/` — 458 tests pass locally; 173 errors are DB-connection issues with no local Postgres, pre-existing.
- [x] `lcfs/tests/organization/test_organization_validation.py` (pure unit, no DB) — 9/9 pass. Confirms `ComplianceReportCreateSchema(...)` construction still works after removing the field.
- [x] Grep confirms no residual production-code references to `legacy_id` on the write side.
- [ ] Smoke test: creating a new compliance report and a supplemental report via the UI still works.

## Net diff
3 files, +1 / −24.