### PR TITLE
Fix: LCFS - Performance issues

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-04-20-09-00_d4f5e6a7b8c9.py
+++ b/backend/lcfs/db/migrations/versions/2026-04-20-09-00_d4f5e6a7b8c9.py
@@ -1,0 +1,84 @@
+"""Add compliance report schedule performance indexes
+
+Revision ID: d4f5e6a7b8c9
+Revises: c1d2e3f4a5b6
+Create Date: 2026-04-20 09:00:00.000000
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d4f5e6a7b8c9"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_compliance_report_group_uuid_version_id
+        ON compliance_report (compliance_report_group_uuid, version, compliance_report_id);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_fuel_supply_report_group_version_action
+        ON fuel_supply (compliance_report_id, group_uuid, version DESC, action_type);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_fuel_export_report_group_version_action
+        ON fuel_export (compliance_report_id, group_uuid, version DESC, action_type);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_allocation_agreement_report_group_version_action
+        ON allocation_agreement (compliance_report_id, group_uuid, version DESC, action_type);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_notional_transfer_report_group_version_action
+        ON notional_transfer (compliance_report_id, group_uuid, version DESC, action_type);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_other_uses_report_group_version_action
+        ON other_uses (compliance_report_id, group_uuid, version DESC, action_type);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_final_supply_equipment_report_create_date
+        ON final_supply_equipment (compliance_report_id, create_date);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS idx_final_supply_equipment_report_create_date;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_other_uses_report_group_version_action;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_notional_transfer_report_group_version_action;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_allocation_agreement_report_group_version_action;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_fuel_export_report_group_version_action;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_fuel_supply_report_group_version_action;"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_compliance_report_group_uuid_version_id;"
+    )

--- a/backend/lcfs/services/jobs/jobs.py
+++ b/backend/lcfs/services/jobs/jobs.py
@@ -38,6 +38,16 @@ from lcfs.web.api.final_supply_equipment.services import FinalSupplyEquipmentSer
 
 logger = logging.getLogger(__name__)
 
+COMPLIANCE_REINDEX_TABLES = (
+    "compliance_report",
+    "fuel_supply",
+    "fuel_export",
+    "allocation_agreement",
+    "notional_transfer",
+    "other_uses",
+    "final_supply_equipment",
+)
+
 
 async def submit_supplemental_report(report_id: int, app: FastAPI):
     """
@@ -192,3 +202,27 @@ async def check_overdue_supplemental_reports(app: FastAPI):
             raise
 
     logger.info("Finished check for overdue supplemental reports.")
+
+
+async def reindex_compliance_report_tables(app: FastAPI):
+    """
+    Rebuild compliance-report related indexes during off-hours.
+
+    Uses PostgreSQL's CONCURRENTLY mode so report traffic can continue while
+    indexes are refreshed.
+    """
+    logger.info("Starting compliance-report table reindex job")
+    conn = await app.state.db_engine.connect()
+
+    try:
+        conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        for table_name in COMPLIANCE_REINDEX_TABLES:
+            logger.info("Reindexing compliance table", table_name=table_name)
+            await conn.execute(text(f"REINDEX TABLE CONCURRENTLY {table_name}"))
+    except Exception:
+        logger.exception("Compliance-report table reindex job failed")
+        raise
+    finally:
+        await conn.close()
+
+    logger.info("Finished compliance-report table reindex job")

--- a/backend/lcfs/services/jobs/jobs.py
+++ b/backend/lcfs/services/jobs/jobs.py
@@ -47,6 +47,7 @@ COMPLIANCE_REINDEX_TABLES = (
     "other_uses",
     "final_supply_equipment",
 )
+COMPLIANCE_REINDEX_LOCK_ID = 60271451
 
 
 async def submit_supplemental_report(report_id: int, app: FastAPI):
@@ -216,13 +217,31 @@ async def reindex_compliance_report_tables(app: FastAPI):
 
     try:
         conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        lock_acquired = await conn.scalar(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": COMPLIANCE_REINDEX_LOCK_ID},
+        )
+
+        if not lock_acquired:
+            logger.info(
+                "Skipping compliance-report reindex job because another instance holds the lock"
+            )
+            return
+
         for table_name in COMPLIANCE_REINDEX_TABLES:
-            logger.info("Reindexing compliance table", table_name=table_name)
+            logger.info("Reindexing compliance table: %s", table_name)
             await conn.execute(text(f"REINDEX TABLE CONCURRENTLY {table_name}"))
     except Exception:
         logger.exception("Compliance-report table reindex job failed")
         raise
     finally:
+        try:
+            await conn.execute(
+                text("SELECT pg_advisory_unlock(:lock_id)"),
+                {"lock_id": COMPLIANCE_REINDEX_LOCK_ID},
+            )
+        except Exception:
+            logger.debug("Compliance-report reindex advisory unlock skipped")
         await conn.close()
 
     logger.info("Finished compliance-report table reindex job")

--- a/backend/lcfs/services/scheduler/scheduler.py
+++ b/backend/lcfs/services/scheduler/scheduler.py
@@ -5,8 +5,13 @@ from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.executors.asyncio import AsyncIOExecutor
 from pytz import utc
 from fastapi import FastAPI
+from zoneinfo import ZoneInfo
 
-from lcfs.services.jobs.jobs import check_overdue_supplemental_reports
+from lcfs.services.jobs.jobs import (
+    check_overdue_supplemental_reports,
+    reindex_compliance_report_tables,
+)
+from lcfs.settings import settings
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -46,6 +51,28 @@ def start_scheduler(app: FastAPI):
         #     args=[app]
         # )
         # logger.info("Added job: 'check_overdue_supplemental_reports' to run daily at midnight.")
+        if settings.compliance_reindex_enabled:
+            scheduler.add_job(
+                reindex_compliance_report_tables,
+                "cron",
+                month=settings.compliance_reindex_months,
+                day=settings.compliance_reindex_day,
+                hour=settings.compliance_reindex_hour,
+                minute=settings.compliance_reindex_minute,
+                timezone=ZoneInfo("America/Vancouver"),
+                id="reindex_compliance_report_tables",
+                replace_existing=True,
+                args=[app],
+            )
+            logger.info(
+                "Added job: 'reindex_compliance_report_tables'",
+                extra={
+                    "months": settings.compliance_reindex_months,
+                    "day": settings.compliance_reindex_day,
+                    "hour": settings.compliance_reindex_hour,
+                    "minute": settings.compliance_reindex_minute,
+                },
+            )
 
 def shutdown_scheduler():
     """

--- a/backend/lcfs/services/scheduler/scheduler.py
+++ b/backend/lcfs/services/scheduler/scheduler.py
@@ -74,6 +74,19 @@ def start_scheduler(app: FastAPI):
                 },
             )
 
+        if settings.compliance_reindex_run_on_startup:
+            scheduler.add_job(
+                reindex_compliance_report_tables,
+                "date",
+                run_date=datetime.now(utc),
+                id="reindex_compliance_report_tables_startup",
+                replace_existing=True,
+                args=[app],
+            )
+            logger.info(
+                "Added one-time startup job: 'reindex_compliance_report_tables_startup'"
+            )
+
 def shutdown_scheduler():
     """
     Shuts down the scheduler.

--- a/backend/lcfs/settings.py
+++ b/backend/lcfs/settings.py
@@ -51,6 +51,12 @@ class Settings(BaseSettings):
     db_base: str = "lcfs"
     db_test: str = "lcfs_test"
     db_echo: bool = False
+    compliance_reindex_enabled: bool = True
+    compliance_reindex_months: str = "1,4,7,10"
+    compliance_reindex_day: int = 1
+    compliance_reindex_hour: int = 3
+    compliance_reindex_minute: int = 15
+    compliance_reindex_run_on_startup: bool = False
 
     # Variables for Redis
     redis_host: str = "localhost"

--- a/backend/lcfs/tests/services/scheduler/test_scheduler.py
+++ b/backend/lcfs/tests/services/scheduler/test_scheduler.py
@@ -46,9 +46,8 @@ async def test_scheduler_lifecycle(mock_app):
         start_scheduler(mock_app)
         assert scheduler.running, "Scheduler should be running after start"
 
-        # Job is disabled per ticket #3752 - auto-submit functionality removed
-        # The scheduler should start but no jobs should be added
-        mock_add_job.assert_not_called()
+        mock_add_job.assert_called_once()
+        assert mock_add_job.call_args.kwargs["id"] == "reindex_compliance_report_tables"
 
         safe_shutdown_scheduler()
 
@@ -151,9 +150,11 @@ async def test_scheduler_adds_startup_job(mock_app):
             # Verify start was called
             mock_start.assert_called_once()
 
-            # DISABLED per ticket #3752 - auto-submit job commented out
-            # Verify no jobs are added when auto-submit is disabled
-            mock_add_job.assert_not_called()
+            mock_add_job.assert_called_once()
+            assert (
+                mock_add_job.call_args.kwargs["id"]
+                == "reindex_compliance_report_tables"
+            )
 
             # # Verify the job was added
             # mock_add_job.assert_called_once()
@@ -218,9 +219,11 @@ async def test_scheduler_startup_job_essentials(mock_app):
         # Verify scheduler.start was called
         mock_scheduler_instance.start.assert_called_once()
 
-        # DISABLED per ticket #3752 - auto-submit job commented out
-        # Verify no jobs are added when auto-submit is disabled
-        mock_scheduler_instance.add_job.assert_not_called()
+        mock_scheduler_instance.add_job.assert_called_once()
+        assert (
+            mock_scheduler_instance.add_job.call_args.kwargs["id"]
+            == "reindex_compliance_report_tables"
+        )
 
         # # Verify add_job was called with correct parameters
         # mock_scheduler_instance.add_job.assert_called_once()

--- a/backend/lcfs/tests/services/scheduler/test_scheduler.py
+++ b/backend/lcfs/tests/services/scheduler/test_scheduler.py
@@ -9,6 +9,7 @@ from lcfs.services.scheduler.scheduler import (
     scheduler,
 )
 from lcfs.services.jobs.jobs import check_overdue_supplemental_reports
+from lcfs.settings import settings
 
 
 @pytest.fixture
@@ -235,6 +236,32 @@ async def test_scheduler_startup_job_essentials(mock_app):
         # kwargs = call_args[1] if len(call_args) > 1 else call_args.kwargs
         # assert kwargs.get("args") == [mock_app]
         # assert "id" in kwargs
+
+
+@pytest.mark.anyio
+async def test_scheduler_adds_one_time_startup_reindex_job_when_enabled(mock_app):
+    safe_shutdown_scheduler()
+
+    original_value = settings.compliance_reindex_run_on_startup
+    settings.compliance_reindex_run_on_startup = True
+
+    with patch.object(scheduler, "add_job") as mock_add_job, patch.object(
+        scheduler, "start"
+    ) as mock_start:
+        mock_start.return_value = None
+        scheduler._state = 1
+
+        try:
+            start_scheduler(mock_app)
+
+            assert mock_add_job.call_count == 2
+            added_job_ids = [call.kwargs["id"] for call in mock_add_job.call_args_list]
+            assert "reindex_compliance_report_tables" in added_job_ids
+            assert "reindex_compliance_report_tables_startup" in added_job_ids
+        finally:
+            settings.compliance_reindex_run_on_startup = original_value
+            scheduler._state = 0
+            safe_shutdown_scheduler()
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, joinedload
 from typing import List, Optional, TypedDict, Type, Sequence
 
+from lcfs.db.base import ActionTypeEnum
 from lcfs.db.dependencies import get_async_db_session
 from lcfs.db.models import CompliancePeriod
 from lcfs.db.models.comment import ComplianceReportInternalComment
@@ -706,6 +707,98 @@ class ComplianceReportRepository:
             .limit(1)
         )
         return result.scalar() is not None
+
+    async def _get_report_chain_anchor(self, compliance_report_id: int):
+        result = await self.db.execute(
+            select(
+                ComplianceReport.compliance_report_group_uuid,
+                ComplianceReport.version,
+                ComplianceReport.organization_id,
+            ).where(ComplianceReport.compliance_report_id == compliance_report_id)
+        )
+        return result.first()
+
+    def _get_chain_report_ids_subquery(
+        self, compliance_report_group_uuid: str, version: int
+    ):
+        return select(ComplianceReport.compliance_report_id).where(
+            and_(
+                ComplianceReport.compliance_report_group_uuid
+                == compliance_report_group_uuid,
+                ComplianceReport.version <= version,
+            )
+        )
+
+    @repo_handler
+    async def get_supporting_document_count(self, compliance_report_id: int) -> int:
+        return (
+            await self.db.scalar(
+                select(func.count())
+                .select_from(compliance_report_document_association)
+                .where(
+                    compliance_report_document_association.c.compliance_report_id
+                    == compliance_report_id
+                )
+            )
+        ) or 0
+
+    @repo_handler
+    async def get_effective_versioned_record_counts(
+        self, compliance_report_id: int, model: Type
+    ) -> dict[str, int]:
+        anchor = await self._get_report_chain_anchor(compliance_report_id)
+        if not anchor or not anchor[0]:
+            return {"active_count": 0, "deleted_count": 0}
+
+        group_uuid, version, _ = anchor
+        chain_report_ids = self._get_chain_report_ids_subquery(group_uuid, version)
+
+        latest_version_per_group = (
+            select(
+                model.group_uuid,
+                func.max(model.version).label("max_version"),
+            )
+            .where(model.compliance_report_id.in_(chain_report_ids))
+            .group_by(model.group_uuid)
+            .subquery()
+        )
+
+        latest_records = (
+            select(model.action_type)
+            .join(
+                latest_version_per_group,
+                and_(
+                    model.group_uuid == latest_version_per_group.c.group_uuid,
+                    model.version == latest_version_per_group.c.max_version,
+                ),
+            )
+            .subquery()
+        )
+
+        counts = await self.db.execute(
+            select(
+                func.count().filter(
+                    latest_records.c.action_type != ActionTypeEnum.DELETE
+                ),
+                func.count().filter(
+                    latest_records.c.action_type == ActionTypeEnum.DELETE
+                ),
+            )
+        )
+        active_count, deleted_count = counts.one()
+        return {
+            "active_count": active_count or 0,
+            "deleted_count": deleted_count or 0,
+        }
+
+    @repo_handler
+    async def get_report_chain_organization_id(
+        self, compliance_report_id: int
+    ) -> Optional[int]:
+        anchor = await self._get_report_chain_anchor(compliance_report_id)
+        if not anchor:
+            return None
+        return anchor[2]
 
     @repo_handler
     async def get_supplemental_report_ids_in_chain(

--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -288,6 +288,24 @@ class ChainedComplianceReportSchema(BaseSchema):
     has_government_reassessment_in_progress: Optional[bool] = False
 
 
+class ComplianceReportScheduleOverviewItemSchema(BaseSchema):
+    count: int = 0
+    active_count: int = 0
+    deleted_count: int = 0
+    was_edited: bool = False
+    has_charging_equipment: bool = False
+
+
+class ComplianceReportScheduleOverviewSchema(BaseSchema):
+    supporting_docs: ComplianceReportScheduleOverviewItemSchema
+    fuel_supplies: ComplianceReportScheduleOverviewItemSchema
+    final_supply_equipments: ComplianceReportScheduleOverviewItemSchema
+    allocation_agreements: ComplianceReportScheduleOverviewItemSchema
+    notional_transfers: ComplianceReportScheduleOverviewItemSchema
+    other_uses: ComplianceReportScheduleOverviewItemSchema
+    fuel_exports: ComplianceReportScheduleOverviewItemSchema
+
+
 class ComplianceReportYearNavigationItemSchema(BaseSchema):
     compliance_report_id: int
     compliance_period: str

--- a/backend/lcfs/web/api/compliance_report/services.py
+++ b/backend/lcfs/web/api/compliance_report/services.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 
 import copy
@@ -37,6 +38,8 @@ from lcfs.web.api.compliance_report.schema import (
     ComplianceReportBaseSchema,
     ComplianceReportCreateSchema,
     ComplianceReportListSchema,
+    ComplianceReportScheduleOverviewItemSchema,
+    ComplianceReportScheduleOverviewSchema,
     ComplianceReportStatusSchema,
     ComplianceReportViewSchema,
     ComplianceReportYearNavigationItemSchema,
@@ -154,6 +157,71 @@ class ComplianceReportServices:
             CompliancePeriodBaseSchema.model_validate(period)
             for period in visible_periods
         ]
+
+    @service_handler
+    async def get_schedule_overview(
+        self, compliance_report_id: int
+    ) -> ComplianceReportScheduleOverviewSchema:
+        async def _build_versioned_item(model):
+            counts = await self.repo.get_effective_versioned_record_counts(
+                compliance_report_id, model
+            )
+            was_edited = await self.repo.has_supplemental_changes(
+                compliance_report_id, model
+            )
+            return ComplianceReportScheduleOverviewItemSchema(
+                count=counts["active_count"] + counts["deleted_count"],
+                active_count=counts["active_count"],
+                deleted_count=counts["deleted_count"],
+                was_edited=was_edited,
+            )
+
+        (
+            supporting_docs_count,
+            organization_id,
+            fuel_supplies,
+            allocation_agreements,
+            notional_transfers,
+            other_uses,
+            fuel_exports,
+        ) = await asyncio.gather(
+            self.repo.get_supporting_document_count(compliance_report_id),
+            self.repo.get_report_chain_organization_id(compliance_report_id),
+            _build_versioned_item(FuelSupply),
+            _build_versioned_item(AllocationAgreement),
+            _build_versioned_item(NotionalTransfer),
+            _build_versioned_item(OtherUses),
+            _build_versioned_item(FuelExport),
+        )
+
+        has_charging_equipment = False
+        fse_count = 0
+        if organization_id is not None:
+            has_charging_equipment, fse_count = await asyncio.gather(
+                self.fse_service.repo.has_charging_equipment_for_organization(
+                    organization_id
+                ),
+                self.fse_service.repo.get_fse_reporting_count(
+                    organization_id, compliance_report_id
+                ),
+            )
+
+        return ComplianceReportScheduleOverviewSchema(
+            supporting_docs=ComplianceReportScheduleOverviewItemSchema(
+                count=supporting_docs_count,
+                active_count=supporting_docs_count,
+            ),
+            fuel_supplies=fuel_supplies,
+            final_supply_equipments=ComplianceReportScheduleOverviewItemSchema(
+                count=fse_count,
+                active_count=fse_count,
+                has_charging_equipment=has_charging_equipment,
+            ),
+            allocation_agreements=allocation_agreements,
+            notional_transfers=notional_transfers,
+            other_uses=other_uses,
+            fuel_exports=fuel_exports,
+        )
 
     @service_handler
     async def create_compliance_report(

--- a/backend/lcfs/web/api/compliance_report/views.py
+++ b/backend/lcfs/web/api/compliance_report/views.py
@@ -11,6 +11,7 @@ from lcfs.web.api.compliance_report.export import ComplianceReportExporter
 from lcfs.web.api.compliance_report.schema import (
     ComplianceReportBaseSchema,
     ComplianceReportListSchema,
+    ComplianceReportScheduleOverviewSchema,
     ComplianceReportStatusSchema,
     ComplianceReportSummarySchema,
     ComplianceReportYearNavigationSchema,
@@ -117,6 +118,24 @@ async def get_compliance_report_by_id(
     await validate.validate_compliance_report_access(compliance_report)
 
     return await service.get_compliance_report_chain(report_id, request.user)
+
+
+@router.get(
+    "/{report_id}/schedule-overview",
+    response_model=ComplianceReportScheduleOverviewSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(
+    [RoleEnum.COMPLIANCE_REPORTING, RoleEnum.SIGNING_AUTHORITY, RoleEnum.GOVERNMENT]
+)
+async def get_compliance_report_schedule_overview(
+    request: Request,
+    report_id: int,
+    service: ComplianceReportServices = Depends(),
+    validate: ComplianceReportValidation = Depends(),
+) -> ComplianceReportScheduleOverviewSchema:
+    await validate.validate_organization_access(report_id)
+    return await service.get_schedule_overview(report_id)
 
 
 @router.get(

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -497,6 +497,16 @@ class FinalSupplyEquipmentRepository:
         return result.unique().scalars().all()
 
     @repo_handler
+    async def get_fse_count(self, report_id: int) -> int:
+        return (
+            await self.db.scalar(
+                select(func.count())
+                .select_from(FinalSupplyEquipment)
+                .where(FinalSupplyEquipment.compliance_report_id == report_id)
+            )
+        ) or 0
+
+    @repo_handler
     async def get_fse_paginated(
         self, pagination: PaginationRequestSchema, compliance_report_id: int
     ) -> tuple[Sequence[FinalSupplyEquipment], Any]:
@@ -1262,6 +1272,36 @@ class FinalSupplyEquipmentRepository:
         data = result.fetchall()
 
         return data, total or 0
+
+    @repo_handler
+    async def get_fse_reporting_count(
+        self,
+        organization_id: int,
+        compliance_report_id: int,
+        mode: str = "all",
+    ) -> int:
+        """
+        Return the count of reporting rows using the same source and filters as
+        the FSE reporting list shown in compliance report details.
+        """
+        vt = FSEReportingBasePrefView.__table__
+
+        conditions = [
+            vt.c.organization_id == organization_id,
+            vt.c.compliance_report_id == compliance_report_id,
+            sa.or_(
+                vt.c.charging_equipment_status != "Decommissioned",
+                vt.c.charging_equipment_compliance_id.is_not(None),
+            ),
+        ]
+
+        if mode == "summary":
+            conditions.append(vt.c.is_active.is_(True))
+
+        total = await self.db.scalar(
+            select(func.count()).select_from(vt).where(*conditions)
+        )
+        return total or 0
 
     @repo_handler
     async def get_effective_fse_reporting_rows_for_export(

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -81,6 +81,7 @@ export const apiRoutes = {
   getComplianceReports: '/reports/list',
   getComplianceReportStatuses: '/reports/statuses',
   getComplianceReport: '/reports/:reportID',
+  getComplianceReportScheduleOverview: '/reports/:reportID/schedule-overview',
   updateComplianceReport: '/reports/:reportID',
   deleteComplianceReport: '/reports/:reportID',
   getComplianceReportNavigation: '/reports/:reportID/navigation',

--- a/frontend/src/hooks/useComplianceReports.js
+++ b/frontend/src/hooks/useComplianceReports.js
@@ -200,6 +200,39 @@ export const useGetComplianceReportSummary = (reportID, options = {}) => {
   })
 }
 
+export const useComplianceReportScheduleOverview = (reportID, options = {}) => {
+  const client = useApiService()
+
+  const {
+    staleTime = DEFAULT_STALE_TIME,
+    cacheTime = DEFAULT_CACHE_TIME,
+    enabled = true,
+    ...restOptions
+  } = options
+
+  return useQuery({
+    queryKey: ['compliance-report-schedule-overview', reportID],
+    queryFn: async () => {
+      if (!reportID) {
+        throw new Error('Report ID is required')
+      }
+
+      const path = apiRoutes.getComplianceReportScheduleOverview.replace(
+        ':reportID',
+        reportID
+      )
+      const response = await client.get(path)
+      return response.data
+    },
+    enabled: enabled && !!reportID,
+    staleTime,
+    cacheTime,
+    retry: 3,
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+    ...restOptions
+  })
+}
+
 export const useUpdateComplianceReportSummary = (reportID, options = {}) => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
+++ b/frontend/src/views/ComplianceReports/components/ReportDetails.jsx
@@ -22,6 +22,7 @@ import { COMPLIANCE_REPORT_STATUSES } from '@/constants/statuses'
 import { useGetAllAllocationAgreements } from '@/hooks/useAllocationAgreement'
 import {
   useComplianceReportDocuments,
+  useComplianceReportScheduleOverview,
   useComplianceReportWithCache
 } from '@/hooks/useComplianceReports'
 import { useGetFSEReportingList } from '@/hooks/useFinalSupplyEquipment'
@@ -89,6 +90,11 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
   const { compliancePeriod, complianceReportId } = useParams()
   const { data: complianceReportData, isLoading: currentReportLoading } =
     useComplianceReportWithCache(complianceReportId)
+  const {
+    data: scheduleOverview,
+    isLoading: scheduleOverviewLoading,
+    error: scheduleOverviewError
+  } = useComplianceReportScheduleOverview(complianceReportId)
   const [isFileDialogOpen, setFileDialogOpen] = useState(false)
   const [expanded, setExpanded] = useState([])
   const [hasAutoExpanded, setHasAutoExpanded] = useState(false)
@@ -209,7 +215,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
             <SupportingDocumentSummary
               parentType="compliance_report"
               parentID={complianceReportId}
-              data={data}
+              data={data || []}
             />
             <DocumentUploadDialog
               parentID={complianceReportId}
@@ -227,7 +233,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.fuelSupplies,
         useFetch: useGetFuelSupplies,
         component: (data) =>
-          data.fuelSupplies.length > 0 && (
+          data?.fuelSupplies?.length > 0 && (
             <TogglePanel
               label="Change log"
               disabled={
@@ -256,13 +262,13 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.finalSupplyEquipments,
         useFetch: useGetFSEReportingList,
         component: (data) =>
-          data.finalSupplyEquipments.length > 0 ? (
+          data?.finalSupplyEquipments?.length > 0 ? (
             <FinalSupplyEquipmentSummary
               status={currentStatus}
               data={data}
               organizationId={complianceReportData?.report?.organizationId}
             />
-          ) : data.hasChargingEquipment ? (
+          ) : data?.hasChargingEquipment ? (
             <BCTypography variant="body4" color="text">
               {t('finalSupplyEquipment:noFseLinkedToReport')}
             </BCTypography>
@@ -274,7 +280,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.allocationAgreements,
         useFetch: useGetAllAllocationAgreements,
         component: (data) =>
-          data?.allocationAgreements.length > 0 && (
+          data?.allocationAgreements?.length > 0 && (
             <TogglePanel
               label="Change log"
               disabled={
@@ -303,7 +309,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.notionalTransfers,
         useFetch: useGetAllNotionalTransfers,
         component: (data) =>
-          data.notionalTransfers.length > 0 && (
+          data?.notionalTransfers?.length > 0 && (
             <TogglePanel
               label="Change log"
               disabled={
@@ -323,7 +329,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         action: navigationHandlers.otherUses,
         useFetch: useGetAllOtherUses,
         component: (data) =>
-          data.otherUses.length > 0 && (
+          data?.otherUses?.length > 0 && (
             <TogglePanel
               label="Change log"
               disabled={
@@ -372,6 +378,55 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
     ]
   )
 
+  const getOverviewForActivity = useCallback(
+    (activityKey) => {
+      if (!scheduleOverview) return null
+
+      const overviewKeyMap = {
+        supportingDocs: 'supportingDocs',
+        fuelSupplies: 'fuelSupplies',
+        finalSupplyEquipments: 'finalSupplyEquipments',
+        allocationAgreements: 'allocationAgreements',
+        notionalTransfers: 'notionalTransfers',
+        otherUses: 'otherUses',
+        fuelExports: 'fuelExports'
+      }
+
+      return scheduleOverview[overviewKeyMap[activityKey]] ?? null
+    },
+    [scheduleOverview]
+  )
+
+  const shouldFetchActivityData = useCallback(
+    (activity, index) => {
+      const panelId = `panel${index}`
+      const overview = getOverviewForActivity(activity.key)
+      const expandedSchedule = location.state?.expandedSchedule
+      const hasKnownData = (overview?.count ?? 0) > 0
+      const hasFSECapability =
+        activity.key === 'finalSupplyEquipments' &&
+        overview?.hasChargingEquipment === true &&
+        currentStatus !== COMPLIANCE_REPORT_STATUSES.ASSESSED
+
+      if (activity.key === 'supportingDocs') {
+        return expanded.includes(panelId) || hasKnownData
+      }
+
+      return (
+        expanded.includes(panelId) ||
+        expandedSchedule === activity.key ||
+        hasKnownData ||
+        hasFSECapability
+      )
+    },
+    [
+      expanded,
+      currentStatus,
+      getOverviewForActivity,
+      location.state?.expandedSchedule
+    ]
+  )
+
   const onExpand = useCallback(
     (panel) => (event, isExpanded) => {
       setExpanded((prev) =>
@@ -382,15 +437,22 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
   )
 
   // Get data for all activities to determine visibility
-  const activityDataResults = activityList.map((activity) => {
-    const result = activity.useFetch(
-      complianceReportId,
-      {
-        changelog: reportInfo.isSupplemental
-      },
-      {},
-      complianceReportData?.report?.organizationId
-    )
+  const activityDataResults = activityList.map((activity, index) => {
+    const result =
+      activity.key === 'supportingDocs'
+        ? activity.useFetch(complianceReportId, {
+            enabled: shouldFetchActivityData(activity, index)
+          })
+        : activity.useFetch(
+            complianceReportId,
+            {
+              changelog: reportInfo.isSupplemental
+            },
+            {
+              enabled: shouldFetchActivityData(activity, index)
+            },
+            complianceReportData?.report?.organizationId
+          )
     return {
       activity,
       ...result
@@ -405,14 +467,14 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
     activityList.forEach((activity, index) => {
       const panelId = `panel${index}`
       const dataResult = activityDataResults[index]
+      const overview = getOverviewForActivity(activity.key)
 
-      // check if they have actual data
       const scheduleData =
         activity.key === 'supportingDocs'
           ? dataResult?.data || []
           : dataResult?.data?.[activity.key] || []
-
-      const hasRealData = !isArrayEmpty(scheduleData)
+      const visibleCount = overview?.count ?? 0
+      const hasRealData = visibleCount > 0
 
       // FSE is not applicable for compliance periods before 2024
       const isFSEHiddenByYear =
@@ -430,7 +492,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
       // FSE was deleted and recreated after the original report.
       const hasFSECapability =
         activity.key === 'finalSupplyEquipments' &&
-        dataResult?.data?.hasChargingEquipment === true &&
+        overview?.hasChargingEquipment === true &&
         currentStatus !== COMPLIANCE_REPORT_STATUSES.ASSESSED
 
       // Show if has data OR if in editing mode OR if it was recently edited
@@ -448,30 +510,31 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
         hasData: hasRealData || hasFSECapability,
         activity,
         data: dataResult?.data,
-        isLoading: dataResult?.isLoading,
-        error: dataResult?.error,
-        scheduleData
+        isLoading:
+          activity.key === 'supportingDocs'
+            ? scheduleOverviewLoading || dataResult?.isLoading
+            : scheduleOverviewLoading || dataResult?.isLoading,
+        error: scheduleOverviewError || dataResult?.error,
+        scheduleData,
+        overview
       })
     })
     return accordionsData
   }, [
     activityList,
     activityDataResults,
-    t,
+    getOverviewForActivity,
     currentStatus,
     compliancePeriod,
-    location.state?.expandedSchedule
+    location.state?.expandedSchedule,
+    scheduleOverviewError,
+    scheduleOverviewLoading
   ])
 
-  // Auto-expand panels once data is loaded
+  // Auto-expand panels once overview metadata is loaded
   useEffect(() => {
     if (hasAutoExpanded) return
-
-    const allDataLoaded = activityDataResults.every(
-      (result) => !result.isLoading
-    )
-
-    if (allDataLoaded && accordionsWithData.size > 0) {
+    if (!scheduleOverviewLoading && accordionsWithData.size > 0) {
       const accordionsWithActualData = []
       const expandedSchedule = location.state?.expandedSchedule
 
@@ -501,10 +564,10 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
       setHasAutoExpanded(true)
     }
   }, [
-    activityDataResults,
     accordionsWithData,
     hasAutoExpanded,
-    location.state?.expandedSchedule
+    location.state?.expandedSchedule,
+    scheduleOverviewLoading
   ])
 
   // Clear the expandedSchedule state after processing to prevent re-expansion on next visit
@@ -550,35 +613,24 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
     []
   )
 
-  // Auto expand/collapse supporting docs section based on document presence
-  const SUPPORTING_DOCS_KEY = 'supportingDocs'
-
   const supportingDocsPanelId = useMemo(() => {
-    const idx = activityList.findIndex((a) => a.key === SUPPORTING_DOCS_KEY)
+    const idx = activityList.findIndex((a) => a.key === 'supportingDocs')
     return idx >= 0 ? `panel${idx}` : null
   }, [activityList])
-
-  // Derive current supporting-docs array from existing query result
-  const supportingDocsData = useMemo(() => {
-    const result = activityDataResults.find(
-      (r) => r.activity.key === SUPPORTING_DOCS_KEY
-    )
-    return result?.data ?? []
-  }, [activityDataResults])
 
   useEffect(() => {
     if (!supportingDocsPanelId) return
 
-    const hasDocs = !isArrayEmpty(supportingDocsData)
+    const hasDocs = (scheduleOverview?.supportingDocs?.count ?? 0) > 0
 
     setExpanded((prev) => {
       const isExpanded = prev.includes(supportingDocsPanelId)
-      if (hasDocs === isExpanded) return prev // no change
+      if (hasDocs === isExpanded) return prev
       return hasDocs
         ? [...prev, supportingDocsPanelId]
         : prev.filter((p) => p !== supportingDocsPanelId)
     })
-  }, [supportingDocsData, supportingDocsPanelId])
+  }, [scheduleOverview?.supportingDocs?.count, supportingDocsPanelId])
 
   return (
     <>
@@ -611,17 +663,23 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
           return null
         }
 
-        const { data, error, isLoading, scheduleData } = accordionInfo
-        const hasNoData = isArrayEmpty(scheduleData)
+        const { data, error, isLoading, scheduleData, overview } = accordionInfo
+        const hasNoData =
+          overview != null ? overview.count === 0 : isArrayEmpty(scheduleData)
         const isDisabled = !canEdit && hasNoData
+        const isEdited = overview?.wasEdited ?? wasEdited(data)
+        const isExpanded = expanded.includes(panelId)
+        const isDataPending =
+          isExpanded && !error && typeof data === 'undefined' && !hasNoData
 
         // Check if all records are marked as DELETE
         const allRecordsDeleted =
-          Array.isArray(scheduleData) &&
-          scheduleData.length > 0 &&
-          scheduleData.every((item) => item.actionType === 'DELETE')
+          overview != null
+            ? overview.activeCount === 0 && overview.deletedCount > 0
+            : Array.isArray(scheduleData) &&
+              scheduleData.length > 0 &&
+              scheduleData.every((item) => item.actionType === 'DELETE')
 
-        const isExpanded = expanded.includes(panelId)
         const showEditIcon = shouldShowEditIcon(activity.name)
 
         return (
@@ -671,7 +729,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
                     </IconButton>
                   </Role>
                 )}{' '}
-                {wasEdited(data) && !allRecordsDeleted && (
+                {isEdited && !allRecordsDeleted && (
                   <Chip
                     aria-label="changes were made since original report"
                     icon={<NewReleasesOutlined fontSize="small" />}
@@ -711,7 +769,7 @@ const ReportDetails = ({ canEdit, currentStatus = 'Draft', hasRoles }) => {
                   {t('report:allRecordsDeleted')}
                 </BCAlert>
               )}
-              {isLoading ? (
+              {isLoading || isDataPending ? (
                 <CircularProgress />
               ) : error ? (
                 <BCTypography color="error">Error loading data</BCTypography>

--- a/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/ReportDetails.test.jsx
@@ -13,6 +13,7 @@ const mockUseParams = vi.fn(() => ({
 }))
 const mockUseCurrentUser = vi.fn()
 const mockUseComplianceReportWithCache = vi.fn()
+const mockUseComplianceReportScheduleOverview = vi.fn()
 const mockUseComplianceReportDocuments = vi.fn()
 const mockUseGetFuelSupplies = vi.fn()
 const mockUseGetFSEReportingList = vi.fn()
@@ -60,6 +61,8 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/hooks/useComplianceReports', () => ({
   useComplianceReportDocuments: () => mockUseComplianceReportDocuments(),
+  useComplianceReportScheduleOverview: () =>
+    mockUseComplianceReportScheduleOverview(),
   useComplianceReportWithCache: () => mockUseComplianceReportWithCache()
 }))
 
@@ -211,6 +214,35 @@ describe('ReportDetails', () => {
     error: null
   }
 
+  const defaultScheduleOverview = {
+    data: {
+      supportingDocs: { count: 0, activeCount: 0, deletedCount: 0 },
+      fuelSupplies: { count: 0, activeCount: 0, deletedCount: 0, wasEdited: false },
+      finalSupplyEquipments: {
+        count: 0,
+        activeCount: 0,
+        deletedCount: 0,
+        hasChargingEquipment: false
+      },
+      allocationAgreements: {
+        count: 0,
+        activeCount: 0,
+        deletedCount: 0,
+        wasEdited: false
+      },
+      notionalTransfers: {
+        count: 0,
+        activeCount: 0,
+        deletedCount: 0,
+        wasEdited: false
+      },
+      otherUses: { count: 0, activeCount: 0, deletedCount: 0, wasEdited: false },
+      fuelExports: { count: 0, activeCount: 0, deletedCount: 0, wasEdited: false }
+    },
+    isLoading: false,
+    error: null
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
 
@@ -222,6 +254,9 @@ describe('ReportDetails', () => {
     mockUseLocation.mockReturnValue({ state: {} })
     mockUseCurrentUser.mockReturnValue(defaultCurrentUser)
     mockUseComplianceReportWithCache.mockReturnValue(defaultComplianceReport)
+    mockUseComplianceReportScheduleOverview.mockReturnValue(
+      defaultScheduleOverview
+    )
     mockUseComplianceReportDocuments.mockReturnValue(emptyDataResponse)
     mockUseGetFuelSupplies.mockReturnValue({
       data: { fuelSupplies: [] },
@@ -369,6 +404,18 @@ describe('ReportDetails', () => {
       isLoading: false,
       error: null
     })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 1,
+          activeCount: 1,
+          deletedCount: 0,
+          wasEdited: false
+        }
+      }
+    })
 
     render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
       wrapper
@@ -425,6 +472,18 @@ describe('ReportDetails', () => {
       isLoading: false,
       error: null
     })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 1,
+          activeCount: 1,
+          deletedCount: 0,
+          wasEdited: true
+        }
+      }
+    })
 
     render(<ReportDetails currentStatus="Submitted" hasRoles={() => false} />, {
       wrapper
@@ -457,6 +516,18 @@ describe('ReportDetails', () => {
       isLoading: false,
       error: null
     })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 2,
+          activeCount: 0,
+          deletedCount: 2,
+          wasEdited: true
+        }
+      }
+    })
 
     render(<ReportDetails currentStatus="Submitted" hasRoles={() => false} />, {
       wrapper
@@ -472,6 +543,18 @@ describe('ReportDetails', () => {
       data: { fuelSupplies: [{ fuelSupplyId: 24 }] },
       isLoading: false,
       error: new Error('Failed to load data')
+    })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 1,
+          activeCount: 1,
+          deletedCount: 0,
+          wasEdited: false
+        }
+      }
     })
 
     render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
@@ -499,6 +582,18 @@ describe('ReportDetails', () => {
       data: { fuelSupplies: [{ fuelSupplyId: 24 }] },
       isLoading: false,
       error: null
+    })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 1,
+          activeCount: 1,
+          deletedCount: 0,
+          wasEdited: false
+        }
+      }
     })
 
     render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
@@ -529,6 +624,18 @@ describe('ReportDetails', () => {
       data: { fuelSupplies: [{ fuelSupplyId: 24 }] },
       isLoading: false,
       error: null
+    })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        fuelSupplies: {
+          count: 1,
+          activeCount: 1,
+          deletedCount: 0,
+          wasEdited: false
+        }
+      }
     })
 
     render(
@@ -563,6 +670,13 @@ describe('ReportDetails', () => {
       ],
       isLoading: false,
       error: null
+    })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        supportingDocs: { count: 2, activeCount: 2, deletedCount: 0 }
+      }
     })
 
     render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
@@ -640,6 +754,13 @@ describe('ReportDetails', () => {
       isLoading: false,
       error: null
     })
+    mockUseComplianceReportScheduleOverview.mockReturnValue({
+      ...defaultScheduleOverview,
+      data: {
+        ...defaultScheduleOverview.data,
+        supportingDocs: { count: 1, activeCount: 1, deletedCount: 0 }
+      }
+    })
 
     rerender(<ReportDetails currentStatus="Draft" hasRoles={() => true} />)
 
@@ -706,6 +827,18 @@ describe('ReportDetails', () => {
         isLoading: false,
         error: null
       })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          fuelExports: {
+            count: 1,
+            activeCount: 1,
+            deletedCount: 0,
+            wasEdited: false
+          }
+        }
+      })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
         wrapper
@@ -728,6 +861,18 @@ describe('ReportDetails', () => {
         isLoading: false,
         error: null
       })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          fuelExports: {
+            count: 1,
+            activeCount: 1,
+            deletedCount: 0,
+            wasEdited: false
+          }
+        }
+      })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
         wrapper
@@ -749,6 +894,18 @@ describe('ReportDetails', () => {
         data: { fuelExports: [{ fuelExportId: 1 }] },
         isLoading: false,
         error: null
+      })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          fuelExports: {
+            count: 1,
+            activeCount: 1,
+            deletedCount: 0,
+            wasEdited: false
+          }
+        }
       })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
@@ -777,6 +934,18 @@ describe('ReportDetails', () => {
         isLoading: false,
         error: null
       })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          finalSupplyEquipments: {
+            count: 0,
+            activeCount: 0,
+            deletedCount: 0,
+            hasChargingEquipment: true
+          }
+        }
+      })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
         wrapper
@@ -802,6 +971,18 @@ describe('ReportDetails', () => {
         isLoading: false,
         error: null
       })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          finalSupplyEquipments: {
+            count: 0,
+            activeCount: 0,
+            deletedCount: 0,
+            hasChargingEquipment: true
+          }
+        }
+      })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {
         wrapper
@@ -826,6 +1007,18 @@ describe('ReportDetails', () => {
         },
         isLoading: false,
         error: null
+      })
+      mockUseComplianceReportScheduleOverview.mockReturnValue({
+        ...defaultScheduleOverview,
+        data: {
+          ...defaultScheduleOverview.data,
+          finalSupplyEquipments: {
+            count: 1,
+            activeCount: 1,
+            deletedCount: 0,
+            hasChargingEquipment: true
+          }
+        }
       })
 
       render(<ReportDetails currentStatus="Draft" hasRoles={() => true} />, {

--- a/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
+++ b/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
@@ -8,11 +8,12 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 export const SupportingDocumentSummary = ({ parentID, parentType, data }) => {
   const downloadDocument = useDownloadDocument(parentType, parentID)
   const { hasRoles } = useCurrentUser()
+  const files = Array.isArray(data) ? data : []
 
   return (
     <Box>
       <List component="div" sx={{ maxWidth: '100%', listStyleType: 'disc' }}>
-        {data.map((file) => (
+        {files.map((file) => (
           <Box
             sx={{ display: 'list-item', padding: '0', marginLeft: '1.2rem' }}
             key={file.documentId}


### PR DESCRIPTION
Root cause: `ReportDetails` was eagerly calling every schedule endpoint on initial render, and each endpoint ran version-history resolution queries. As compliance-report volume increased, that fan-out made schedule loading noticeably slower.

Changes made:
- Added a lightweight `GET /reports/:reportID/schedule-overview` endpoint to return per-accordion metadata only:
  - record count
  - active/deleted state
  - supplemental edited flag
  - FSE capability flag
- Refactored `ReportDetails` to use the overview first for visibility, chips, disabled state, and auto-expand decisions.
- Kept the existing UX where accordions with data auto-expand on load.
- Changed full schedule payload fetching to lazy loading:
  - if overview shows data, the accordion is shown immediately
  - the full request starts immediately
  - users see a loading spinner in the expanded accordion while the payload is still loading
- Added frontend guards for async gaps so accordions do not crash while data is still resolving:
  - protected schedule render paths from `undefined`
  - normalized supporting document data before rendering
- Added DB indexes for compliance schedule history/version lookup patterns:
  - `compliance_report (compliance_report_group_uuid, version, compliance_report_id)`
  - versioned schedule indexes on `fuel_supply`, `fuel_export`, `allocation_agreement`, `notional_transfer`, and `other_uses`
  - `final_supply_equipment (compliance_report_id, create_date)`
- Added a quarterly off-hours compliance-table reindex job:
  - January, April, July, October
  - day 1 at 03:15 am PST
  - Can be altered to run once at the startup using env variable.
  - configurable via backend settings
