### PR TITLE
feat: CI application Step 2 - Proposed fuel pathways (#4200)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-05-06-12-00_e7c2b9a4d018.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-06-12-00_e7c2b9a4d018.py
@@ -1,0 +1,49 @@
+"""Add document_category to ci_application_document_association.
+
+Step 3 of the CI application workflow uploads documents in three buckets:
+``technical_report`` (mandatory), ``ghgenius_model`` (mandatory), and
+``supporting`` (optional). The category is stored on the join table so a
+single Document row stays uncategorised globally and only carries
+meaning in the context of a specific CI application.
+
+Revision ID: e7c2b9a4d018
+Revises: d4f5e6a7b8c9
+Create Date: 2026-05-06 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "e7c2b9a4d018"
+down_revision = "d4f5e6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ci_application_document_association",
+        sa.Column(
+            "document_category",
+            sa.String(50),
+            nullable=False,
+            server_default="supporting",
+            comment=(
+                "Category of the upload in the context of the parent CI "
+                "application: 'technical_report', 'ghgenius_model', or "
+                "'supporting'."
+            ),
+        ),
+    )
+    # Drop the server default so subsequent inserts must specify a value
+    # explicitly. The default only exists to backfill any pre-existing rows.
+    op.alter_column(
+        "ci_application_document_association",
+        "document_category",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ci_application_document_association", "document_category")

--- a/backend/lcfs/db/models/ci_application/CIApplication.py
+++ b/backend/lcfs/db/models/ci_application/CIApplication.py
@@ -30,7 +30,27 @@ ci_application_document_association = Table(
         primary_key=True,
         comment="Foreign key to document",
     ),
+    Column(
+        "document_category",
+        String(50),
+        nullable=False,
+        comment=(
+            "Step 3 categorisation: 'technical_report', 'ghgenius_model', "
+            "or 'supporting'."
+        ),
+    ),
 )
+
+
+# Document category values for CI application uploads (Step 3).
+CI_DOC_CATEGORY_TECHNICAL_REPORT = "technical_report"
+CI_DOC_CATEGORY_GHGENIUS_MODEL = "ghgenius_model"
+CI_DOC_CATEGORY_SUPPORTING = "supporting"
+CI_DOC_CATEGORIES = {
+    CI_DOC_CATEGORY_TECHNICAL_REPORT,
+    CI_DOC_CATEGORY_GHGENIUS_MODEL,
+    CI_DOC_CATEGORY_SUPPORTING,
+}
 
 
 class CIApplication(BaseModel, Auditable, Versioning):

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -23,6 +23,12 @@ from lcfs.db.models.compliance import ComplianceReport
 from lcfs.db.models.compliance.ComplianceReport import (
     compliance_report_document_association,
 )
+from lcfs.db.models.ci_application.CIApplication import (
+    CI_DOC_CATEGORIES,
+    CI_DOC_CATEGORY_SUPPORTING,
+    CIApplication,
+    ci_application_document_association,
+)
 from lcfs.db.models.document import Document
 from lcfs.services.clamav.client import ClamAVService
 from lcfs.settings import settings
@@ -60,7 +66,14 @@ class DocumentService:
         self.charging_site_repo = charging_site_repo
 
     @repo_handler
-    async def upload_file(self, file, parent_id: int, parent_type, user=None):
+    async def upload_file(
+        self,
+        file,
+        parent_id: int,
+        parent_type,
+        user=None,
+        document_category: str | None = None,
+    ):
         if parent_type == "compliance_report":
             await self._verify_compliance_report_access(parent_id, user)
         elif parent_type == "administrativeAdjustment":
@@ -69,6 +82,15 @@ class DocumentService:
             await self._verify_initiative_agreement_access(parent_id, user)
         elif parent_type == "charging_site":
             await self._verify_charging_site_access(parent_id, user)
+        elif parent_type == "ci_application":
+            # Access checks for CI application uploads live in the
+            # ci_application validation layer; the views.py wrapper invokes
+            # them before delegating here.
+            if document_category and document_category not in CI_DOC_CATEGORIES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid document_category '{document_category}'.",
+                )
         else:
             raise ServiceException(f"Unknown parent type {parent_type} in upload_file")
 
@@ -196,6 +218,20 @@ class DocumentService:
                 document_id=document.document_id,
             )
             await self.db.execute(stmt)
+        elif parent_type == "ci_application":
+            ci_application = await self.db.get(CIApplication, parent_id)
+            if not ci_application:
+                raise Exception("CI application not found")
+
+            self.db.add(document)
+            await self.db.flush()
+
+            stmt = ci_application_document_association.insert().values(
+                ci_application_id=ci_application.ci_application_id,
+                document_id=document.document_id,
+                document_category=document_category or CI_DOC_CATEGORY_SUPPORTING,
+            )
+            await self.db.execute(stmt)
         else:
             raise ServiceException(f"Invalid Type {parent_type}")
 
@@ -314,6 +350,10 @@ class DocumentService:
                 charging_site_document_association,
                 "charging_site_id",
             ),
+            "ci_application": (
+                ci_application_document_association,
+                "ci_application_id",
+            ),
         }
 
         # Get the association table and column based on the parent_type
@@ -370,6 +410,10 @@ class DocumentService:
             "charging_site": (
                 charging_site_document_association,
                 "charging_site_id",
+            ),
+            "ci_application": (
+                ci_application_document_association,
+                "ci_application_id",
             ),
         }
 

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -426,25 +426,53 @@ class DocumentService:
         association_table, column_name = association_info
 
         # Construct the SQL statement dynamically
-        stmt = select(Document)
         if parent_type == "compliance_report":
             parent_ids = (
                 await self.compliance_report_repo.get_related_compliance_report_ids(
                     parent_id
                 )
             )
-            stmt = stmt.join(association_table).where(
-                getattr(association_table.c, column_name).in_(parent_ids)
-            ).distinct(Document.document_id)
-        else:
-            stmt = stmt.join(association_table).where(
-                getattr(association_table.c, column_name) == parent_id
+            stmt = (
+                select(Document)
+                .join(association_table)
+                .where(
+                    getattr(association_table.c, column_name).in_(parent_ids)
+                )
+                .distinct(Document.document_id)
             )
+            result = await self.db.execute(stmt)
+            return result.scalars().all()
 
-        # Execute the statement and fetch results
+        if parent_type == "ci_application":
+            # Project the join's document_category alongside Document so the
+            # API response can carry the Step 3 bucket without a separate
+            # endpoint.
+            stmt = (
+                select(Document, association_table.c.document_category)
+                .join(
+                    association_table,
+                    association_table.c.document_id == Document.document_id,
+                )
+                .where(
+                    getattr(association_table.c, column_name) == parent_id
+                )
+            )
+            result = await self.db.execute(stmt)
+            documents = []
+            for document, category in result.all():
+                # Pydantic's from_attributes reads attribute names verbatim,
+                # so stamp the join column onto the Document row.
+                document.document_category = category
+                documents.append(document)
+            return documents
+
+        stmt = (
+            select(Document)
+            .join(association_table)
+            .where(getattr(association_table.c, column_name) == parent_id)
+        )
         result = await self.db.execute(stmt)
-        documents = result.scalars().all()
-        return documents
+        return result.scalars().all()
 
     @repo_handler
     async def get_object(self, document_id: int):

--- a/backend/lcfs/services/s3/schema.py
+++ b/backend/lcfs/services/s3/schema.py
@@ -8,6 +8,8 @@ class FileResponseSchema(BaseSchema):
     file_size: int
     create_date: datetime | None = None
     create_user: str | None = None
+    # Step 3 categorisation; only populated for ci_application uploads.
+    document_category: str | None = None
 
     class Config:
         from_attributes = True

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -458,3 +458,91 @@ async def test_pathway_input_rejects_inverted_dates():
             operating_data_from=date(2025, 12, 31),
             operating_data_to=date(2025, 1, 1),
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Documents & GHGenius modelling
+# ---------------------------------------------------------------------------
+
+
+def _doc(document_id=1, file_name="tech-report.pdf", file_size=1024):
+    return SimpleNamespace(
+        document_id=document_id,
+        file_name=file_name,
+        file_size=file_size,
+        mime_type="application/pdf",
+        create_date=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        create_user="ci_applicant_user",
+    )
+
+
+@pytest.mark.anyio
+async def test_list_documents_returns_categorised_files(service, repo):
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1, "tech.pdf"), "technical_report"),
+        (_doc(2, "model.xlsx"), "ghgenius_model"),
+    ]
+    result = await service.list_documents(10)
+    assert [d.document_category for d in result] == [
+        "technical_report",
+        "ghgenius_model",
+    ]
+    assert result[0].file_name == "tech.pdf"
+
+
+@pytest.mark.anyio
+async def test_update_step3_succeeds_when_required_present(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1), "technical_report"),
+        (_doc(2), "ghgenius_model"),
+    ]
+    repo.update.side_effect = lambda obj: obj
+    repo.get_by_id.return_value = ci
+
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    payload = CIApplicationStep3Schema(supporting_document_other="Extra notes")
+    result = await service.update_step3(ci, payload, mock_user)
+
+    assert ci.supporting_document_other == "Extra notes"
+    assert ci.action_type == ActionTypeEnum.UPDATE
+    assert isinstance(result, CIApplicationSchema)
+
+
+@pytest.mark.anyio
+async def test_update_step3_rejects_when_technical_report_missing(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(2), "ghgenius_model"),
+    ]
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step3(
+            ci, CIApplicationStep3Schema(), mock_user
+        )
+    assert "Technical report" in str(exc.value)
+    repo.update.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_step3_rejects_when_ghgenius_missing(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1), "technical_report"),
+    ]
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step3(
+            ci, CIApplicationStep3Schema(), mock_user
+        )
+    assert "GHGenius" in str(exc.value)
+    repo.update.assert_not_called()

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -465,39 +465,14 @@ async def test_pathway_input_rejects_inverted_dates():
 # ---------------------------------------------------------------------------
 
 
-def _doc(document_id=1, file_name="tech-report.pdf", file_size=1024):
-    return SimpleNamespace(
-        document_id=document_id,
-        file_name=file_name,
-        file_size=file_size,
-        mime_type="application/pdf",
-        create_date=datetime(2026, 5, 1, tzinfo=timezone.utc),
-        create_user="ci_applicant_user",
-    )
-
-
-@pytest.mark.anyio
-async def test_list_documents_returns_categorised_files(service, repo):
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1, "tech.pdf"), "technical_report"),
-        (_doc(2, "model.xlsx"), "ghgenius_model"),
-    ]
-    result = await service.list_documents(10)
-    assert [d.document_category for d in result] == [
-        "technical_report",
-        "ghgenius_model",
-    ]
-    assert result[0].file_name == "tech.pdf"
-
-
 @pytest.mark.anyio
 async def test_update_step3_succeeds_when_required_present(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1), "technical_report"),
-        (_doc(2), "ghgenius_model"),
+    repo.get_document_categories.return_value = [
+        "technical_report",
+        "ghgenius_model",
     ]
     repo.update.side_effect = lambda obj: obj
     repo.get_by_id.return_value = ci
@@ -517,9 +492,7 @@ async def test_update_step3_rejects_when_technical_report_missing(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(2), "ghgenius_model"),
-    ]
+    repo.get_document_categories.return_value = ["ghgenius_model"]
     from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
 
     with pytest.raises(Exception) as exc:
@@ -535,9 +508,7 @@ async def test_update_step3_rejects_when_ghgenius_missing(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1), "technical_report"),
-    ]
+    repo.get_document_categories.return_value = ["technical_report"]
     from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
 
     with pytest.raises(Exception) as exc:

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -15,7 +15,9 @@ from lcfs.web.api.ci_application.schema import (
     CIApplicationSchema,
     CIApplicationStatusEnum,
     CIApplicationStep1Schema,
+    CIApplicationStep2Schema,
     CITableOptionsSchema,
+    PathwayInputSchema,
 )
 from lcfs.web.api.ci_application.services import CIApplicationServices
 from lcfs.web.exception.exceptions import DataNotFoundException
@@ -283,3 +285,176 @@ async def test_delete_draft_calls_repo(service, repo):
     ci = _ci_application()
     await service.delete_draft(ci)
     repo.delete.assert_awaited_once_with(ci)
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Proposed fuel pathways
+# ---------------------------------------------------------------------------
+
+
+def _pathway_app_type(ident=1, name="New"):
+    return SimpleNamespace(
+        pathway_application_type_id=ident,
+        type=name,
+        description=name,
+    )
+
+
+def _pathway_fc_type(ident=1, name="1-year provisional"):
+    return SimpleNamespace(
+        pathway_fuel_code_type_id=ident,
+        type=name,
+        description=name,
+    )
+
+
+def _fuel_type_obj(ident=1, name="Biodiesel"):
+    return SimpleNamespace(fuel_type_id=ident, fuel_type=name)
+
+
+def _fuel_code_obj(ident=42, suffix="100.4", prefix="C-BCLCF"):
+    return SimpleNamespace(
+        fuel_code_id=ident,
+        fuel_suffix=suffix,
+        carbon_intensity=23.23,
+        fuel_type_id=1,
+        fuel_type=_fuel_type_obj(),
+        feedstock="Corn",
+        feedstock_location="Ontario, CA",
+        fuel_code_prefix=SimpleNamespace(prefix=prefix),
+    )
+
+
+def _new_pathway_input(**overrides):
+    base = dict(
+        application_type_id=1,
+        fuel_code_type_id=1,
+        operating_data_from=date(2025, 1, 1),
+        operating_data_to=date(2025, 12, 31),
+        fuel_code_id=None,
+        proposed_ci=5.61,
+        fuel_type_id=1,
+        feedstock="Canola",
+        feedstock_region="Saskatchewan",
+        feedstock_transport_mode="Truck",
+        feedstock_transport_distance=100,
+        coproducts=None,
+        finished_fuel_transport_mode="Rail",
+        finished_fuel_transport_distance=200,
+    )
+    base.update(overrides)
+    return PathwayInputSchema(**base)
+
+
+def _stub_step2_lookups(repo, *, with_fuel_code=False):
+    repo.get_pathway_application_types.return_value = [
+        _pathway_app_type(1, "New"),
+        _pathway_app_type(2, "Renewal"),
+    ]
+    repo.get_pathway_fuel_code_types.return_value = [
+        _pathway_fc_type(1, "1-year provisional"),
+        _pathway_fc_type(2, "3-year"),
+    ]
+    repo.get_fuel_types.return_value = [_fuel_type_obj(1, "Biodiesel")]
+    repo.get_fuel_codes_by_ids.return_value = (
+        [_fuel_code_obj()] if with_fuel_code else []
+    )
+
+
+@pytest.mark.anyio
+async def test_update_step2_replaces_pathways_and_description(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    ci.pathways = []
+    _stub_step2_lookups(repo)
+    repo.replace_pathways.return_value = []
+    repo.update.side_effect = lambda obj: obj
+    repo.get_by_id.return_value = ci
+
+    payload = CIApplicationStep2Schema(
+        pathways=[_new_pathway_input()],
+        pathway_description="Uses CCS",
+    )
+
+    result = await service.update_step2(ci, payload, mock_user)
+
+    repo.replace_pathways.assert_awaited_once()
+    args, _ = repo.replace_pathways.await_args
+    assert args[0] == ci.ci_application_id
+    new_rows = args[1]
+    assert len(new_rows) == 1
+    assert new_rows[0].application_type_id == 1
+    assert new_rows[0].create_user == "ci_applicant_user"
+    assert new_rows[0].action_type == ActionTypeEnum.CREATE
+
+    assert ci.pathway_description == "Uses CCS"
+    assert ci.action_type == ActionTypeEnum.UPDATE
+    assert isinstance(result, CIApplicationSchema)
+
+
+@pytest.mark.anyio
+async def test_update_step2_rejects_renewal_without_fuel_code(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    _stub_step2_lookups(repo)
+
+    payload = CIApplicationStep2Schema(
+        pathways=[_new_pathway_input(application_type_id=2, fuel_code_id=None)],
+    )
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step2(ci, payload, mock_user)
+    assert "fuel code iteration" in str(exc.value)
+    repo.replace_pathways.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_step2_rejects_new_with_fuel_code(service, repo, mock_user):
+    ci = _ci_application()
+    _stub_step2_lookups(repo, with_fuel_code=True)
+
+    payload = CIApplicationStep2Schema(
+        pathways=[_new_pathway_input(application_type_id=1, fuel_code_id=42)],
+    )
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step2(ci, payload, mock_user)
+    assert "must not reference" in str(exc.value)
+    repo.replace_pathways.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_step2_renewal_with_valid_fuel_code(service, repo, mock_user):
+    ci = _ci_application()
+    ci.pathways = []
+    _stub_step2_lookups(repo, with_fuel_code=True)
+    repo.replace_pathways.return_value = []
+    repo.update.side_effect = lambda obj: obj
+    repo.get_by_id.return_value = ci
+
+    payload = CIApplicationStep2Schema(
+        pathways=[_new_pathway_input(application_type_id=2, fuel_code_id=42)],
+    )
+
+    result = await service.update_step2(ci, payload, mock_user)
+    assert isinstance(result, CIApplicationSchema)
+    repo.replace_pathways.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_step2_schema_requires_at_least_one_pathway():
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        CIApplicationStep2Schema(pathways=[])
+
+
+@pytest.mark.anyio
+async def test_pathway_input_rejects_inverted_dates():
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        _new_pathway_input(
+            operating_data_from=date(2025, 12, 31),
+            operating_data_to=date(2025, 1, 1),
+        )

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -28,7 +28,6 @@ from lcfs.db.models.ci_application import (
 from lcfs.db.models.ci_application.CIApplication import (
     ci_application_document_association,
 )
-from lcfs.db.models.document import Document
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
@@ -231,29 +230,23 @@ class CIApplicationRepository:
         return list(result.scalars().all())
 
     @repo_handler
-    async def get_documents_with_categories(
+    async def get_document_categories(
         self, ci_application_id: int
-    ) -> List[Tuple[Document, str]]:
+    ) -> List[str]:
         """
-        Returns ``(document, category)`` tuples for every file uploaded to
-        this CI application. The category lives on the M:N row, not on
-        Document, so we project both together.
+        Return just the ``document_category`` values currently linked to
+        this CI application. Used by Step 3's required-uploads check; we
+        deliberately don't pull Document rows so the validation stays cheap.
         """
         stmt = (
-            select(Document, ci_application_document_association.c.document_category)
-            .join(
-                ci_application_document_association,
-                ci_application_document_association.c.document_id
-                == Document.document_id,
-            )
+            select(ci_application_document_association.c.document_category)
             .where(
                 ci_application_document_association.c.ci_application_id
                 == ci_application_id
             )
-            .order_by(Document.create_date)
         )
         result = await self.db.execute(stmt)
-        return [(row[0], row[1]) for row in result.all()]
+        return [row[0] for row in result.all()]
 
     @repo_handler
     async def get_fuel_codes_by_ids(

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -21,7 +21,14 @@ from lcfs.db.models.ci_application import (
     CIApplication,
     CIApplicationHistory,
     CIApplicationStatus,
+    Pathway,
+    PathwayApplicationType,
+    PathwayFuelCodeType,
 )
+from lcfs.db.models.fuel.FuelCode import FuelCode
+from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
+from lcfs.db.models.fuel.FuelType import FuelType
+from lcfs.db.models.fuel.TransportMode import TransportMode
 from lcfs.db.models.fuel.UnitOfMeasure import UnitOfMeasure
 from lcfs.web.api.base import (
     PaginationRequestSchema,
@@ -62,6 +69,56 @@ class CIApplicationRepository:
         )
         return result.scalars().all()
 
+    @repo_handler
+    async def get_pathway_application_types(
+        self,
+    ) -> Sequence[PathwayApplicationType]:
+        result = await self.db.execute(
+            select(PathwayApplicationType).order_by(
+                PathwayApplicationType.display_order
+            )
+        )
+        return result.scalars().all()
+
+    @repo_handler
+    async def get_pathway_fuel_code_types(self) -> Sequence[PathwayFuelCodeType]:
+        result = await self.db.execute(
+            select(PathwayFuelCodeType).order_by(PathwayFuelCodeType.display_order)
+        )
+        return result.scalars().all()
+
+    @repo_handler
+    async def get_fuel_types(self) -> Sequence[FuelType]:
+        result = await self.db.execute(select(FuelType).order_by(FuelType.fuel_type))
+        return result.scalars().all()
+
+    @repo_handler
+    async def get_transport_modes(self) -> Sequence[TransportMode]:
+        result = await self.db.execute(
+            select(TransportMode).order_by(TransportMode.transport_mode)
+        )
+        return result.scalars().all()
+
+    @repo_handler
+    async def get_approved_fuel_codes(self) -> Sequence[FuelCode]:
+        """
+        Approved fuel codes the applicant can renew. Eagerly loads the
+        prefix (for display string assembly) and the fuel type (used to
+        auto-populate locked grid cells when a renewal row is selected).
+        """
+        result = await self.db.execute(
+            select(FuelCode)
+            .options(
+                selectinload(FuelCode.fuel_code_prefix),
+                selectinload(FuelCode.fuel_code_status),
+                selectinload(FuelCode.fuel_type),
+            )
+            .join(FuelCode.fuel_code_status)
+            .where(FuelCodeStatus.status == FuelCodeStatusEnum.Approved)
+            .order_by(FuelCode.fuel_code_id)
+        )
+        return result.scalars().all()
+
     # ------------------------------------------------------------------
     # CI application CRUD
     # ------------------------------------------------------------------
@@ -74,7 +131,19 @@ class CIApplicationRepository:
                 selectinload(CIApplication.organization),
                 selectinload(CIApplication.ci_application_status),
                 selectinload(CIApplication.facility_nameplate_capacity_unit),
-                selectinload(CIApplication.pathways),
+                selectinload(CIApplication.pathways).selectinload(
+                    Pathway.application_type
+                ),
+                selectinload(CIApplication.pathways).selectinload(
+                    Pathway.fuel_code_type
+                ),
+                selectinload(CIApplication.pathways).selectinload(Pathway.fuel_type),
+                selectinload(CIApplication.pathways)
+                .selectinload(Pathway.fuel_code)
+                .selectinload(FuelCode.fuel_code_prefix),
+                selectinload(CIApplication.pathways)
+                .selectinload(Pathway.fuel_code)
+                .selectinload(FuelCode.fuel_type),
             )
             .where(CIApplication.ci_application_id == ci_application_id)
         )
@@ -111,6 +180,62 @@ class CIApplicationRepository:
     async def delete(self, ci_application: CIApplication) -> None:
         await self.db.delete(ci_application)
         await self.db.flush()
+
+    @repo_handler
+    async def replace_pathways(
+        self,
+        ci_application_id: int,
+        pathways: List[Pathway],
+    ) -> List[Pathway]:
+        """
+        Replace the full set of pathways for a CI application.
+
+        Step 2 always submits the entire grid, so we delete existing rows
+        and insert the new ones in one unit of work. The application
+        owns its pathways via a delete-orphan cascade, so the simple
+        ``DELETE FROM pathway WHERE ci_application_id = :id`` mirrors
+        what an ORM-level removal would do without forcing the service
+        layer to load every existing row first.
+        """
+        from sqlalchemy import delete
+
+        await self.db.execute(
+            delete(Pathway).where(Pathway.ci_application_id == ci_application_id)
+        )
+        for pathway in pathways:
+            pathway.ci_application_id = ci_application_id
+            self.db.add(pathway)
+        await self.db.flush()
+        return pathways
+
+    @repo_handler
+    async def get_pathways(self, ci_application_id: int) -> List[Pathway]:
+        result = await self.db.execute(
+            select(Pathway)
+            .options(
+                selectinload(Pathway.application_type),
+                selectinload(Pathway.fuel_code_type),
+                selectinload(Pathway.fuel_type),
+                selectinload(Pathway.fuel_code).selectinload(
+                    FuelCode.fuel_code_prefix
+                ),
+                selectinload(Pathway.fuel_code).selectinload(FuelCode.fuel_type),
+            )
+            .where(Pathway.ci_application_id == ci_application_id)
+            .order_by(Pathway.pathway_id)
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
+    async def get_fuel_codes_by_ids(
+        self, fuel_code_ids: Sequence[int]
+    ) -> List[FuelCode]:
+        if not fuel_code_ids:
+            return []
+        result = await self.db.execute(
+            select(FuelCode).where(FuelCode.fuel_code_id.in_(list(fuel_code_ids)))
+        )
+        return list(result.scalars().all())
 
     @repo_handler
     async def add_history(

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -25,6 +25,10 @@ from lcfs.db.models.ci_application import (
     PathwayApplicationType,
     PathwayFuelCodeType,
 )
+from lcfs.db.models.ci_application.CIApplication import (
+    ci_application_document_association,
+)
+from lcfs.db.models.document import Document
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
@@ -225,6 +229,31 @@ class CIApplicationRepository:
             .order_by(Pathway.pathway_id)
         )
         return list(result.scalars().all())
+
+    @repo_handler
+    async def get_documents_with_categories(
+        self, ci_application_id: int
+    ) -> List[Tuple[Document, str]]:
+        """
+        Returns ``(document, category)`` tuples for every file uploaded to
+        this CI application. The category lives on the M:N row, not on
+        Document, so we project both together.
+        """
+        stmt = (
+            select(Document, ci_application_document_association.c.document_category)
+            .join(
+                ci_application_document_association,
+                ci_application_document_association.c.document_id
+                == Document.document_id,
+            )
+            .where(
+                ci_application_document_association.c.ci_application_id
+                == ci_application_id
+            )
+            .order_by(Document.create_date)
+        )
+        result = await self.db.execute(stmt)
+        return [(row[0], row[1]) for row in result.all()]
 
     @repo_handler
     async def get_fuel_codes_by_ids(

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -267,17 +267,6 @@ class CIApplicationsListSchema(BaseSchema):
 # ---------------------------------------------------------------------------
 
 
-class CIApplicationDocumentSchema(BaseSchema):
-    """A document linked to a CI application, tagged with its Step 3 category."""
-
-    document_id: int
-    file_name: str
-    file_size: int
-    document_category: str
-    create_date: Optional[str] = None
-    create_user: Optional[str] = None
-
-
 class CIApplicationStep3Schema(BaseSchema):
     """
     Payload for ``PUT /ci-applications/{id}/step3``.

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -260,3 +260,34 @@ class CIApplicationSchema(BaseSchema):
 class CIApplicationsListSchema(BaseSchema):
     ci_applications: List[CIApplicationBaseSchema]
     pagination: PaginationResponseSchema
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Documents & GHGenius modelling
+# ---------------------------------------------------------------------------
+
+
+class CIApplicationDocumentSchema(BaseSchema):
+    """A document linked to a CI application, tagged with its Step 3 category."""
+
+    document_id: int
+    file_name: str
+    file_size: int
+    document_category: str
+    create_date: Optional[str] = None
+    create_user: Optional[str] = None
+
+
+class CIApplicationStep3Schema(BaseSchema):
+    """
+    Payload for ``PUT /ci-applications/{id}/step3``.
+
+    Files are uploaded one-at-a-time via the generic
+    ``/documents/ci_application/{id}`` endpoint with a
+    ``document_category`` query param. This call only persists the
+    optional free-text "other supporting" description and validates
+    that the mandatory Technical report and GHGenius model uploads
+    are in place.
+    """
+
+    supporting_document_other: Optional[str] = Field(default=None, max_length=1000)

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -1,18 +1,18 @@
 """
 Pydantic schemas for the Carbon Intensity (CI) application module.
 
-Step 1 of the CI application workflow ("Application information") is the
-only step fully wired through the API. The remaining four steps
-(Proposed fuel pathways, Documents & GHGenius modelling, Sign & submit,
-Government decision) are intentionally stubbed out at the view layer and
-will reuse / extend these schemas as additional fields are introduced.
+Steps 1 ("Application information") and 2 ("Proposed fuel pathways") are
+fully wired through the API. The remaining three steps (Documents &
+GHGenius modelling, Sign & submit, Government decision) are stubbed out
+at the view layer and will reuse / extend these schemas.
 """
 
 from datetime import date
+from decimal import Decimal
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
 from lcfs.web.api.base import BaseSchema, PaginationResponseSchema
 
@@ -57,16 +57,50 @@ class OrganizationInfoSchema(BaseSchema):
     address_line: Optional[str] = None
 
 
-class CITableOptionsSchema(BaseSchema):
-    """
-    Reference data needed to render the CI application forms.
+class PathwayApplicationTypeSchema(BaseSchema):
+    pathway_application_type_id: int
+    type: str
+    description: Optional[str] = None
 
-    Pre-loaded once on form mount; new lookup arrays will be added here as
-    Steps 2-5 are implemented.
+
+class PathwayFuelCodeTypeSchema(BaseSchema):
+    pathway_fuel_code_type_id: int
+    type: str
+    description: Optional[str] = None
+
+
+class FuelTypeOptionSchema(BaseSchema):
+    fuel_type_id: int
+    fuel_type: str
+
+
+class FuelCodeOptionSchema(BaseSchema):
     """
+    Compact representation of an existing fuel code, surfaced to the
+    Step 2 grid as the dropdown for renewals (the "Fuel code iteration"
+    column). Only the fields needed to display the option and to
+    auto-populate locked grid cells are returned.
+    """
+
+    fuel_code_id: int
+    fuel_code: str
+    carbon_intensity: Optional[Decimal] = None
+    fuel_type_id: Optional[int] = None
+    fuel_type: Optional[str] = None
+    feedstock: Optional[str] = None
+    feedstock_location: Optional[str] = None
+
+
+class CITableOptionsSchema(BaseSchema):
+    """Reference data needed to render the CI application forms."""
 
     statuses: List[CIApplicationStatusSchema]
     units_of_measure: List[UnitOfMeasureSchema]
+    pathway_application_types: List[PathwayApplicationTypeSchema] = []
+    pathway_fuel_code_types: List[PathwayFuelCodeTypeSchema] = []
+    fuel_types: List[FuelTypeOptionSchema] = []
+    transport_modes: List[str] = []
+    fuel_codes: List[FuelCodeOptionSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +124,85 @@ class CIApplicationStep1Schema(BaseSchema):
     facility_nameplate_capacity: int = Field(..., gt=0)
     facility_nameplate_capacity_unit_id: int
     proposed_fuel_code_effective_date: Optional[date] = None
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Proposed fuel pathways
+# ---------------------------------------------------------------------------
+
+
+class PathwayInputSchema(BaseSchema):
+    """
+    Single row submitted from the Step 2 AG Grid.
+
+    Behavioural rules enforced here:
+      - Renewal rows must reference an existing ``fuel_code_id``.
+      - New rows must NOT reference a fuel code (the column is disabled
+        on new rows in the UI; reject any value defensively).
+    """
+
+    pathway_id: Optional[int] = None
+    application_type_id: int
+    fuel_code_type_id: int
+    operating_data_from: date
+    operating_data_to: date
+    fuel_code_id: Optional[int] = None
+    proposed_ci: Decimal = Field(..., ge=0)
+    fuel_type_id: int
+    feedstock: str = Field(..., max_length=500)
+    feedstock_region: str = Field(..., max_length=500)
+    feedstock_transport_mode: str = Field(..., max_length=500)
+    feedstock_transport_distance: int = Field(..., ge=0)
+    coproducts: Optional[str] = Field(default=None, max_length=1000)
+    finished_fuel_transport_mode: str = Field(..., max_length=500)
+    finished_fuel_transport_distance: int = Field(..., ge=0)
+
+    @model_validator(mode="after")
+    def _validate_dates(self):
+        if self.operating_data_to < self.operating_data_from:
+            raise ValueError(
+                "operating_data_to must be on or after operating_data_from."
+            )
+        return self
+
+
+class CIApplicationStep2Schema(BaseSchema):
+    """Payload for ``PUT /ci-applications/{id}/step2``."""
+
+    pathways: List[PathwayInputSchema] = Field(default_factory=list)
+    pathway_description: Optional[str] = None
+
+    @field_validator("pathways")
+    @classmethod
+    def _at_least_one_pathway(cls, value: List[PathwayInputSchema]):
+        if not value:
+            raise ValueError("At least one pathway is required.")
+        return value
+
+
+class PathwaySchema(BaseSchema):
+    """Pathway as returned from the API (read side)."""
+
+    pathway_id: int
+    ci_application_id: int
+    application_type_id: int
+    application_type: Optional[PathwayApplicationTypeSchema] = None
+    fuel_code_type_id: int
+    fuel_code_type: Optional[PathwayFuelCodeTypeSchema] = None
+    operating_data_from: date
+    operating_data_to: date
+    fuel_code_id: Optional[int] = None
+    fuel_code: Optional[FuelCodeOptionSchema] = None
+    proposed_ci: Decimal
+    fuel_type_id: int
+    fuel_type: Optional[FuelTypeOptionSchema] = None
+    feedstock: str
+    feedstock_region: str
+    feedstock_transport_mode: str
+    feedstock_transport_distance: int
+    coproducts: Optional[str] = None
+    finished_fuel_transport_mode: str
+    finished_fuel_transport_distance: int
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +244,12 @@ class CIApplicationSchema(BaseSchema):
     facility_nameplate_capacity_unit: Optional[UnitOfMeasureSchema] = None
     proposed_fuel_code_effective_date: Optional[date] = None
 
+    # Step 2
+    pathway_description: Optional[str] = None
+    pathways: List[PathwaySchema] = Field(default_factory=list)
+
     # Reserved for later steps — surfaced on read so the UI can pre-fill any
     # values previously persisted by other developers / future steps.
-    pathway_description: Optional[str] = None
     supporting_document_other: Optional[str] = None
     consultant_name: Optional[str] = None
     consultant_company: Optional[str] = None

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -28,7 +28,6 @@ from lcfs.web.api.base import (
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 from lcfs.web.api.ci_application.schema import (
     CIApplicationBaseSchema,
-    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationStatusEnum,
     CIApplicationStatusSchema,
@@ -436,26 +435,6 @@ class CIApplicationServices:
     # ------------------------------------------------------------------
 
     @service_handler
-    async def list_documents(
-        self, ci_application_id: int
-    ) -> List[CIApplicationDocumentSchema]:
-        """All Step 3 uploads for an application, with their categories."""
-        rows = await self.repo.get_documents_with_categories(ci_application_id)
-        return [
-            CIApplicationDocumentSchema(
-                document_id=document.document_id,
-                file_name=document.file_name,
-                file_size=document.file_size,
-                document_category=category,
-                create_date=(
-                    document.create_date.isoformat() if document.create_date else None
-                ),
-                create_user=document.create_user,
-            )
-            for document, category in rows
-        ]
-
-    @service_handler
     async def update_step3(
         self,
         ci_application: CIApplication,
@@ -468,10 +447,9 @@ class CIApplicationServices:
         present. Files are uploaded out-of-band via the generic document
         endpoint with a category query param.
         """
-        rows = await self.repo.get_documents_with_categories(
-            ci_application.ci_application_id
+        present_categories = set(
+            await self.repo.get_document_categories(ci_application.ci_application_id)
         )
-        present_categories = {category for _, category in rows}
         missing = []
         if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
             missing.append("Technical report")

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -8,14 +8,15 @@ are introduced.
 """
 
 import uuid
-from typing import Optional
+from typing import List, Optional
 
 import structlog
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models import UserProfile
-from lcfs.db.models.ci_application import CIApplication
+from lcfs.db.models.ci_application import CIApplication, Pathway
+from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.web.api.base import (
     PaginationRequestSchema,
     PaginationResponseSchema,
@@ -28,12 +29,23 @@ from lcfs.web.api.ci_application.schema import (
     CIApplicationStatusSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
+    CIApplicationStep2Schema,
     CITableOptionsSchema,
+    FuelCodeOptionSchema,
+    FuelTypeOptionSchema,
     OrganizationInfoSchema,
+    PathwayApplicationTypeSchema,
+    PathwayFuelCodeTypeSchema,
+    PathwayInputSchema,
+    PathwaySchema,
     UnitOfMeasureSchema,
 )
 from lcfs.web.core.decorators import service_handler
 from lcfs.web.exception.exceptions import DataNotFoundException
+
+# pathway_application_type.type values seeded by the migration
+PATHWAY_APPLICATION_TYPE_NEW = "New"
+PATHWAY_APPLICATION_TYPE_RENEWAL = "Renewal"
 
 logger = structlog.get_logger(__name__)
 
@@ -47,6 +59,57 @@ def _to_org_info(organization) -> Optional[OrganizationInfoSchema]:
         operating_name=organization.operating_name,
         email=organization.email,
         phone=organization.phone,
+    )
+
+
+def _to_fuel_code_option(fc: FuelCode) -> FuelCodeOptionSchema:
+    """Compose the display string and lift the renewal-relevant fields."""
+    prefix = fc.fuel_code_prefix.prefix if fc.fuel_code_prefix else ""
+    return FuelCodeOptionSchema(
+        fuel_code_id=fc.fuel_code_id,
+        fuel_code=f"{prefix}{fc.fuel_suffix}" if prefix else fc.fuel_suffix,
+        carbon_intensity=fc.carbon_intensity,
+        fuel_type_id=fc.fuel_type_id,
+        fuel_type=fc.fuel_type.fuel_type if fc.fuel_type else None,
+        feedstock=fc.feedstock,
+        feedstock_location=fc.feedstock_location,
+    )
+
+
+def _to_pathway_schema(pathway: Pathway) -> PathwaySchema:
+    return PathwaySchema(
+        pathway_id=pathway.pathway_id,
+        ci_application_id=pathway.ci_application_id,
+        application_type_id=pathway.application_type_id,
+        application_type=(
+            PathwayApplicationTypeSchema.model_validate(pathway.application_type)
+            if pathway.application_type
+            else None
+        ),
+        fuel_code_type_id=pathway.fuel_code_type_id,
+        fuel_code_type=(
+            PathwayFuelCodeTypeSchema.model_validate(pathway.fuel_code_type)
+            if pathway.fuel_code_type
+            else None
+        ),
+        operating_data_from=pathway.operating_data_from,
+        operating_data_to=pathway.operating_data_to,
+        fuel_code_id=pathway.fuel_code_id,
+        fuel_code=_to_fuel_code_option(pathway.fuel_code) if pathway.fuel_code else None,
+        proposed_ci=pathway.proposed_ci,
+        fuel_type_id=pathway.fuel_type_id,
+        fuel_type=(
+            FuelTypeOptionSchema.model_validate(pathway.fuel_type)
+            if pathway.fuel_type
+            else None
+        ),
+        feedstock=pathway.feedstock,
+        feedstock_region=pathway.feedstock_region,
+        feedstock_transport_mode=pathway.feedstock_transport_mode,
+        feedstock_transport_distance=pathway.feedstock_transport_distance,
+        coproducts=pathway.coproducts,
+        finished_fuel_transport_mode=pathway.finished_fuel_transport_mode,
+        finished_fuel_transport_distance=pathway.finished_fuel_transport_distance,
     )
 
 
@@ -69,6 +132,7 @@ def _to_full_schema(ci: CIApplication) -> CIApplicationSchema:
         ),
         proposed_fuel_code_effective_date=ci.proposed_fuel_code_effective_date,
         pathway_description=ci.pathway_description,
+        pathways=[_to_pathway_schema(p) for p in (getattr(ci, "pathways", None) or [])],
         supporting_document_other=ci.supporting_document_other,
         consultant_name=ci.consultant_name,
         consultant_company=ci.consultant_company,
@@ -108,9 +172,29 @@ class CIApplicationServices:
     async def get_table_options(self) -> CITableOptionsSchema:
         statuses = await self.repo.get_statuses()
         units = await self.repo.get_units_of_measure()
+        application_types = await self.repo.get_pathway_application_types()
+        fuel_code_types = await self.repo.get_pathway_fuel_code_types()
+        fuel_types = await self.repo.get_fuel_types()
+        transport_modes = await self.repo.get_transport_modes()
+        fuel_codes = await self.repo.get_approved_fuel_codes()
         return CITableOptionsSchema(
             statuses=[CIApplicationStatusSchema.model_validate(s) for s in statuses],
             units_of_measure=[UnitOfMeasureSchema.model_validate(u) for u in units],
+            pathway_application_types=[
+                PathwayApplicationTypeSchema.model_validate(t)
+                for t in application_types
+            ],
+            pathway_fuel_code_types=[
+                PathwayFuelCodeTypeSchema.model_validate(t) for t in fuel_code_types
+            ],
+            fuel_types=[
+                FuelTypeOptionSchema(
+                    fuel_type_id=ft.fuel_type_id, fuel_type=ft.fuel_type
+                )
+                for ft in fuel_types
+            ],
+            transport_modes=[tm.transport_mode for tm in transport_modes],
+            fuel_codes=[_to_fuel_code_option(fc) for fc in fuel_codes],
         )
 
     # ------------------------------------------------------------------
@@ -208,3 +292,135 @@ class CIApplicationServices:
     @service_handler
     async def delete_draft(self, ci_application: CIApplication) -> None:
         await self.repo.delete(ci_application)
+
+    # ------------------------------------------------------------------
+    # Step 2 — Proposed fuel pathways
+    # ------------------------------------------------------------------
+
+    async def _validate_step2_payload(
+        self,
+        data: CIApplicationStep2Schema,
+    ) -> dict:
+        """
+        Cross-row validation of Step 2:
+          - referenced application_type / fuel_code_type ids must exist;
+          - Renewal rows require an existing approved fuel_code_id;
+          - New rows must NOT carry a fuel_code_id (the column is
+            disabled in the UI; reject defensively in case someone bypasses);
+          - Every fuel_type_id and fuel_code_id referenced must exist.
+
+        Returns a dict of lookups keyed by id so the caller can avoid
+        re-querying when materialising ORM rows.
+        """
+        application_types = {
+            t.pathway_application_type_id: t
+            for t in await self.repo.get_pathway_application_types()
+        }
+        fuel_code_types = {
+            t.pathway_fuel_code_type_id: t
+            for t in await self.repo.get_pathway_fuel_code_types()
+        }
+        fuel_types = {ft.fuel_type_id for ft in await self.repo.get_fuel_types()}
+
+        referenced_fuel_code_ids = [
+            row.fuel_code_id for row in data.pathways if row.fuel_code_id is not None
+        ]
+        fuel_codes = {
+            fc.fuel_code_id: fc
+            for fc in await self.repo.get_fuel_codes_by_ids(referenced_fuel_code_ids)
+        }
+
+        for index, row in enumerate(data.pathways, start=1):
+            if row.application_type_id not in application_types:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Row {index}: invalid application type.",
+                )
+            if row.fuel_code_type_id not in fuel_code_types:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Row {index}: invalid fuel code type.",
+                )
+            if row.fuel_type_id not in fuel_types:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Row {index}: invalid fuel type.",
+                )
+
+            type_name = application_types[row.application_type_id].type
+            if type_name == PATHWAY_APPLICATION_TYPE_RENEWAL:
+                if row.fuel_code_id is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            f"Row {index}: Renewal pathways require a "
+                            "fuel code iteration."
+                        ),
+                    )
+                if row.fuel_code_id not in fuel_codes:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Row {index}: invalid fuel code iteration.",
+                    )
+            else:
+                # New (or any other non-Renewal) row must not reference a fuel code.
+                if row.fuel_code_id is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            f"Row {index}: New pathways must not reference "
+                            "an existing fuel code."
+                        ),
+                    )
+
+        return {
+            "application_types": application_types,
+            "fuel_code_types": fuel_code_types,
+            "fuel_codes": fuel_codes,
+        }
+
+    @service_handler
+    async def update_step2(
+        self,
+        ci_application: CIApplication,
+        data: CIApplicationStep2Schema,
+        user: UserProfile,
+    ) -> CIApplicationSchema:
+        await self._validate_step2_payload(data)
+
+        new_rows: List[Pathway] = [
+            Pathway(
+                application_type_id=row.application_type_id,
+                fuel_code_type_id=row.fuel_code_type_id,
+                operating_data_from=row.operating_data_from,
+                operating_data_to=row.operating_data_to,
+                fuel_code_id=row.fuel_code_id,
+                proposed_ci=row.proposed_ci,
+                fuel_type_id=row.fuel_type_id,
+                feedstock=row.feedstock,
+                feedstock_region=row.feedstock_region,
+                feedstock_transport_mode=row.feedstock_transport_mode,
+                feedstock_transport_distance=row.feedstock_transport_distance,
+                coproducts=row.coproducts,
+                finished_fuel_transport_mode=row.finished_fuel_transport_mode,
+                finished_fuel_transport_distance=row.finished_fuel_transport_distance,
+                group_uuid=str(uuid.uuid4()),
+                version=0,
+                action_type=ActionTypeEnum.CREATE,
+                create_user=user.keycloak_username,
+                update_user=user.keycloak_username,
+            )
+            for row in data.pathways
+        ]
+
+        await self.repo.replace_pathways(
+            ci_application.ci_application_id, new_rows
+        )
+
+        ci_application.pathway_description = data.pathway_description
+        ci_application.update_user = user.keycloak_username
+        ci_application.action_type = ActionTypeEnum.UPDATE
+        await self.repo.update(ci_application)
+
+        ci = await self.repo.get_by_id(ci_application.ci_application_id)
+        return _to_full_schema(ci)

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -16,6 +16,10 @@ from fastapi import Depends, HTTPException, status
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models import UserProfile
 from lcfs.db.models.ci_application import CIApplication, Pathway
+from lcfs.db.models.ci_application.CIApplication import (
+    CI_DOC_CATEGORY_GHGENIUS_MODEL,
+    CI_DOC_CATEGORY_TECHNICAL_REPORT,
+)
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.web.api.base import (
     PaginationRequestSchema,
@@ -24,12 +28,14 @@ from lcfs.web.api.base import (
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 from lcfs.web.api.ci_application.schema import (
     CIApplicationBaseSchema,
+    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationStatusEnum,
     CIApplicationStatusSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
     CIApplicationStep2Schema,
+    CIApplicationStep3Schema,
     CITableOptionsSchema,
     FuelCodeOptionSchema,
     FuelTypeOptionSchema,
@@ -418,6 +424,68 @@ class CIApplicationServices:
         )
 
         ci_application.pathway_description = data.pathway_description
+        ci_application.update_user = user.keycloak_username
+        ci_application.action_type = ActionTypeEnum.UPDATE
+        await self.repo.update(ci_application)
+
+        ci = await self.repo.get_by_id(ci_application.ci_application_id)
+        return _to_full_schema(ci)
+
+    # ------------------------------------------------------------------
+    # Step 3 — Documents & GHGenius modelling
+    # ------------------------------------------------------------------
+
+    @service_handler
+    async def list_documents(
+        self, ci_application_id: int
+    ) -> List[CIApplicationDocumentSchema]:
+        """All Step 3 uploads for an application, with their categories."""
+        rows = await self.repo.get_documents_with_categories(ci_application_id)
+        return [
+            CIApplicationDocumentSchema(
+                document_id=document.document_id,
+                file_name=document.file_name,
+                file_size=document.file_size,
+                document_category=category,
+                create_date=(
+                    document.create_date.isoformat() if document.create_date else None
+                ),
+                create_user=document.create_user,
+            )
+            for document, category in rows
+        ]
+
+    @service_handler
+    async def update_step3(
+        self,
+        ci_application: CIApplication,
+        data: CIApplicationStep3Schema,
+        user: UserProfile,
+    ) -> CIApplicationSchema:
+        """
+        Persists the optional "other supporting" description and verifies
+        the mandatory uploads (Technical report + GHGenius model) are
+        present. Files are uploaded out-of-band via the generic document
+        endpoint with a category query param.
+        """
+        rows = await self.repo.get_documents_with_categories(
+            ci_application.ci_application_id
+        )
+        present_categories = {category for _, category in rows}
+        missing = []
+        if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
+            missing.append("Technical report")
+        if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
+            missing.append("GHGenius model")
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Missing required upload(s): " + ", ".join(missing) + "."
+                ),
+            )
+
+        ci_application.supporting_document_other = data.supporting_document_other
         ci_application.update_user = user.keycloak_username
         ci_application.action_type = ActionTypeEnum.UPDATE
         await self.repo.update(ci_application)

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -21,6 +21,7 @@ from lcfs.web.api.ci_application.schema import (
     CIApplicationSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
+    CIApplicationStep2Schema,
     CITableOptionsSchema,
 )
 from lcfs.web.api.ci_application.services import CIApplicationServices
@@ -174,11 +175,22 @@ def _not_implemented(step: str):
     )
 
 
-@router.put("/{ci_application_id}/step2", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.put(
+    "/{ci_application_id}/step2",
+    response_model=CIApplicationSchema,
+    status_code=status.HTTP_200_OK,
+)
 @view_handler([RoleEnum.CI_APPLICANT, RoleEnum.SIGNING_AUTHORITY])
-async def update_ci_application_step2(request: Request, ci_application_id: int):
-    """Step 2 — Proposed fuel pathways. To be implemented."""
-    return _not_implemented("Step 2 (Proposed fuel pathways)")
+async def update_ci_application_step2(
+    request: Request,
+    ci_application_id: int,
+    data: CIApplicationStep2Schema = Body(...),
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> CIApplicationSchema:
+    """Step 2 — Proposed fuel pathways. Replaces the entire pathway set."""
+    ci = await validate.validate_access(ci_application_id)
+    return await service.update_step2(ci, data, request.user)
 
 
 @router.put("/{ci_application_id}/step3", status_code=status.HTTP_501_NOT_IMPLEMENTED)

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -9,7 +9,7 @@ surface and OpenAPI contract are reserved while subsequent feature work
 fills them in.
 """
 
-from typing import List, Optional
+from typing import Optional
 
 import structlog
 from fastapi import APIRouter, Body, Depends, Request, status
@@ -18,7 +18,6 @@ from fastapi.responses import JSONResponse
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
-    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
@@ -193,23 +192,6 @@ async def update_ci_application_step2(
     """Step 2 — Proposed fuel pathways. Replaces the entire pathway set."""
     ci = await validate.validate_access(ci_application_id)
     return await service.update_step2(ci, data, request.user)
-
-
-@router.get(
-    "/{ci_application_id}/documents",
-    response_model=List[CIApplicationDocumentSchema],
-    status_code=status.HTTP_200_OK,
-)
-@view_handler(["*"])
-async def list_ci_application_documents(
-    request: Request,
-    ci_application_id: int,
-    service: CIApplicationServices = Depends(),
-    validate: CIApplicationValidation = Depends(),
-) -> List[CIApplicationDocumentSchema]:
-    """List Step 3 uploads with their categories."""
-    await validate.validate_access(ci_application_id)
-    return await service.list_documents(ci_application_id)
 
 
 @router.put(

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -9,7 +9,7 @@ surface and OpenAPI contract are reserved while subsequent feature work
 fills them in.
 """
 
-from typing import Optional
+from typing import List, Optional
 
 import structlog
 from fastapi import APIRouter, Body, Depends, Request, status
@@ -18,10 +18,12 @@ from fastapi.responses import JSONResponse
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
+    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
     CIApplicationStep2Schema,
+    CIApplicationStep3Schema,
     CITableOptionsSchema,
 )
 from lcfs.web.api.ci_application.services import CIApplicationServices
@@ -193,11 +195,39 @@ async def update_ci_application_step2(
     return await service.update_step2(ci, data, request.user)
 
 
-@router.put("/{ci_application_id}/step3", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.get(
+    "/{ci_application_id}/documents",
+    response_model=List[CIApplicationDocumentSchema],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(["*"])
+async def list_ci_application_documents(
+    request: Request,
+    ci_application_id: int,
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> List[CIApplicationDocumentSchema]:
+    """List Step 3 uploads with their categories."""
+    await validate.validate_access(ci_application_id)
+    return await service.list_documents(ci_application_id)
+
+
+@router.put(
+    "/{ci_application_id}/step3",
+    response_model=CIApplicationSchema,
+    status_code=status.HTTP_200_OK,
+)
 @view_handler([RoleEnum.CI_APPLICANT, RoleEnum.SIGNING_AUTHORITY])
-async def update_ci_application_step3(request: Request, ci_application_id: int):
-    """Step 3 — Documents & GHGenius modelling. To be implemented."""
-    return _not_implemented("Step 3 (Documents & GHGenius modelling)")
+async def update_ci_application_step3(
+    request: Request,
+    ci_application_id: int,
+    data: CIApplicationStep3Schema = Body(...),
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> CIApplicationSchema:
+    """Step 3 — Documents & GHGenius modelling. Validates required uploads."""
+    ci = await validate.validate_access(ci_application_id)
+    return await service.update_step3(ci, data, request.user)
 
 
 @router.post(

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -1,13 +1,14 @@
 from http.client import HTTPException
 from lcfs.web.api.admin_adjustment.validation import AdminAdjustmentValidation
 import structlog
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Request, UploadFile
+from fastapi import APIRouter, Depends, Query, Request, UploadFile
 from fastapi.params import File
 from starlette import status
 from starlette.responses import StreamingResponse
 
+from lcfs.db.dependencies import get_async_db_session
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.services.s3.client import DocumentService
 from lcfs.services.s3.schema import FileResponseSchema
@@ -15,6 +16,29 @@ from lcfs.web.api.compliance_report.validation import ComplianceReportValidation
 from lcfs.web.api.initiative_agreement.validation import InitiativeAgreementValidation
 from lcfs.web.api.charging_site.validation import ChargingSiteValidation
 from lcfs.web.core.decorators import view_handler
+
+
+# Lazy-resolved CI validation: see note inside ``ci_application_validator``.
+async def ci_application_validator(
+    request: Request,
+    db=Depends(get_async_db_session),
+):
+    """
+    Resolve a CIApplicationValidation instance on-demand.
+
+    Eagerly importing CIApplicationValidation at module load reaches
+    the ci_application repo, which transitively re-enters this module
+    via ``Document -> compliance_report -> s3.client``. Doing the
+    import inside the request scope breaks that cycle and keeps
+    FastAPI's DI behaviour intact.
+    """
+    from lcfs.web.api.ci_application.repo import CIApplicationRepository
+    from lcfs.web.api.ci_application.validation import CIApplicationValidation
+
+    return CIApplicationValidation(
+        request=request, repo=CIApplicationRepository(db=db)
+    )
+
 
 router = APIRouter()
 logger = structlog.get_logger(__name__)
@@ -51,11 +75,19 @@ async def upload_file(
     parent_id: int,
     parent_type: str,
     file: UploadFile = File(...),
+    document_category: Optional[str] = Query(
+        None,
+        description=(
+            "Optional Step 3 categorisation for ci_application uploads: "
+            "'technical_report', 'ghgenius_model', or 'supporting'."
+        ),
+    ),
     document_service: DocumentService = Depends(),
     cr_validate: ComplianceReportValidation = Depends(),
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ) -> FileResponseSchema:
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -69,8 +101,15 @@ async def upload_file(
     if parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
 
+    if parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
+
     document = await document_service.upload_file(
-        file, parent_id, parent_type, request.user
+        file,
+        parent_id,
+        parent_type,
+        request.user,
+        document_category=document_category,
     )
     return FileResponseSchema.model_validate(document)
 
@@ -89,6 +128,7 @@ async def stream_document(
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ):
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -101,6 +141,9 @@ async def stream_document(
 
     if parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
+
+    if parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
 
     file, document = await document_service.get_object(document_id)
 
@@ -127,6 +170,7 @@ async def delete_file(
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ):
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -136,6 +180,8 @@ async def delete_file(
         await aa_validate.validate_organization_access(parent_id)
     elif parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
+    elif parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
     else:
         raise HTTPException(403, "Unable to verify authorization for document download")
 

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -38,6 +38,31 @@
       "uomRequired": "Unit of measure is required."
     }
   },
+  "step2": {
+    "title": "Proposed fuel pathways",
+    "saveAndProceed": "Save & proceed",
+    "saveSuccess": "Proposed fuel pathways saved.",
+    "action": "Action",
+    "applicationType": "Application type",
+    "proposedFuelCodeType": "Proposed fuel code type",
+    "operatingDataFrom": "Operating data collection from",
+    "operatingDataTo": "Operating data collection to",
+    "fuelCodeIteration": "Fuel code iteration",
+    "proposedCi": "Proposed CI (gCO2e/MJ)",
+    "fuelType": "Fuel type",
+    "feedstock": "Feedstock",
+    "feedstockRegion": "Feedstock region",
+    "feedstockTransportMode": "Feedstock transport mode",
+    "feedstockTransportDistance": "Feedstock transport distance (km)",
+    "coproducts": "Co-products",
+    "finishedFuelTransportMode": "Finished fuel transport mode",
+    "finishedFuelTransportDistance": "Finished fuel transport distance (km)",
+    "descriptionLabel": "Description of distinctive or unique characteristics of the fuel pathway(s) included in this application",
+    "descriptionHelp": "e.g. use of carbon capture and sequestration (CCS), novel energy sources for fuel production, upgrades made to facility (for fuel code renewal applications), etc.",
+    "validation": {
+      "atLeastOneRow": "At least one pathway is required."
+    }
+  },
   "stepStub": {
     "comingSoon": "This step is not yet available.",
     "description": "This part of the workflow will be implemented in a future task. The accordion above keeps your place in the wizard."

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -63,6 +63,36 @@
       "atLeastOneRow": "At least one pathway is required."
     }
   },
+  "step3": {
+    "title": "Documents & GHGenius modelling",
+    "uploadedHeader": "Uploaded documents for application",
+    "noDocuments": "No documents uploaded yet.",
+    "supportingHeader": "Supporting documentation",
+    "uploadSupporting": "Upload supporting documentation",
+    "categoryTechnicalReport": "Technical report (required)",
+    "categorySupporting": "Other supporting document",
+    "notUploaded": "(not uploaded)",
+    "bullets": {
+      "technicalReport": "Technical report (required)",
+      "notification": "Notification of representation agreement form (optional, required if applicable)",
+      "other": "Other supporting documents — describe below (optional)"
+    },
+    "otherPlaceholder": "Brief description of other supporting documentation included",
+    "ghgeniusHeader": "GHGenius Modelling — Input & output tables",
+    "ghgeniusIntro": "Download the Excel template below and complete it with the required modelling input and output tables. When completed, upload the Excel spreadsheet.",
+    "uploadGHGenius": "Upload GHGenius model",
+    "downloadTemplate": "Download GHGenius Excel template",
+    "ghgeniusRequired": "GHGenius model upload is required.",
+    "saveAndProceed": "Save & proceed",
+    "saveSuccess": "Documents saved.",
+    "errors": {
+      "tooLarge": "File exceeds the 50 MB limit.",
+      "unsupportedType": "Unsupported file type. Allowed: PDF, Word, Excel, CSV, plain text, PNG, JPEG.",
+      "uploadFailed": "Upload failed.",
+      "deleteFailed": "Delete failed.",
+      "missingRequired": "Technical report and GHGenius model uploads are required."
+    }
+  },
   "stepStub": {
     "comingSoon": "This step is not yet available.",
     "description": "This part of the workflow will be implemented in a future task. The accordion above keeps your place in the wizard."

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -87,6 +87,7 @@ export const apiRoutes = {
   submitCIApplication: '/ci-applications/:ciApplicationId/submit',
   ciApplicationDecision: '/ci-applications/:ciApplicationId/decision',
   deleteCIApplication: '/ci-applications/:ciApplicationId',
+  ciApplicationDocuments: '/ci-applications/:ciApplicationId/documents',
 
   // reports
   getCompliancePeriods: '/reports/compliance-periods',

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -87,7 +87,6 @@ export const apiRoutes = {
   submitCIApplication: '/ci-applications/:ciApplicationId/submit',
   ciApplicationDecision: '/ci-applications/:ciApplicationId/decision',
   deleteCIApplication: '/ci-applications/:ciApplicationId',
-  ciApplicationDocuments: '/ci-applications/:ciApplicationId/documents',
 
   // reports
   getCompliancePeriods: '/reports/compliance-periods',

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -121,6 +121,90 @@ export const useUpdateCIApplicationStep2 = (ciApplicationId) => {
   })
 }
 
+export const useUpdateCIApplicationStep3 = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload) => {
+      return (
+        await client.put(
+          apiRoutes.updateCIApplicationStep3.replace(
+            ':ciApplicationId',
+            ciApplicationId
+          ),
+          payload
+        )
+      ).data
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ci-applications'] })
+      queryClient.setQueryData(QUERY_KEYS.detail(ciApplicationId), data)
+    }
+  })
+}
+
+export const useGetCIApplicationDocuments = (ciApplicationId, options) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!ciApplicationId,
+    queryKey: ['ci-application-documents', String(ciApplicationId)],
+    queryFn: async () => {
+      return (
+        await client.get(
+          apiRoutes.ciApplicationDocuments.replace(
+            ':ciApplicationId',
+            ciApplicationId
+          )
+        )
+      ).data
+    },
+    staleTime: 30 * 1000,
+    ...options
+  })
+}
+
+export const useUploadCIApplicationDocument = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ file, documentCategory }) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('filename', file.name)
+      const path = `/documents/ci_application/${ciApplicationId}`
+      return (
+        await client.post(path, formData, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          params: documentCategory
+            ? { document_category: documentCategory }
+            : undefined
+        })
+      ).data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['ci-application-documents', String(ciApplicationId)]
+      })
+    }
+  })
+}
+
+export const useDeleteCIApplicationDocument = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (documentId) => {
+      const path = `/documents/ci_application/${ciApplicationId}/${documentId}`
+      return (await client.delete(path)).data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['ci-application-documents', String(ciApplicationId)]
+      })
+    }
+  })
+}
+
 export const useDeleteCIApplication = () => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -99,6 +99,28 @@ export const useUpdateCIApplicationStep1 = (ciApplicationId) => {
   })
 }
 
+export const useUpdateCIApplicationStep2 = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload) => {
+      return (
+        await client.put(
+          apiRoutes.updateCIApplicationStep2.replace(
+            ':ciApplicationId',
+            ciApplicationId
+          ),
+          payload
+        )
+      ).data
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ci-applications'] })
+      queryClient.setQueryData(QUERY_KEYS.detail(ciApplicationId), data)
+    }
+  })
+}
+
 export const useDeleteCIApplication = () => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -143,68 +143,6 @@ export const useUpdateCIApplicationStep3 = (ciApplicationId) => {
   })
 }
 
-export const useGetCIApplicationDocuments = (ciApplicationId, options) => {
-  const client = useApiService()
-  return useQuery({
-    enabled: !!ciApplicationId,
-    queryKey: ['ci-application-documents', String(ciApplicationId)],
-    queryFn: async () => {
-      return (
-        await client.get(
-          apiRoutes.ciApplicationDocuments.replace(
-            ':ciApplicationId',
-            ciApplicationId
-          )
-        )
-      ).data
-    },
-    staleTime: 30 * 1000,
-    ...options
-  })
-}
-
-export const useUploadCIApplicationDocument = (ciApplicationId) => {
-  const client = useApiService()
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async ({ file, documentCategory }) => {
-      const formData = new FormData()
-      formData.append('file', file)
-      formData.append('filename', file.name)
-      const path = `/documents/ci_application/${ciApplicationId}`
-      return (
-        await client.post(path, formData, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-          params: documentCategory
-            ? { document_category: documentCategory }
-            : undefined
-        })
-      ).data
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['ci-application-documents', String(ciApplicationId)]
-      })
-    }
-  })
-}
-
-export const useDeleteCIApplicationDocument = (ciApplicationId) => {
-  const client = useApiService()
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (documentId) => {
-      const path = `/documents/ci_application/${ciApplicationId}/${documentId}`
-      return (await client.delete(path)).data
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['ci-application-documents', String(ciApplicationId)]
-      })
-    }
-  })
-}
-
 export const useDeleteCIApplication = () => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/hooks/useDocuments.js
+++ b/frontend/src/hooks/useDocuments.js
@@ -54,7 +54,16 @@ export const useUploadDocument = (parentType, parentID, options = {}) => {
   } = options
 
   return useMutation({
-    mutationFn: async (file) => {
+    mutationFn: async (input) => {
+      // Backwards compatible: callers can either pass a File directly
+      // (legacy signature) or a { file, documentCategory } object so
+      // CI applications can route uploads to a specific category bucket
+      // (technical_report / ghgenius_model / supporting).
+      const { file, documentCategory } =
+        input instanceof File || input instanceof Blob
+          ? { file: input, documentCategory: undefined }
+          : input || {}
+
       if (!file) {
         throw new Error('File is required for upload')
       }
@@ -74,6 +83,9 @@ export const useUploadDocument = (parentType, parentID, options = {}) => {
         headers: {
           'Content-Type': 'multipart/form-data'
         },
+        params: documentCategory
+          ? { document_category: documentCategory }
+          : undefined,
         onUploadProgress: onUploadProgress
       })
     },

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -25,7 +25,8 @@ import {
   useDeleteCIApplication,
   useGetCIApplication,
   useUpdateCIApplicationStep1,
-  useUpdateCIApplicationStep2
+  useUpdateCIApplicationStep2,
+  useUpdateCIApplicationStep3
 } from '@/hooks/useCIApplication'
 
 import {
@@ -34,6 +35,7 @@ import {
 } from './components/CIApplicationProgress'
 import { ApplicationInformationStep } from './components/ApplicationInformationStep'
 import { ProposedFuelPathwaysStep } from './components/ProposedFuelPathwaysStep'
+import { DocumentsModellingStep } from './components/DocumentsModellingStep'
 import { StepStub } from './components/StepStub'
 import { FuelCodesTabs } from './components/FuelCodesTabs'
 
@@ -63,10 +65,13 @@ const EditViewCIApplicationBase = () => {
     useUpdateCIApplicationStep1(ciApplicationId)
   const { mutateAsync: updateStep2, isPending: isUpdatingStep2 } =
     useUpdateCIApplicationStep2(ciApplicationId)
+  const { mutateAsync: updateStep3, isPending: isUpdatingStep3 } =
+    useUpdateCIApplicationStep3(ciApplicationId)
   const { mutateAsync: deleteDraft, isPending: isDeleting } =
     useDeleteCIApplication()
 
-  const isSaving = isCreating || isUpdating || isUpdatingStep2
+  const isSaving =
+    isCreating || isUpdating || isUpdatingStep2 || isUpdatingStep3
 
   const handleAccordionToggle = (key) => (_, isOpen) => {
     setExpanded((prev) =>
@@ -82,6 +87,28 @@ const EditViewCIApplicationBase = () => {
       window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [])
+
+  const handleStep3Save = useCallback(
+    async (payload) => {
+      try {
+        await updateStep3(payload)
+        alertRef.current?.triggerAlert?.({
+          message: t('carbonIntensity:step3.saveSuccess'),
+          severity: 'success'
+        })
+        goToStep(3)
+      } catch (err) {
+        alertRef.current?.triggerAlert?.({
+          message:
+            err?.response?.data?.detail ||
+            err?.message ||
+            'Failed to save Step 3.',
+          severity: 'error'
+        })
+      }
+    },
+    [updateStep3, goToStep, t]
+  )
 
   const handleStep2Save = useCallback(
     async (payload) => {
@@ -226,7 +253,16 @@ const EditViewCIApplicationBase = () => {
     ) : (
       <StepStub titleKey="carbonIntensity:steps.step2" />
     ),
-    step3: <StepStub titleKey="carbonIntensity:steps.step3" />,
+    step3: ciApplicationId ? (
+      <DocumentsModellingStep
+        ciApplication={ciApplication}
+        onSave={handleStep3Save}
+        onDelete={canDelete ? openDeleteConfirmation : null}
+        isSaving={isSaving || isDeleting}
+      />
+    ) : (
+      <StepStub titleKey="carbonIntensity:steps.step3" />
+    ),
     step4: <StepStub titleKey="carbonIntensity:steps.step4" />,
     step5: <StepStub titleKey="carbonIntensity:steps.step5" />
   }

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -24,7 +24,8 @@ import {
   useCreateCIApplication,
   useDeleteCIApplication,
   useGetCIApplication,
-  useUpdateCIApplicationStep1
+  useUpdateCIApplicationStep1,
+  useUpdateCIApplicationStep2
 } from '@/hooks/useCIApplication'
 
 import {
@@ -32,6 +33,7 @@ import {
   CIApplicationProgress
 } from './components/CIApplicationProgress'
 import { ApplicationInformationStep } from './components/ApplicationInformationStep'
+import { ProposedFuelPathwaysStep } from './components/ProposedFuelPathwaysStep'
 import { StepStub } from './components/StepStub'
 import { FuelCodesTabs } from './components/FuelCodesTabs'
 
@@ -59,10 +61,12 @@ const EditViewCIApplicationBase = () => {
     useCreateCIApplication()
   const { mutateAsync: updateStep1, isPending: isUpdating } =
     useUpdateCIApplicationStep1(ciApplicationId)
+  const { mutateAsync: updateStep2, isPending: isUpdatingStep2 } =
+    useUpdateCIApplicationStep2(ciApplicationId)
   const { mutateAsync: deleteDraft, isPending: isDeleting } =
     useDeleteCIApplication()
 
-  const isSaving = isCreating || isUpdating
+  const isSaving = isCreating || isUpdating || isUpdatingStep2
 
   const handleAccordionToggle = (key) => (_, isOpen) => {
     setExpanded((prev) =>
@@ -78,6 +82,28 @@ const EditViewCIApplicationBase = () => {
       window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [])
+
+  const handleStep2Save = useCallback(
+    async (payload) => {
+      try {
+        await updateStep2(payload)
+        alertRef.current?.triggerAlert?.({
+          message: t('carbonIntensity:step2.saveSuccess'),
+          severity: 'success'
+        })
+        goToStep(2)
+      } catch (err) {
+        alertRef.current?.triggerAlert?.({
+          message:
+            err?.response?.data?.detail ||
+            err?.message ||
+            'Failed to save proposed fuel pathways.',
+          severity: 'error'
+        })
+      }
+    },
+    [updateStep2, goToStep, t]
+  )
 
   const handleStep1Save = useCallback(
     async (payload) => {
@@ -189,7 +215,17 @@ const EditViewCIApplicationBase = () => {
         isSaving={isSaving || isDeleting}
       />
     ),
-    step2: <StepStub titleKey="carbonIntensity:steps.step2" />,
+    step2: ciApplicationId ? (
+      <ProposedFuelPathwaysStep
+        ciApplication={ciApplication}
+        optionsData={tableOptions}
+        onSave={handleStep2Save}
+        onDelete={canDelete ? openDeleteConfirmation : null}
+        isSaving={isSaving || isDeleting}
+      />
+    ) : (
+      <StepStub titleKey="carbonIntensity:steps.step2" />
+    ),
     step3: <StepStub titleKey="carbonIntensity:steps.step3" />,
     step4: <StepStub titleKey="carbonIntensity:steps.step4" />,
     step5: <StepStub titleKey="carbonIntensity:steps.step5" />

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -26,16 +26,13 @@ let mockDocs = []
 const mockUpload = vi.fn().mockResolvedValue({})
 const mockDelete = vi.fn().mockResolvedValue({})
 
-vi.mock('@/hooks/useCIApplication', () => ({
-  useGetCIApplicationDocuments: vi.fn(() => ({
-    data: mockDocs,
-    isLoading: false
-  })),
-  useUploadCIApplicationDocument: vi.fn(() => ({
+vi.mock('@/hooks/useDocuments', () => ({
+  useDocuments: vi.fn(() => ({ data: mockDocs, isLoading: false })),
+  useUploadDocument: vi.fn(() => ({
     mutateAsync: mockUpload,
     isPending: false
   })),
-  useDeleteCIApplicationDocument: vi.fn(() => ({
+  useDeleteDocument: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
   }))
@@ -146,10 +143,9 @@ describe('DocumentsModellingStep', () => {
     fireEvent.change(screen.getByTestId('ci-step3-supporting-input'), {
       target: { files: [file] }
     })
+    // Shared validateFile utility surfaces "File type ... is not allowed".
     await waitFor(() =>
-      expect(
-        screen.getByText('carbonIntensity:step3.errors.unsupportedType')
-      ).toBeInTheDocument()
+      expect(screen.getByText(/is not allowed/i)).toBeInTheDocument()
     )
     expect(mockUpload).not.toHaveBeenCalled()
   })

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+
+import { DocumentsModellingStep } from '@/views/CarbonIntensity/components/DocumentsModellingStep'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+let mockDocs = []
+const mockUpload = vi.fn().mockResolvedValue({})
+const mockDelete = vi.fn().mockResolvedValue({})
+
+vi.mock('@/hooks/useCIApplication', () => ({
+  useGetCIApplicationDocuments: vi.fn(() => ({
+    data: mockDocs,
+    isLoading: false
+  })),
+  useUploadCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: mockUpload,
+    isPending: false
+  })),
+  useDeleteCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: mockDelete,
+    isPending: false
+  }))
+}))
+
+const baseCi = { ciApplicationId: 99, supportingDocumentOther: '' }
+
+describe('DocumentsModellingStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDocs = []
+  })
+  afterEach(cleanup)
+
+  it('renders the upload sections, description input, and Save button', () => {
+    render(
+      <DocumentsModellingStep
+        ciApplication={baseCi}
+        onSave={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(
+      screen.getByTestId('ci-step3-upload-supporting')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-upload-ghgenius')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('ci-step3-download-template')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('ci-step3-other-description')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-save-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-delete-btn')).toBeInTheDocument()
+  })
+
+  it('disables Save & proceed until both required uploads are present', () => {
+    mockDocs = [
+      { documentId: 1, fileName: 'x.pdf', fileSize: 100, documentCategory: 'technical_report' }
+    ]
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    expect(screen.getByTestId('ci-step3-save-btn')).toBeDisabled()
+  })
+
+  it('enables Save & proceed and submits when both required uploads exist', async () => {
+    mockDocs = [
+      { documentId: 1, fileName: 'tech.pdf', fileSize: 100, documentCategory: 'technical_report' },
+      { documentId: 2, fileName: 'model.xlsx', fileSize: 200, documentCategory: 'ghgenius_model' }
+    ]
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <DocumentsModellingStep
+        ciApplication={{ ...baseCi, supportingDocumentOther: 'CCS notes' }}
+        onSave={onSave}
+      />,
+      { wrapper }
+    )
+    const btn = screen.getByTestId('ci-step3-save-btn')
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    expect(onSave.mock.calls[0][0].supportingDocumentOther).toBe('CCS notes')
+  })
+
+  it('uploads a chosen file with the selected supporting category', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'tech.pdf', { type: 'application/pdf' })
+    const input = screen.getByTestId('ci-step3-supporting-input')
+    fireEvent.change(input, { target: { files: [file] } })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
+      'technical_report'
+    )
+  })
+
+  it('uploads a GHGenius file with category ghgenius_model', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'model.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    })
+    fireEvent.change(screen.getByTestId('ci-step3-ghgenius-input'), {
+      target: { files: [file] }
+    })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
+      'ghgenius_model'
+    )
+  })
+
+  it('rejects an unsupported file type without calling upload', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'bad.exe', {
+      type: 'application/x-msdownload'
+    })
+    fireEvent.change(screen.getByTestId('ci-step3-supporting-input'), {
+      target: { files: [file] }
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText('carbonIntensity:step3.errors.unsupportedType')
+      ).toBeInTheDocument()
+    )
+    expect(mockUpload).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -78,11 +78,22 @@ vi.mock('@/hooks/useCIApplication', () => ({
     mutateAsync: mockUpdate,
     isPending: false
   })),
+  useUpdateCIApplicationStep2: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
+    isPending: false
+  })),
   useDeleteCIApplication: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
   }))
 }))
+
+vi.mock(
+  '@/views/CarbonIntensity/components/ProposedFuelPathwaysStep',
+  () => ({
+    ProposedFuelPathwaysStep: () => <div data-test="step2-stub" />
+  })
+)
 
 // Stub the heavy step component so we can drive its props directly.
 vi.mock(

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -86,15 +86,6 @@ vi.mock('@/hooks/useCIApplication', () => ({
     mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
     isPending: false
   })),
-  useGetCIApplicationDocuments: vi.fn(() => ({ data: [], isLoading: false })),
-  useUploadCIApplicationDocument: vi.fn(() => ({
-    mutateAsync: vi.fn(),
-    isPending: false
-  })),
-  useDeleteCIApplicationDocument: vi.fn(() => ({
-    mutateAsync: vi.fn(),
-    isPending: false
-  })),
   useDeleteCIApplication: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -82,11 +82,31 @@ vi.mock('@/hooks/useCIApplication', () => ({
     mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
     isPending: false
   })),
+  useUpdateCIApplicationStep3: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
+    isPending: false
+  })),
+  useGetCIApplicationDocuments: vi.fn(() => ({ data: [], isLoading: false })),
+  useUploadCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false
+  })),
+  useDeleteCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false
+  })),
   useDeleteCIApplication: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
   }))
 }))
+
+vi.mock(
+  '@/views/CarbonIntensity/components/DocumentsModellingStep',
+  () => ({
+    DocumentsModellingStep: () => <div data-test="step3-stub" />
+  })
+)
 
 vi.mock(
   '@/views/CarbonIntensity/components/ProposedFuelPathwaysStep',

--- a/frontend/src/views/CarbonIntensity/__tests__/ProposedFuelPathwaysStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/ProposedFuelPathwaysStep.test.jsx
@@ -1,0 +1,176 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { ProposedFuelPathwaysStep } from '@/views/CarbonIntensity/components/ProposedFuelPathwaysStep'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+// BCGridEditor pulls in AG Grid which is heavy and not relevant to this
+// component's contract. Stub it out so we can drive its callbacks
+// directly from the test.
+let lastGridProps = null
+vi.mock('@/components/BCDataGrid/BCGridEditor', () => ({
+  BCGridEditor: (props) => {
+    lastGridProps = props
+    if (props.gridRef) {
+      props.gridRef.current = {
+        api: {
+          forEachNode: (cb) =>
+            (props.rowData || []).forEach((data) => cb({ data })),
+          applyTransaction: vi.fn(),
+          refreshCells: vi.fn()
+        }
+      }
+    }
+    return <div data-test="grid-stub" />
+  }
+}))
+
+const optionsData = {
+  pathwayApplicationTypes: [
+    { pathwayApplicationTypeId: 1, type: 'New' },
+    { pathwayApplicationTypeId: 2, type: 'Renewal' }
+  ],
+  pathwayFuelCodeTypes: [
+    { pathwayFuelCodeTypeId: 1, type: '1-year provisional' }
+  ],
+  fuelTypes: [{ fuelTypeId: 1, fuelType: 'Biodiesel' }],
+  transportModes: ['Truck', 'Rail'],
+  fuelCodes: [
+    {
+      fuelCodeId: 42,
+      fuelCode: 'C-BCLCF100.4',
+      carbonIntensity: 23.23,
+      fuelTypeId: 1,
+      fuelType: 'Biodiesel',
+      feedstock: 'Corn',
+      feedstockLocation: 'Ontario'
+    }
+  ]
+}
+
+const baseCi = {
+  ciApplicationId: 99,
+  pathways: [],
+  pathwayDescription: ''
+}
+
+describe('ProposedFuelPathwaysStep', () => {
+  beforeEach(() => {
+    lastGridProps = null
+    vi.clearAllMocks()
+  })
+  afterEach(cleanup)
+
+  it('renders the grid, description, and action buttons', () => {
+    render(
+      <ProposedFuelPathwaysStep
+        ciApplication={baseCi}
+        optionsData={optionsData}
+        onSave={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByTestId('grid-stub')).toBeInTheDocument()
+    expect(screen.getByTestId('pathwayDescription')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step2-save-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step2-delete-btn')).toBeInTheDocument()
+  })
+
+  it('blocks save and surfaces validation errors when rows are incomplete', async () => {
+    const onSave = vi.fn()
+    render(
+      <ProposedFuelPathwaysStep
+        ciApplication={baseCi}
+        optionsData={optionsData}
+        onSave={onSave}
+      />,
+      { wrapper }
+    )
+    fireEvent.click(screen.getByTestId('ci-step2-save-btn'))
+    await waitFor(() => expect(onSave).not.toHaveBeenCalled())
+  })
+
+  it('submits a valid payload when all required fields are present', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const ciWithCompleteRow = {
+      ...baseCi,
+      pathways: [
+        {
+          pathwayId: 1,
+          applicationTypeId: 1,
+          fuelCodeTypeId: 1,
+          operatingDataFrom: '2025-01-01',
+          operatingDataTo: '2025-12-31',
+          fuelCodeId: null,
+          proposedCi: 5.61,
+          fuelTypeId: 1,
+          feedstock: 'Canola',
+          feedstockRegion: 'Saskatchewan',
+          feedstockTransportMode: 'Truck',
+          feedstockTransportDistance: 100,
+          coproducts: null,
+          finishedFuelTransportMode: 'Rail',
+          finishedFuelTransportDistance: 200
+        }
+      ],
+      pathwayDescription: 'Uses CCS'
+    }
+    render(
+      <ProposedFuelPathwaysStep
+        ciApplication={ciWithCompleteRow}
+        optionsData={optionsData}
+        onSave={onSave}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('ci-step2-save-btn'))
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    const payload = onSave.mock.calls[0][0]
+    expect(payload.pathways).toHaveLength(1)
+    expect(payload.pathways[0].applicationTypeId).toBe(1)
+    expect(payload.pathwayDescription).toBe('Uses CCS')
+  })
+
+  it('rejects a Renewal row that is missing the fuel code iteration', async () => {
+    const onSave = vi.fn()
+    const renewalMissingFuelCode = {
+      ...baseCi,
+      pathways: [
+        {
+          pathwayId: 2,
+          applicationTypeId: 2,
+          fuelCodeTypeId: 1,
+          operatingDataFrom: '2025-01-01',
+          operatingDataTo: '2025-12-31',
+          fuelCodeId: null,
+          proposedCi: 23.23,
+          fuelTypeId: 1,
+          feedstock: 'Corn',
+          feedstockRegion: 'Ontario',
+          feedstockTransportMode: 'Truck',
+          feedstockTransportDistance: 50,
+          coproducts: null,
+          finishedFuelTransportMode: 'Rail',
+          finishedFuelTransportDistance: 75
+        }
+      ]
+    }
+    render(
+      <ProposedFuelPathwaysStep
+        ciApplication={renewalMissingFuelCode}
+        optionsData={optionsData}
+        onSave={onSave}
+      />,
+      { wrapper }
+    )
+    fireEvent.click(screen.getByTestId('ci-step2-save-btn'))
+    await waitFor(() => expect(onSave).not.toHaveBeenCalled())
+  })
+})

--- a/frontend/src/views/CarbonIntensity/__tests__/step2Schema.test.js
+++ b/frontend/src/views/CarbonIntensity/__tests__/step2Schema.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  apiToRow,
+  isRenewalRow,
+  rowToApiPayload,
+  validatePathwayRow
+} from '@/views/CarbonIntensity/components/_step2Schema'
+
+const APPLICATION_TYPES = [
+  { pathwayApplicationTypeId: 1, type: 'New' },
+  { pathwayApplicationTypeId: 2, type: 'Renewal' }
+]
+
+const validRow = {
+  id: 'r1',
+  pathwayId: null,
+  applicationTypeId: 1,
+  fuelCodeTypeId: 1,
+  operatingDataFrom: '2025-01-01',
+  operatingDataTo: '2025-12-31',
+  fuelCodeId: null,
+  proposedCi: 5.61,
+  fuelTypeId: 1,
+  feedstock: 'Canola',
+  feedstockRegion: 'Saskatchewan',
+  feedstockTransportMode: 'Truck',
+  feedstockTransportDistance: 100,
+  coproducts: '',
+  finishedFuelTransportMode: 'Rail',
+  finishedFuelTransportDistance: 200
+}
+
+describe('isRenewalRow', () => {
+  it('returns true when application type matches Renewal', () => {
+    expect(
+      isRenewalRow({ applicationTypeId: 2 }, APPLICATION_TYPES)
+    ).toBe(true)
+  })
+  it('returns false for New rows', () => {
+    expect(
+      isRenewalRow({ applicationTypeId: 1 }, APPLICATION_TYPES)
+    ).toBe(false)
+  })
+  it('returns false for unset rows', () => {
+    expect(isRenewalRow({}, APPLICATION_TYPES)).toBe(false)
+  })
+})
+
+describe('validatePathwayRow', () => {
+  it('returns no errors for a complete New row', () => {
+    expect(validatePathwayRow(validRow, APPLICATION_TYPES)).toEqual([])
+  })
+
+  it('flags every required field on an empty row', () => {
+    const errs = validatePathwayRow(
+      { id: 'x', applicationTypeId: 1 },
+      APPLICATION_TYPES
+    )
+    expect(errs).toContain('fuelCodeTypeId')
+    expect(errs).toContain('operatingDataFrom')
+    expect(errs).toContain('operatingDataTo')
+    expect(errs).toContain('proposedCi')
+    expect(errs).toContain('fuelTypeId')
+    expect(errs).toContain('feedstock')
+    expect(errs).toContain('feedstockRegion')
+    expect(errs).toContain('feedstockTransportMode')
+    expect(errs).toContain('finishedFuelTransportMode')
+  })
+
+  it('requires fuelCodeId on Renewal rows', () => {
+    const renewal = { ...validRow, applicationTypeId: 2, fuelCodeId: null }
+    expect(validatePathwayRow(renewal, APPLICATION_TYPES)).toContain('fuelCodeId')
+  })
+
+  it('does not require fuelCodeId on New rows', () => {
+    expect(validatePathwayRow(validRow, APPLICATION_TYPES)).not.toContain(
+      'fuelCodeId'
+    )
+  })
+
+  it('flags inverted operating dates', () => {
+    const inverted = {
+      ...validRow,
+      operatingDataFrom: '2025-12-31',
+      operatingDataTo: '2025-01-01'
+    }
+    expect(validatePathwayRow(inverted, APPLICATION_TYPES)).toContain(
+      'operatingDataTo'
+    )
+  })
+})
+
+describe('rowToApiPayload', () => {
+  it('coerces numeric fields and strips empty coproducts', () => {
+    const payload = rowToApiPayload({
+      ...validRow,
+      proposedCi: '5.61',
+      feedstockTransportDistance: '100',
+      finishedFuelTransportDistance: '200',
+      coproducts: '   '
+    })
+    expect(payload.proposedCi).toBe(5.61)
+    expect(payload.feedstockTransportDistance).toBe(100)
+    expect(payload.finishedFuelTransportDistance).toBe(200)
+    expect(payload.coproducts).toBeNull()
+  })
+
+  it('passes through fuelCodeId for renewals', () => {
+    const payload = rowToApiPayload({ ...validRow, fuelCodeId: 99 })
+    expect(payload.fuelCodeId).toBe(99)
+  })
+})
+
+describe('apiToRow', () => {
+  it('maps a server pathway back to grid shape', () => {
+    const row = apiToRow({
+      pathwayId: 7,
+      applicationTypeId: 2,
+      fuelCodeTypeId: 1,
+      operatingDataFrom: '2025-01-01',
+      operatingDataTo: '2025-12-31',
+      fuelCodeId: 42,
+      proposedCi: '23.23',
+      fuelTypeId: 1,
+      feedstock: 'Corn',
+      feedstockRegion: 'Ontario',
+      feedstockTransportMode: 'Truck',
+      feedstockTransportDistance: 50,
+      coproducts: null,
+      finishedFuelTransportMode: 'Rail',
+      finishedFuelTransportDistance: 75
+    })
+    expect(row.pathwayId).toBe(7)
+    expect(row.proposedCi).toBe(23.23)
+    expect(row.id).toBe('pathway-7')
+  })
+})

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -19,30 +19,23 @@ import BCAlert from '@/components/BCAlert'
 import BCButton from '@/components/BCButton'
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
-import colors from '@/themes/base/colors'
 import {
-  useDeleteCIApplicationDocument,
-  useGetCIApplicationDocuments,
-  useUploadCIApplicationDocument
-} from '@/hooks/useCIApplication'
+  COMPLIANCE_REPORT_FILE_TYPES,
+  MAX_FILE_SIZE_BYTES
+} from '@/constants/common'
+import {
+  useDeleteDocument,
+  useDocuments,
+  useUploadDocument
+} from '@/hooks/useDocuments'
+import colors from '@/themes/base/colors'
+import { validateFile } from '@/utils/fileValidation'
 
 export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
 export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
 export const DOC_CATEGORY_SUPPORTING = 'supporting'
 
-const ACCEPT_MIME = [
-  'application/pdf',
-  'image/png',
-  'image/jpeg',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'text/csv',
-  'text/plain'
-].join(',')
-
-const MAX_FILE_BYTES = 50 * 1024 * 1024
+const PARENT_TYPE = 'ci_application'
 
 const formatBytes = (bytes) => {
   if (bytes == null) return ''
@@ -51,10 +44,7 @@ const formatBytes = (bytes) => {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-const formatDate = (iso) => {
-  if (!iso) return ''
-  return iso.slice(0, 10)
-}
+const formatDate = (iso) => (iso ? String(iso).slice(0, 10) : '')
 
 export const DocumentsModellingStep = ({
   ciApplication,
@@ -77,12 +67,18 @@ export const DocumentsModellingStep = ({
   )
   const [uploadError, setUploadError] = useState(null)
 
-  const { data: documents = [], isLoading: isLoadingDocs } =
-    useGetCIApplicationDocuments(ciApplicationId)
-  const { mutateAsync: uploadDoc, isPending: isUploading } =
-    useUploadCIApplicationDocument(ciApplicationId)
-  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
-    useDeleteCIApplicationDocument(ciApplicationId)
+  const { data: documents = [], isLoading: isLoadingDocs } = useDocuments(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: uploadDoc, isPending: isUploading } = useUploadDocument(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } = useDeleteDocument(
+    PARENT_TYPE,
+    ciApplicationId
+  )
 
   const hasTechnicalReport = documents.some(
     (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
@@ -91,27 +87,21 @@ export const DocumentsModellingStep = ({
     (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
   )
 
-  const handlePickSupporting = () => {
-    setUploadError(null)
-    supportingFileRef.current?.click()
-  }
-  const handlePickGHGenius = () => {
-    setUploadError(null)
-    ghgeniusFileRef.current?.click()
-  }
-
   const handleFileChosen = async (event, category) => {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
-    if (file.size > MAX_FILE_BYTES) {
-      setUploadError(t('carbonIntensity:step3.errors.tooLarge'))
+
+    const result = validateFile(
+      file,
+      MAX_FILE_SIZE_BYTES,
+      COMPLIANCE_REPORT_FILE_TYPES
+    )
+    if (!result.isValid) {
+      setUploadError(result.errorMessage)
       return
     }
-    if (!ACCEPT_MIME.split(',').includes(file.type)) {
-      setUploadError(t('carbonIntensity:step3.errors.unsupportedType'))
-      return
-    }
+    setUploadError(null)
     try {
       await uploadDoc({ file, documentCategory: category })
     } catch (err) {
@@ -254,7 +244,7 @@ export const DocumentsModellingStep = ({
           variant="outlined"
           color="primary"
           startIcon={<CloudUploadIcon />}
-          onClick={handlePickSupporting}
+          onClick={() => supportingFileRef.current?.click()}
           disabled={readOnly || isUploading}
           data-test="ci-step3-upload-supporting"
         >
@@ -263,7 +253,7 @@ export const DocumentsModellingStep = ({
         <input
           ref={supportingFileRef}
           type="file"
-          accept={ACCEPT_MIME}
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
           hidden
           onChange={(e) => handleFileChosen(e, supportingCategory)}
           data-test="ci-step3-supporting-input"
@@ -325,7 +315,7 @@ export const DocumentsModellingStep = ({
           variant="outlined"
           color="primary"
           startIcon={<CloudUploadIcon />}
-          onClick={handlePickGHGenius}
+          onClick={() => ghgeniusFileRef.current?.click()}
           disabled={readOnly || isUploading}
           data-test="ci-step3-upload-ghgenius"
         >
@@ -345,7 +335,7 @@ export const DocumentsModellingStep = ({
         <input
           ref={ghgeniusFileRef}
           type="file"
-          accept={ACCEPT_MIME}
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
           hidden
           onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
           data-test="ci-step3-ghgenius-input"

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -1,0 +1,389 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  IconButton,
+  Link,
+  MenuItem,
+  Stack,
+  TextField,
+  Tooltip
+} from '@mui/material'
+import {
+  CloudUpload as CloudUploadIcon,
+  Delete as DeleteIcon,
+  FileDownload as FileDownloadIcon
+} from '@mui/icons-material'
+
+import BCAlert from '@/components/BCAlert'
+import BCButton from '@/components/BCButton'
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import colors from '@/themes/base/colors'
+import {
+  useDeleteCIApplicationDocument,
+  useGetCIApplicationDocuments,
+  useUploadCIApplicationDocument
+} from '@/hooks/useCIApplication'
+
+export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
+export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
+export const DOC_CATEGORY_SUPPORTING = 'supporting'
+
+const ACCEPT_MIME = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/csv',
+  'text/plain'
+].join(',')
+
+const MAX_FILE_BYTES = 50 * 1024 * 1024
+
+const formatBytes = (bytes) => {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+const formatDate = (iso) => {
+  if (!iso) return ''
+  return iso.slice(0, 10)
+}
+
+export const DocumentsModellingStep = ({
+  ciApplication,
+  onSave,
+  onDelete,
+  isSaving = false,
+  readOnly = false
+}) => {
+  const { t } = useTranslation(['common', 'carbonIntensity'])
+  const ciApplicationId = ciApplication?.ciApplicationId
+
+  const supportingFileRef = useRef(null)
+  const ghgeniusFileRef = useRef(null)
+
+  const [supportingCategory, setSupportingCategory] = useState(
+    DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const [otherDescription, setOtherDescription] = useState(
+    ciApplication?.supportingDocumentOther || ''
+  )
+  const [uploadError, setUploadError] = useState(null)
+
+  const { data: documents = [], isLoading: isLoadingDocs } =
+    useGetCIApplicationDocuments(ciApplicationId)
+  const { mutateAsync: uploadDoc, isPending: isUploading } =
+    useUploadCIApplicationDocument(ciApplicationId)
+  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
+    useDeleteCIApplicationDocument(ciApplicationId)
+
+  const hasTechnicalReport = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const hasGHGeniusModel = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
+  )
+
+  const handlePickSupporting = () => {
+    setUploadError(null)
+    supportingFileRef.current?.click()
+  }
+  const handlePickGHGenius = () => {
+    setUploadError(null)
+    ghgeniusFileRef.current?.click()
+  }
+
+  const handleFileChosen = async (event, category) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    if (file.size > MAX_FILE_BYTES) {
+      setUploadError(t('carbonIntensity:step3.errors.tooLarge'))
+      return
+    }
+    if (!ACCEPT_MIME.split(',').includes(file.type)) {
+      setUploadError(t('carbonIntensity:step3.errors.unsupportedType'))
+      return
+    }
+    try {
+      await uploadDoc({ file, documentCategory: category })
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.uploadFailed')
+      )
+    }
+  }
+
+  const handleDelete = async (documentId) => {
+    try {
+      await deleteDoc(documentId)
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.deleteFailed')
+      )
+    }
+  }
+
+  const canProceed = hasTechnicalReport && hasGHGeniusModel && !readOnly
+
+  const handleSaveAndProceed = async () => {
+    setUploadError(null)
+    if (!hasTechnicalReport || !hasGHGeniusModel) {
+      setUploadError(t('carbonIntensity:step3.errors.missingRequired'))
+      return
+    }
+    await onSave?.({ supportingDocumentOther: otherDescription || null })
+  }
+
+  return (
+    <Box>
+      <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
+        {t('carbonIntensity:step3.title')}
+      </BCTypography>
+
+      {/* Uploaded documents list */}
+      <BCBox
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          mb: 3,
+          maxHeight: 240,
+          overflowY: 'auto'
+        }}
+        data-test="ci-step3-uploaded-list"
+      >
+        <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+          {t('carbonIntensity:step3.uploadedHeader')}
+        </BCTypography>
+        {isLoadingDocs ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('common:loading')}
+          </BCTypography>
+        ) : documents.length === 0 ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('carbonIntensity:step3.noDocuments')}
+          </BCTypography>
+        ) : (
+          documents.map((doc) => (
+            <Box
+              key={doc.documentId}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '2fr 1fr 1fr 1fr auto',
+                alignItems: 'center',
+                py: 0.5,
+                gap: 2
+              }}
+              data-test="ci-step3-uploaded-row"
+            >
+              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+                {doc.fileName}
+              </Link>
+              <BCTypography variant="body2">
+                {formatBytes(doc.fileSize)}
+              </BCTypography>
+              <BCTypography variant="body2">{doc.createUser || ''}</BCTypography>
+              <BCTypography variant="body2">
+                {formatDate(doc.createDate)}
+              </BCTypography>
+              {!readOnly && (
+                <Tooltip title={t('common:deleteBtn')}>
+                  <span>
+                    <IconButton
+                      aria-label="delete document"
+                      size="small"
+                      onClick={() => handleDelete(doc.documentId)}
+                      disabled={isDeletingDoc}
+                      data-test="ci-step3-delete-doc"
+                    >
+                      <DeleteIcon fontSize="small" color="error" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+            </Box>
+          ))
+        )}
+      </BCBox>
+
+      {uploadError && (
+        <Box mb={2}>
+          <BCAlert severity="error" onClose={() => setUploadError(null)}>
+            {uploadError}
+          </BCAlert>
+        </Box>
+      )}
+
+      {/* Supporting documentation */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.supportingHeader')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
+        <TextField
+          select
+          size="small"
+          value={supportingCategory}
+          onChange={(e) => setSupportingCategory(e.target.value)}
+          disabled={readOnly}
+          sx={{ minWidth: 280 }}
+          inputProps={{ 'data-test': 'ci-step3-supporting-category' }}
+        >
+          <MenuItem value={DOC_CATEGORY_TECHNICAL_REPORT}>
+            {t('carbonIntensity:step3.categoryTechnicalReport')}
+          </MenuItem>
+          <MenuItem value={DOC_CATEGORY_SUPPORTING}>
+            {t('carbonIntensity:step3.categorySupporting')}
+          </MenuItem>
+        </TextField>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<CloudUploadIcon />}
+          onClick={handlePickSupporting}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-supporting"
+        >
+          {t('carbonIntensity:step3.uploadSupporting')}
+        </BCButton>
+        <input
+          ref={supportingFileRef}
+          type="file"
+          accept={ACCEPT_MIME}
+          hidden
+          onChange={(e) => handleFileChosen(e, supportingCategory)}
+          data-test="ci-step3-supporting-input"
+        />
+      </Stack>
+
+      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.technicalReport')}
+            {!hasTechnicalReport && (
+              <BCTypography
+                component="span"
+                variant="body2"
+                color="error"
+                sx={{ ml: 1 }}
+              >
+                {t('carbonIntensity:step3.notUploaded')}
+              </BCTypography>
+            )}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.notification')}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.other')}
+          </BCTypography>
+        </li>
+      </Box>
+
+      <TextField
+        fullWidth
+        value={otherDescription}
+        onChange={(e) => setOtherDescription(e.target.value)}
+        disabled={readOnly}
+        placeholder={t('carbonIntensity:step3.otherPlaceholder')}
+        inputProps={{
+          'data-test': 'ci-step3-other-description',
+          maxLength: 1000
+        }}
+        sx={{ mb: 4 }}
+      />
+
+      {/* GHGenius modelling */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.ghgeniusHeader')}
+      </BCTypography>
+      <BCTypography variant="body2" sx={{ mb: 2 }}>
+        {t('carbonIntensity:step3.ghgeniusIntro')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<CloudUploadIcon />}
+          onClick={handlePickGHGenius}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-ghgenius"
+        >
+          {t('carbonIntensity:step3.uploadGHGenius')}
+        </BCButton>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<FileDownloadIcon />}
+          href="/templates/ghgenius-input-output.xlsx"
+          download
+          data-test="ci-step3-download-template"
+        >
+          {t('carbonIntensity:step3.downloadTemplate')}
+        </BCButton>
+        <input
+          ref={ghgeniusFileRef}
+          type="file"
+          accept={ACCEPT_MIME}
+          hidden
+          onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
+          data-test="ci-step3-ghgenius-input"
+        />
+      </Stack>
+
+      {!hasGHGeniusModel && (
+        <BCTypography variant="body2" color="error" sx={{ mb: 2 }}>
+          {t('carbonIntensity:step3.ghgeniusRequired')}
+        </BCTypography>
+      )}
+
+      <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+        <BCButton
+          type="button"
+          variant="contained"
+          color="primary"
+          onClick={handleSaveAndProceed}
+          disabled={!canProceed || isSaving || isUploading}
+          data-test="ci-step3-save-btn"
+        >
+          {t('carbonIntensity:step3.saveAndProceed')}
+        </BCButton>
+        {ciApplicationId && onDelete && (
+          <BCButton
+            type="button"
+            variant="outlined"
+            color="error"
+            onClick={onDelete}
+            disabled={readOnly || isSaving}
+            data-test="ci-step3-delete-btn"
+          >
+            {t('carbonIntensity:step1.deleteDraft')}
+          </BCButton>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+DocumentsModellingStep.displayName = 'DocumentsModellingStep'

--- a/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, Stack, TextField } from '@mui/material'
+import { v4 as uuid } from 'uuid'
+
+import BCButton from '@/components/BCButton'
+import BCTypography from '@/components/BCTypography'
+import { BCGridEditor } from '@/components/BCDataGrid/BCGridEditor'
+import colors from '@/themes/base/colors'
+
+import {
+  apiToRow,
+  buildPathwayColDefs,
+  defaultColDef,
+  rowToApiPayload,
+  validatePathwayRow
+} from './_step2Schema'
+
+const createEmptyRow = () => ({
+  id: uuid(),
+  pathwayId: null,
+  applicationTypeId: null,
+  fuelCodeTypeId: null,
+  operatingDataFrom: '',
+  operatingDataTo: '',
+  fuelCodeId: null,
+  proposedCi: null,
+  fuelTypeId: null,
+  feedstock: '',
+  feedstockRegion: '',
+  feedstockTransportMode: '',
+  feedstockTransportDistance: null,
+  coproducts: '',
+  finishedFuelTransportMode: '',
+  finishedFuelTransportDistance: null
+})
+
+export const ProposedFuelPathwaysStep = ({
+  ciApplication,
+  optionsData,
+  onSave,
+  onDelete,
+  isSaving = false,
+  readOnly = false
+}) => {
+  const { t } = useTranslation(['common', 'carbonIntensity'])
+  const gridRef = useRef(null)
+
+  const canEdit = !readOnly
+
+  const [rowData, setRowData] = useState(() =>
+    ciApplication?.pathways?.length
+      ? ciApplication.pathways.map(apiToRow)
+      : [createEmptyRow()]
+  )
+  const [description, setDescription] = useState(
+    ciApplication?.pathwayDescription || ''
+  )
+  const [errors, setErrors] = useState({})
+
+  // Re-seed local state when the parent reloads the application (e.g. after save)
+  useEffect(() => {
+    if (ciApplication?.pathways?.length) {
+      setRowData(ciApplication.pathways.map(apiToRow))
+    }
+    setDescription(ciApplication?.pathwayDescription || '')
+  }, [ciApplication])
+
+  const columnDefs = useMemo(
+    () => buildPathwayColDefs({ optionsData, canEdit }),
+    [optionsData, canEdit]
+  )
+
+  const onCellValueChanged = useCallback((params) => {
+    setRowData((prev) =>
+      prev.map((row) => (row.id === params.data.id ? { ...params.data } : row))
+    )
+  }, [])
+
+  const onAction = useCallback(async (action, params) => {
+    switch (action) {
+      case 'add':
+        return { add: [createEmptyRow()] }
+      case 'duplicate': {
+        const original = params.data
+        const copy = { ...original, id: uuid(), pathwayId: null }
+        return { add: [copy] }
+      }
+      case 'delete':
+        params.api.applyTransaction({ remove: [params.data] })
+        setRowData((prev) => prev.filter((r) => r.id !== params.data.id))
+        return null
+      default:
+        return null
+    }
+  }, [])
+
+  const handleAddRow = useCallback(() => {
+    const newRow = createEmptyRow()
+    setRowData((prev) => [...prev, newRow])
+    gridRef.current?.api?.applyTransaction({ add: [newRow] })
+  }, [])
+
+  const collectGridRows = () => {
+    const rows = []
+    gridRef.current?.api?.forEachNode((node) => rows.push(node.data))
+    return rows.length ? rows : rowData
+  }
+
+  const handleSave = async () => {
+    const rows = collectGridRows()
+    const applicationTypes = optionsData?.pathwayApplicationTypes || []
+
+    if (!rows.length) {
+      setErrors({ _form: t('carbonIntensity:step2.validation.atLeastOneRow') })
+      return
+    }
+
+    const newErrors = {}
+    rows.forEach((row) => {
+      const fieldErrors = validatePathwayRow(row, applicationTypes)
+      if (fieldErrors.length) {
+        newErrors[row.id] = fieldErrors
+      }
+    })
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors)
+      gridRef.current?.api?.refreshCells({ force: true })
+      return
+    }
+
+    setErrors({})
+    await onSave?.({
+      pathways: rows.map(rowToApiPayload),
+      pathwayDescription: description?.trim() || null
+    })
+  }
+
+  return (
+    <Box>
+      <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
+        {t('carbonIntensity:step2.title')}
+      </BCTypography>
+
+      <BCGridEditor
+        gridRef={gridRef}
+        columnDefs={columnDefs}
+        defaultColDef={defaultColDef}
+        rowData={rowData}
+        onCellValueChanged={onCellValueChanged}
+        onAction={onAction}
+        showAddRowsButton={canEdit}
+        onAddRows={handleAddRow}
+        context={{ errors }}
+        showMandatoryColumns={canEdit}
+        getRowId={(params) => params.data.id}
+      />
+
+      <Box mt={3}>
+        <BCTypography variant="subtitle2" sx={{ pb: 1 }}>
+          {t('carbonIntensity:step2.descriptionLabel')}
+        </BCTypography>
+        <BCTypography variant="caption" color="text.secondary" sx={{ pb: 1, display: 'block' }}>
+          {t('carbonIntensity:step2.descriptionHelp')}
+        </BCTypography>
+        <TextField
+          multiline
+          rows={4}
+          fullWidth
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          disabled={readOnly}
+          inputProps={{ 'data-test': 'pathwayDescription' }}
+        />
+      </Box>
+
+      <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+        <BCButton
+          type="button"
+          variant="contained"
+          color="primary"
+          data-test="ci-step2-save-btn"
+          onClick={handleSave}
+          disabled={readOnly || isSaving}
+        >
+          {t('carbonIntensity:step2.saveAndProceed')}
+        </BCButton>
+        {ciApplication?.ciApplicationId && onDelete && (
+          <BCButton
+            type="button"
+            variant="outlined"
+            color="error"
+            data-test="ci-step2-delete-btn"
+            onClick={onDelete}
+            disabled={readOnly || isSaving}
+          >
+            {t('carbonIntensity:step1.deleteDraft')}
+          </BCButton>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+ProposedFuelPathwaysStep.displayName = 'ProposedFuelPathwaysStep'

--- a/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
+++ b/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
@@ -1,0 +1,458 @@
+import {
+  ActionsRenderer,
+  AutocompleteCellEditor,
+  DateEditor,
+  RequiredHeader
+} from '@/components/BCDataGrid/components'
+import { suppressKeyboardEvent } from '@/utils/grid/eventHandlers'
+import BCTypography from '@/components/BCTypography'
+import i18n from '@/i18n'
+
+const APPLICATION_TYPE_RENEWAL = 'Renewal'
+
+export const isRenewalRow = (data, applicationTypes) => {
+  if (!data?.applicationTypeId) return false
+  const match = applicationTypes?.find(
+    (t) => t.pathwayApplicationTypeId === data.applicationTypeId
+  )
+  return match?.type === APPLICATION_TYPE_RENEWAL
+}
+
+const renderSelectPlaceholder = (params) =>
+  params.value || <BCTypography variant="body4">Select</BCTypography>
+
+const cellErrorStyle = (params) => {
+  const rowErrors = params.context?.errors?.[params.data?.id]
+  if (rowErrors?.includes(params.colDef.field)) {
+    return { borderColor: 'red' }
+  }
+  return { borderColor: 'unset' }
+}
+
+/**
+ * Apply the locked fields auto-populated from the selected fuel code on
+ * a Renewal row. The fuel code carries the canonical fuel type, feedstock,
+ * and feedstock region — the spec says these should be locked on
+ * Renewal so the applicant cannot diverge from the source pathway.
+ */
+const applyFuelCodeAutofill = (rowData, fuelCode) => {
+  if (!fuelCode) return rowData
+  return {
+    ...rowData,
+    fuelCodeId: fuelCode.fuelCodeId,
+    fuelTypeId: fuelCode.fuelTypeId ?? rowData.fuelTypeId,
+    feedstock: fuelCode.feedstock ?? rowData.feedstock,
+    feedstockRegion: fuelCode.feedstockLocation ?? rowData.feedstockRegion,
+    proposedCi:
+      fuelCode.carbonIntensity != null
+        ? Number(fuelCode.carbonIntensity)
+        : rowData.proposedCi
+  }
+}
+
+export const buildPathwayColDefs = ({
+  optionsData,
+  canEdit
+}) => {
+  const applicationTypes = optionsData?.pathwayApplicationTypes || []
+  const fuelCodeTypes = optionsData?.pathwayFuelCodeTypes || []
+  const fuelTypes = optionsData?.fuelTypes || []
+  const transportModes = optionsData?.transportModes || []
+  const fuelCodes = optionsData?.fuelCodes || []
+
+  const fuelCodeById = new Map(fuelCodes.map((fc) => [fc.fuelCodeId, fc]))
+
+  const isRenewal = (params) => isRenewalRow(params.data, applicationTypes)
+  const lockedOnRenewal = (params) => canEdit && !isRenewal(params)
+
+  return [
+    {
+      colId: 'action',
+      headerName: i18n.t('carbonIntensity:step2.action'),
+      cellRenderer: ActionsRenderer,
+      cellRendererParams: (params) => ({
+        enableDuplicate: canEdit && !isRenewal(params),
+        enableDelete: canEdit
+      }),
+      pinned: 'left',
+      maxWidth: 120,
+      minWidth: 100,
+      editable: false,
+      suppressKeyboardEvent,
+      filter: false
+    },
+    { field: 'id', hide: true },
+    { field: 'pathwayId', hide: true },
+    {
+      field: 'applicationTypeId',
+      headerName: i18n.t('carbonIntensity:step2.applicationType'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: applicationTypes.map((t) => t.type),
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: renderSelectPlaceholder,
+      valueGetter: (params) =>
+        applicationTypes.find(
+          (t) => t.pathwayApplicationTypeId === params.data?.applicationTypeId
+        )?.type ?? '',
+      valueSetter: (params) => {
+        const match = applicationTypes.find((t) => t.type === params.newValue)
+        if (!match) return false
+        params.data.applicationTypeId = match.pathwayApplicationTypeId
+        // Switching back to "New" must clear any renewal-specific fuel code
+        // reference; otherwise validation will reject the row server-side.
+        if (match.type !== APPLICATION_TYPE_RENEWAL) {
+          params.data.fuelCodeId = null
+        }
+        return true
+      },
+      minWidth: 160
+    },
+    {
+      field: 'fuelCodeTypeId',
+      headerName: i18n.t('carbonIntensity:step2.proposedFuelCodeType'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: fuelCodeTypes.map((t) => t.type),
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: renderSelectPlaceholder,
+      valueGetter: (params) =>
+        fuelCodeTypes.find(
+          (t) => t.pathwayFuelCodeTypeId === params.data?.fuelCodeTypeId
+        )?.type ?? '',
+      valueSetter: (params) => {
+        const match = fuelCodeTypes.find((t) => t.type === params.newValue)
+        if (!match) return false
+        params.data.fuelCodeTypeId = match.pathwayFuelCodeTypeId
+        return true
+      },
+      minWidth: 200
+    },
+    {
+      field: 'operatingDataFrom',
+      headerName: i18n.t('carbonIntensity:step2.operatingDataFrom'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: DateEditor,
+      suppressKeyboardEvent,
+      cellRenderer: (params) => (
+        <BCTypography variant="body4">
+          {params.value || 'YYYY-MM-DD'}
+        </BCTypography>
+      ),
+      minWidth: 200
+    },
+    {
+      field: 'operatingDataTo',
+      headerName: i18n.t('carbonIntensity:step2.operatingDataTo'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: DateEditor,
+      suppressKeyboardEvent,
+      cellRenderer: (params) => (
+        <BCTypography variant="body4">
+          {params.value || 'YYYY-MM-DD'}
+        </BCTypography>
+      ),
+      minWidth: 200
+    },
+    {
+      field: 'fuelCodeId',
+      headerName: i18n.t('carbonIntensity:step2.fuelCodeIteration'),
+      // Only enabled (and required) for Renewal rows. The wireframe shows
+      // this column greyed out for "New" rows.
+      editable: (params) => canEdit && isRenewal(params),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: fuelCodes.map((fc) => fc.fuelCode),
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: (params) => {
+        if (!isRenewal(params)) {
+          return <BCTypography variant="body4">—</BCTypography>
+        }
+        const match = fuelCodes.find(
+          (fc) => fc.fuelCodeId === params.data?.fuelCodeId
+        )
+        return match ? (
+          match.fuelCode
+        ) : (
+          <BCTypography variant="body4">Select</BCTypography>
+        )
+      },
+      cellStyle: (params) => {
+        const base = cellErrorStyle(params)
+        if (!isRenewal(params)) {
+          return { ...base, backgroundColor: '#f5f5f5' }
+        }
+        return base
+      },
+      valueGetter: (params) => {
+        const match = fuelCodes.find(
+          (fc) => fc.fuelCodeId === params.data?.fuelCodeId
+        )
+        return match?.fuelCode ?? ''
+      },
+      valueSetter: (params) => {
+        if (!params.newValue) {
+          params.data.fuelCodeId = null
+          return true
+        }
+        const match = fuelCodes.find((fc) => fc.fuelCode === params.newValue)
+        if (!match) return false
+        Object.assign(params.data, applyFuelCodeAutofill(params.data, match))
+        return true
+      },
+      minWidth: 200
+    },
+    {
+      field: 'proposedCi',
+      headerName: i18n.t('carbonIntensity:step2.proposedCi'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: lockedOnRenewal,
+      cellEditor: 'agNumberCellEditor',
+      cellEditorParams: { precision: 2, showStepperButtons: false },
+      type: 'numericColumn',
+      cellRenderer: renderSelectPlaceholder,
+      cellStyle: (params) => {
+        const base = cellErrorStyle(params)
+        if (isRenewal(params)) return { ...base, backgroundColor: '#f5f5f5' }
+        return base
+      },
+      minWidth: 180
+    },
+    {
+      field: 'fuelTypeId',
+      headerName: i18n.t('carbonIntensity:step2.fuelType'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: lockedOnRenewal,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: fuelTypes.map((ft) => ft.fuelType),
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: renderSelectPlaceholder,
+      cellStyle: (params) => {
+        const base = cellErrorStyle(params)
+        if (isRenewal(params)) return { ...base, backgroundColor: '#f5f5f5' }
+        return base
+      },
+      valueGetter: (params) =>
+        fuelTypes.find((t) => t.fuelTypeId === params.data?.fuelTypeId)
+          ?.fuelType ?? '',
+      valueSetter: (params) => {
+        const match = fuelTypes.find((t) => t.fuelType === params.newValue)
+        if (!match) return false
+        params.data.fuelTypeId = match.fuelTypeId
+        return true
+      },
+      minWidth: 220
+    },
+    {
+      field: 'feedstock',
+      headerName: i18n.t('carbonIntensity:step2.feedstock'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: lockedOnRenewal,
+      cellEditor: 'agTextCellEditor',
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 220
+    },
+    {
+      field: 'feedstockRegion',
+      headerName: i18n.t('carbonIntensity:step2.feedstockRegion'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: lockedOnRenewal,
+      cellEditor: 'agTextCellEditor',
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 220
+    },
+    {
+      field: 'feedstockTransportMode',
+      headerName: i18n.t('carbonIntensity:step2.feedstockTransportMode'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: transportModes,
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 240
+    },
+    {
+      field: 'feedstockTransportDistance',
+      headerName: i18n.t('carbonIntensity:step2.feedstockTransportDistance'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: 'agNumberCellEditor',
+      cellEditorParams: { precision: 0, min: 0, showStepperButtons: false },
+      type: 'numericColumn',
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 240
+    },
+    {
+      field: 'coproducts',
+      headerName: i18n.t('carbonIntensity:step2.coproducts'),
+      editable: canEdit,
+      cellEditor: 'agTextCellEditor',
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 240
+    },
+    {
+      field: 'finishedFuelTransportMode',
+      headerName: i18n.t('carbonIntensity:step2.finishedFuelTransportMode'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: AutocompleteCellEditor,
+      cellEditorParams: {
+        options: transportModes,
+        multiple: false,
+        disableCloseOnSelect: false,
+        freeSolo: false,
+        openOnFocus: true
+      },
+      suppressKeyboardEvent,
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 260
+    },
+    {
+      field: 'finishedFuelTransportDistance',
+      headerName: i18n.t('carbonIntensity:step2.finishedFuelTransportDistance'),
+      headerComponent: canEdit ? RequiredHeader : undefined,
+      editable: canEdit,
+      cellEditor: 'agNumberCellEditor',
+      cellEditorParams: { precision: 0, min: 0, showStepperButtons: false },
+      type: 'numericColumn',
+      cellRenderer: renderSelectPlaceholder,
+      minWidth: 260
+    }
+  ].map((colDef) => ({
+    cellStyle: cellErrorStyle,
+    ...colDef
+  }))
+}
+
+export const defaultColDef = {
+  editable: false,
+  resizable: true,
+  filter: false,
+  floatingFilter: false,
+  sortable: false,
+  singleClickEdit: true
+}
+
+/**
+ * Validate a single row client-side. Returns a list of bad field names;
+ * empty list means the row is OK.
+ */
+export const validatePathwayRow = (row, applicationTypes) => {
+  const errors = []
+  if (!row.applicationTypeId) errors.push('applicationTypeId')
+  if (!row.fuelCodeTypeId) errors.push('fuelCodeTypeId')
+  if (!row.operatingDataFrom) errors.push('operatingDataFrom')
+  if (!row.operatingDataTo) errors.push('operatingDataTo')
+  if (
+    row.operatingDataFrom &&
+    row.operatingDataTo &&
+    row.operatingDataTo < row.operatingDataFrom
+  ) {
+    errors.push('operatingDataTo')
+  }
+  if (
+    row.proposedCi === null ||
+    row.proposedCi === undefined ||
+    row.proposedCi === '' ||
+    Number.isNaN(Number(row.proposedCi))
+  ) {
+    errors.push('proposedCi')
+  }
+  if (!row.fuelTypeId) errors.push('fuelTypeId')
+  if (!row.feedstock?.toString().trim()) errors.push('feedstock')
+  if (!row.feedstockRegion?.toString().trim()) errors.push('feedstockRegion')
+  if (!row.feedstockTransportMode) errors.push('feedstockTransportMode')
+  if (
+    row.feedstockTransportDistance === null ||
+    row.feedstockTransportDistance === undefined ||
+    row.feedstockTransportDistance === ''
+  ) {
+    errors.push('feedstockTransportDistance')
+  }
+  if (!row.finishedFuelTransportMode) errors.push('finishedFuelTransportMode')
+  if (
+    row.finishedFuelTransportDistance === null ||
+    row.finishedFuelTransportDistance === undefined ||
+    row.finishedFuelTransportDistance === ''
+  ) {
+    errors.push('finishedFuelTransportDistance')
+  }
+
+  if (isRenewalRow(row, applicationTypes) && !row.fuelCodeId) {
+    errors.push('fuelCodeId')
+  }
+  return errors
+}
+
+export const rowToApiPayload = (row) => ({
+  pathwayId: row.pathwayId ?? null,
+  applicationTypeId: Number(row.applicationTypeId),
+  fuelCodeTypeId: Number(row.fuelCodeTypeId),
+  operatingDataFrom: row.operatingDataFrom,
+  operatingDataTo: row.operatingDataTo,
+  fuelCodeId: row.fuelCodeId ? Number(row.fuelCodeId) : null,
+  proposedCi: Number(row.proposedCi),
+  fuelTypeId: Number(row.fuelTypeId),
+  feedstock: row.feedstock?.toString().trim() ?? '',
+  feedstockRegion: row.feedstockRegion?.toString().trim() ?? '',
+  feedstockTransportMode: row.feedstockTransportMode,
+  feedstockTransportDistance: Number(row.feedstockTransportDistance),
+  coproducts: row.coproducts?.toString().trim() || null,
+  finishedFuelTransportMode: row.finishedFuelTransportMode,
+  finishedFuelTransportDistance: Number(row.finishedFuelTransportDistance)
+})
+
+export const apiToRow = (pathway) => ({
+  id: `pathway-${pathway.pathwayId}`,
+  pathwayId: pathway.pathwayId,
+  applicationTypeId: pathway.applicationTypeId,
+  fuelCodeTypeId: pathway.fuelCodeTypeId,
+  operatingDataFrom: pathway.operatingDataFrom,
+  operatingDataTo: pathway.operatingDataTo,
+  fuelCodeId: pathway.fuelCodeId,
+  proposedCi:
+    pathway.proposedCi != null ? Number(pathway.proposedCi) : null,
+  fuelTypeId: pathway.fuelTypeId,
+  feedstock: pathway.feedstock,
+  feedstockRegion: pathway.feedstockRegion,
+  feedstockTransportMode: pathway.feedstockTransportMode,
+  feedstockTransportDistance: pathway.feedstockTransportDistance,
+  coproducts: pathway.coproducts,
+  finishedFuelTransportMode: pathway.finishedFuelTransportMode,
+  finishedFuelTransportDistance: pathway.finishedFuelTransportDistance
+})


### PR DESCRIPTION
## Summary
- Implements Step 2 of the BCeID CI application wizard: AG Grid for proposed fuel pathways plus a description textarea (issue #4200).
- Backend wires up `PUT /ci-applications/{id}/step2` (replaces the entire pathway set + description) with cross-row validation: Renewal rows require a `fuel_code_id`, New rows must not reference one.
- Frontend grid auto-populates and locks fuel type / feedstock / region / proposed CI on Renewal rows from the selected fuel code; the Fuel code iteration column is disabled for New rows. Duplicate is exposed only on New rows.

> Stacked on top of #4199 (Step 1). Targets that branch — please merge #4199 first, then this will retarget to `develop`.

## Test plan
- [x] Backend: `pytest lcfs/tests/ci_application` passes (15 service tests, including 6 new Step 2 cases covering replace, Renewal/New rule enforcement, schema-level pathway validation).
- [x] Frontend: `vitest run src/views/CarbonIntensity` passes (47 tests, 15 new — pure schema helpers + component render / validation gating / renewal-without-fuel-code guard).
- [ ] Manual: walk through the Step 1 → Step 2 flow as a CI Applicant; verify Add row, Duplicate (New only), Delete, Renewal autofill, validation messages, and Save & proceed advancing the wizard.
- [ ] Accessibility: keyboard-only nav across grid cells; tab order through Add row, description, Save & proceed, Delete draft.
- [ ] Cross-browser smoke (Chrome / Firefox / Safari).