### PR TITLE
feat: CI application Step 3 - Documents & GHGenius modelling (#4201)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-05-06-12-00_e7c2b9a4d018.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-06-12-00_e7c2b9a4d018.py
@@ -1,0 +1,49 @@
+"""Add document_category to ci_application_document_association.
+
+Step 3 of the CI application workflow uploads documents in three buckets:
+``technical_report`` (mandatory), ``ghgenius_model`` (mandatory), and
+``supporting`` (optional). The category is stored on the join table so a
+single Document row stays uncategorised globally and only carries
+meaning in the context of a specific CI application.
+
+Revision ID: e7c2b9a4d018
+Revises: d4f5e6a7b8c9
+Create Date: 2026-05-06 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "e7c2b9a4d018"
+down_revision = "d4f5e6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ci_application_document_association",
+        sa.Column(
+            "document_category",
+            sa.String(50),
+            nullable=False,
+            server_default="supporting",
+            comment=(
+                "Category of the upload in the context of the parent CI "
+                "application: 'technical_report', 'ghgenius_model', or "
+                "'supporting'."
+            ),
+        ),
+    )
+    # Drop the server default so subsequent inserts must specify a value
+    # explicitly. The default only exists to backfill any pre-existing rows.
+    op.alter_column(
+        "ci_application_document_association",
+        "document_category",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ci_application_document_association", "document_category")

--- a/backend/lcfs/db/models/ci_application/CIApplication.py
+++ b/backend/lcfs/db/models/ci_application/CIApplication.py
@@ -30,7 +30,27 @@ ci_application_document_association = Table(
         primary_key=True,
         comment="Foreign key to document",
     ),
+    Column(
+        "document_category",
+        String(50),
+        nullable=False,
+        comment=(
+            "Step 3 categorisation: 'technical_report', 'ghgenius_model', "
+            "or 'supporting'."
+        ),
+    ),
 )
+
+
+# Document category values for CI application uploads (Step 3).
+CI_DOC_CATEGORY_TECHNICAL_REPORT = "technical_report"
+CI_DOC_CATEGORY_GHGENIUS_MODEL = "ghgenius_model"
+CI_DOC_CATEGORY_SUPPORTING = "supporting"
+CI_DOC_CATEGORIES = {
+    CI_DOC_CATEGORY_TECHNICAL_REPORT,
+    CI_DOC_CATEGORY_GHGENIUS_MODEL,
+    CI_DOC_CATEGORY_SUPPORTING,
+}
 
 
 class CIApplication(BaseModel, Auditable, Versioning):

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -23,6 +23,12 @@ from lcfs.db.models.compliance import ComplianceReport
 from lcfs.db.models.compliance.ComplianceReport import (
     compliance_report_document_association,
 )
+from lcfs.db.models.ci_application.CIApplication import (
+    CI_DOC_CATEGORIES,
+    CI_DOC_CATEGORY_SUPPORTING,
+    CIApplication,
+    ci_application_document_association,
+)
 from lcfs.db.models.document import Document
 from lcfs.services.clamav.client import ClamAVService
 from lcfs.settings import settings
@@ -60,7 +66,14 @@ class DocumentService:
         self.charging_site_repo = charging_site_repo
 
     @repo_handler
-    async def upload_file(self, file, parent_id: int, parent_type, user=None):
+    async def upload_file(
+        self,
+        file,
+        parent_id: int,
+        parent_type,
+        user=None,
+        document_category: str | None = None,
+    ):
         if parent_type == "compliance_report":
             await self._verify_compliance_report_access(parent_id, user)
         elif parent_type == "administrativeAdjustment":
@@ -69,6 +82,15 @@ class DocumentService:
             await self._verify_initiative_agreement_access(parent_id, user)
         elif parent_type == "charging_site":
             await self._verify_charging_site_access(parent_id, user)
+        elif parent_type == "ci_application":
+            # Access checks for CI application uploads live in the
+            # ci_application validation layer; the views.py wrapper invokes
+            # them before delegating here.
+            if document_category and document_category not in CI_DOC_CATEGORIES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid document_category '{document_category}'.",
+                )
         else:
             raise ServiceException(f"Unknown parent type {parent_type} in upload_file")
 
@@ -196,6 +218,20 @@ class DocumentService:
                 document_id=document.document_id,
             )
             await self.db.execute(stmt)
+        elif parent_type == "ci_application":
+            ci_application = await self.db.get(CIApplication, parent_id)
+            if not ci_application:
+                raise Exception("CI application not found")
+
+            self.db.add(document)
+            await self.db.flush()
+
+            stmt = ci_application_document_association.insert().values(
+                ci_application_id=ci_application.ci_application_id,
+                document_id=document.document_id,
+                document_category=document_category or CI_DOC_CATEGORY_SUPPORTING,
+            )
+            await self.db.execute(stmt)
         else:
             raise ServiceException(f"Invalid Type {parent_type}")
 
@@ -314,6 +350,10 @@ class DocumentService:
                 charging_site_document_association,
                 "charging_site_id",
             ),
+            "ci_application": (
+                ci_application_document_association,
+                "ci_application_id",
+            ),
         }
 
         # Get the association table and column based on the parent_type
@@ -370,6 +410,10 @@ class DocumentService:
             "charging_site": (
                 charging_site_document_association,
                 "charging_site_id",
+            ),
+            "ci_application": (
+                ci_application_document_association,
+                "ci_application_id",
             ),
         }
 

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -426,25 +426,53 @@ class DocumentService:
         association_table, column_name = association_info
 
         # Construct the SQL statement dynamically
-        stmt = select(Document)
         if parent_type == "compliance_report":
             parent_ids = (
                 await self.compliance_report_repo.get_related_compliance_report_ids(
                     parent_id
                 )
             )
-            stmt = stmt.join(association_table).where(
-                getattr(association_table.c, column_name).in_(parent_ids)
-            ).distinct(Document.document_id)
-        else:
-            stmt = stmt.join(association_table).where(
-                getattr(association_table.c, column_name) == parent_id
+            stmt = (
+                select(Document)
+                .join(association_table)
+                .where(
+                    getattr(association_table.c, column_name).in_(parent_ids)
+                )
+                .distinct(Document.document_id)
             )
+            result = await self.db.execute(stmt)
+            return result.scalars().all()
 
-        # Execute the statement and fetch results
+        if parent_type == "ci_application":
+            # Project the join's document_category alongside Document so the
+            # API response can carry the Step 3 bucket without a separate
+            # endpoint.
+            stmt = (
+                select(Document, association_table.c.document_category)
+                .join(
+                    association_table,
+                    association_table.c.document_id == Document.document_id,
+                )
+                .where(
+                    getattr(association_table.c, column_name) == parent_id
+                )
+            )
+            result = await self.db.execute(stmt)
+            documents = []
+            for document, category in result.all():
+                # Pydantic's from_attributes reads attribute names verbatim,
+                # so stamp the join column onto the Document row.
+                document.document_category = category
+                documents.append(document)
+            return documents
+
+        stmt = (
+            select(Document)
+            .join(association_table)
+            .where(getattr(association_table.c, column_name) == parent_id)
+        )
         result = await self.db.execute(stmt)
-        documents = result.scalars().all()
-        return documents
+        return result.scalars().all()
 
     @repo_handler
     async def get_object(self, document_id: int):

--- a/backend/lcfs/services/s3/schema.py
+++ b/backend/lcfs/services/s3/schema.py
@@ -8,6 +8,8 @@ class FileResponseSchema(BaseSchema):
     file_size: int
     create_date: datetime | None = None
     create_user: str | None = None
+    # Step 3 categorisation; only populated for ci_application uploads.
+    document_category: str | None = None
 
     class Config:
         from_attributes = True

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -458,3 +458,91 @@ async def test_pathway_input_rejects_inverted_dates():
             operating_data_from=date(2025, 12, 31),
             operating_data_to=date(2025, 1, 1),
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Documents & GHGenius modelling
+# ---------------------------------------------------------------------------
+
+
+def _doc(document_id=1, file_name="tech-report.pdf", file_size=1024):
+    return SimpleNamespace(
+        document_id=document_id,
+        file_name=file_name,
+        file_size=file_size,
+        mime_type="application/pdf",
+        create_date=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        create_user="ci_applicant_user",
+    )
+
+
+@pytest.mark.anyio
+async def test_list_documents_returns_categorised_files(service, repo):
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1, "tech.pdf"), "technical_report"),
+        (_doc(2, "model.xlsx"), "ghgenius_model"),
+    ]
+    result = await service.list_documents(10)
+    assert [d.document_category for d in result] == [
+        "technical_report",
+        "ghgenius_model",
+    ]
+    assert result[0].file_name == "tech.pdf"
+
+
+@pytest.mark.anyio
+async def test_update_step3_succeeds_when_required_present(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1), "technical_report"),
+        (_doc(2), "ghgenius_model"),
+    ]
+    repo.update.side_effect = lambda obj: obj
+    repo.get_by_id.return_value = ci
+
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    payload = CIApplicationStep3Schema(supporting_document_other="Extra notes")
+    result = await service.update_step3(ci, payload, mock_user)
+
+    assert ci.supporting_document_other == "Extra notes"
+    assert ci.action_type == ActionTypeEnum.UPDATE
+    assert isinstance(result, CIApplicationSchema)
+
+
+@pytest.mark.anyio
+async def test_update_step3_rejects_when_technical_report_missing(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(2), "ghgenius_model"),
+    ]
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step3(
+            ci, CIApplicationStep3Schema(), mock_user
+        )
+    assert "Technical report" in str(exc.value)
+    repo.update.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_step3_rejects_when_ghgenius_missing(
+    service, repo, mock_user
+):
+    ci = _ci_application()
+    repo.get_documents_with_categories.return_value = [
+        (_doc(1), "technical_report"),
+    ]
+    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
+
+    with pytest.raises(Exception) as exc:
+        await service.update_step3(
+            ci, CIApplicationStep3Schema(), mock_user
+        )
+    assert "GHGenius" in str(exc.value)
+    repo.update.assert_not_called()

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -465,39 +465,14 @@ async def test_pathway_input_rejects_inverted_dates():
 # ---------------------------------------------------------------------------
 
 
-def _doc(document_id=1, file_name="tech-report.pdf", file_size=1024):
-    return SimpleNamespace(
-        document_id=document_id,
-        file_name=file_name,
-        file_size=file_size,
-        mime_type="application/pdf",
-        create_date=datetime(2026, 5, 1, tzinfo=timezone.utc),
-        create_user="ci_applicant_user",
-    )
-
-
-@pytest.mark.anyio
-async def test_list_documents_returns_categorised_files(service, repo):
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1, "tech.pdf"), "technical_report"),
-        (_doc(2, "model.xlsx"), "ghgenius_model"),
-    ]
-    result = await service.list_documents(10)
-    assert [d.document_category for d in result] == [
-        "technical_report",
-        "ghgenius_model",
-    ]
-    assert result[0].file_name == "tech.pdf"
-
-
 @pytest.mark.anyio
 async def test_update_step3_succeeds_when_required_present(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1), "technical_report"),
-        (_doc(2), "ghgenius_model"),
+    repo.get_document_categories.return_value = [
+        "technical_report",
+        "ghgenius_model",
     ]
     repo.update.side_effect = lambda obj: obj
     repo.get_by_id.return_value = ci
@@ -517,9 +492,7 @@ async def test_update_step3_rejects_when_technical_report_missing(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(2), "ghgenius_model"),
-    ]
+    repo.get_document_categories.return_value = ["ghgenius_model"]
     from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
 
     with pytest.raises(Exception) as exc:
@@ -535,9 +508,7 @@ async def test_update_step3_rejects_when_ghgenius_missing(
     service, repo, mock_user
 ):
     ci = _ci_application()
-    repo.get_documents_with_categories.return_value = [
-        (_doc(1), "technical_report"),
-    ]
+    repo.get_document_categories.return_value = ["technical_report"]
     from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
 
     with pytest.raises(Exception) as exc:

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -28,7 +28,6 @@ from lcfs.db.models.ci_application import (
 from lcfs.db.models.ci_application.CIApplication import (
     ci_application_document_association,
 )
-from lcfs.db.models.document import Document
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
@@ -231,29 +230,23 @@ class CIApplicationRepository:
         return list(result.scalars().all())
 
     @repo_handler
-    async def get_documents_with_categories(
+    async def get_document_categories(
         self, ci_application_id: int
-    ) -> List[Tuple[Document, str]]:
+    ) -> List[str]:
         """
-        Returns ``(document, category)`` tuples for every file uploaded to
-        this CI application. The category lives on the M:N row, not on
-        Document, so we project both together.
+        Return just the ``document_category`` values currently linked to
+        this CI application. Used by Step 3's required-uploads check; we
+        deliberately don't pull Document rows so the validation stays cheap.
         """
         stmt = (
-            select(Document, ci_application_document_association.c.document_category)
-            .join(
-                ci_application_document_association,
-                ci_application_document_association.c.document_id
-                == Document.document_id,
-            )
+            select(ci_application_document_association.c.document_category)
             .where(
                 ci_application_document_association.c.ci_application_id
                 == ci_application_id
             )
-            .order_by(Document.create_date)
         )
         result = await self.db.execute(stmt)
-        return [(row[0], row[1]) for row in result.all()]
+        return [row[0] for row in result.all()]
 
     @repo_handler
     async def get_fuel_codes_by_ids(

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -25,6 +25,10 @@ from lcfs.db.models.ci_application import (
     PathwayApplicationType,
     PathwayFuelCodeType,
 )
+from lcfs.db.models.ci_application.CIApplication import (
+    ci_application_document_association,
+)
+from lcfs.db.models.document import Document
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
@@ -225,6 +229,31 @@ class CIApplicationRepository:
             .order_by(Pathway.pathway_id)
         )
         return list(result.scalars().all())
+
+    @repo_handler
+    async def get_documents_with_categories(
+        self, ci_application_id: int
+    ) -> List[Tuple[Document, str]]:
+        """
+        Returns ``(document, category)`` tuples for every file uploaded to
+        this CI application. The category lives on the M:N row, not on
+        Document, so we project both together.
+        """
+        stmt = (
+            select(Document, ci_application_document_association.c.document_category)
+            .join(
+                ci_application_document_association,
+                ci_application_document_association.c.document_id
+                == Document.document_id,
+            )
+            .where(
+                ci_application_document_association.c.ci_application_id
+                == ci_application_id
+            )
+            .order_by(Document.create_date)
+        )
+        result = await self.db.execute(stmt)
+        return [(row[0], row[1]) for row in result.all()]
 
     @repo_handler
     async def get_fuel_codes_by_ids(

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -267,17 +267,6 @@ class CIApplicationsListSchema(BaseSchema):
 # ---------------------------------------------------------------------------
 
 
-class CIApplicationDocumentSchema(BaseSchema):
-    """A document linked to a CI application, tagged with its Step 3 category."""
-
-    document_id: int
-    file_name: str
-    file_size: int
-    document_category: str
-    create_date: Optional[str] = None
-    create_user: Optional[str] = None
-
-
 class CIApplicationStep3Schema(BaseSchema):
     """
     Payload for ``PUT /ci-applications/{id}/step3``.

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -260,3 +260,34 @@ class CIApplicationSchema(BaseSchema):
 class CIApplicationsListSchema(BaseSchema):
     ci_applications: List[CIApplicationBaseSchema]
     pagination: PaginationResponseSchema
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Documents & GHGenius modelling
+# ---------------------------------------------------------------------------
+
+
+class CIApplicationDocumentSchema(BaseSchema):
+    """A document linked to a CI application, tagged with its Step 3 category."""
+
+    document_id: int
+    file_name: str
+    file_size: int
+    document_category: str
+    create_date: Optional[str] = None
+    create_user: Optional[str] = None
+
+
+class CIApplicationStep3Schema(BaseSchema):
+    """
+    Payload for ``PUT /ci-applications/{id}/step3``.
+
+    Files are uploaded one-at-a-time via the generic
+    ``/documents/ci_application/{id}`` endpoint with a
+    ``document_category`` query param. This call only persists the
+    optional free-text "other supporting" description and validates
+    that the mandatory Technical report and GHGenius model uploads
+    are in place.
+    """
+
+    supporting_document_other: Optional[str] = Field(default=None, max_length=1000)

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -28,7 +28,6 @@ from lcfs.web.api.base import (
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 from lcfs.web.api.ci_application.schema import (
     CIApplicationBaseSchema,
-    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationStatusEnum,
     CIApplicationStatusSchema,
@@ -436,26 +435,6 @@ class CIApplicationServices:
     # ------------------------------------------------------------------
 
     @service_handler
-    async def list_documents(
-        self, ci_application_id: int
-    ) -> List[CIApplicationDocumentSchema]:
-        """All Step 3 uploads for an application, with their categories."""
-        rows = await self.repo.get_documents_with_categories(ci_application_id)
-        return [
-            CIApplicationDocumentSchema(
-                document_id=document.document_id,
-                file_name=document.file_name,
-                file_size=document.file_size,
-                document_category=category,
-                create_date=(
-                    document.create_date.isoformat() if document.create_date else None
-                ),
-                create_user=document.create_user,
-            )
-            for document, category in rows
-        ]
-
-    @service_handler
     async def update_step3(
         self,
         ci_application: CIApplication,
@@ -468,10 +447,9 @@ class CIApplicationServices:
         present. Files are uploaded out-of-band via the generic document
         endpoint with a category query param.
         """
-        rows = await self.repo.get_documents_with_categories(
-            ci_application.ci_application_id
+        present_categories = set(
+            await self.repo.get_document_categories(ci_application.ci_application_id)
         )
-        present_categories = {category for _, category in rows}
         missing = []
         if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
             missing.append("Technical report")

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -16,6 +16,10 @@ from fastapi import Depends, HTTPException, status
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models import UserProfile
 from lcfs.db.models.ci_application import CIApplication, Pathway
+from lcfs.db.models.ci_application.CIApplication import (
+    CI_DOC_CATEGORY_GHGENIUS_MODEL,
+    CI_DOC_CATEGORY_TECHNICAL_REPORT,
+)
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.web.api.base import (
     PaginationRequestSchema,
@@ -24,12 +28,14 @@ from lcfs.web.api.base import (
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 from lcfs.web.api.ci_application.schema import (
     CIApplicationBaseSchema,
+    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationStatusEnum,
     CIApplicationStatusSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
     CIApplicationStep2Schema,
+    CIApplicationStep3Schema,
     CITableOptionsSchema,
     FuelCodeOptionSchema,
     FuelTypeOptionSchema,
@@ -418,6 +424,68 @@ class CIApplicationServices:
         )
 
         ci_application.pathway_description = data.pathway_description
+        ci_application.update_user = user.keycloak_username
+        ci_application.action_type = ActionTypeEnum.UPDATE
+        await self.repo.update(ci_application)
+
+        ci = await self.repo.get_by_id(ci_application.ci_application_id)
+        return _to_full_schema(ci)
+
+    # ------------------------------------------------------------------
+    # Step 3 — Documents & GHGenius modelling
+    # ------------------------------------------------------------------
+
+    @service_handler
+    async def list_documents(
+        self, ci_application_id: int
+    ) -> List[CIApplicationDocumentSchema]:
+        """All Step 3 uploads for an application, with their categories."""
+        rows = await self.repo.get_documents_with_categories(ci_application_id)
+        return [
+            CIApplicationDocumentSchema(
+                document_id=document.document_id,
+                file_name=document.file_name,
+                file_size=document.file_size,
+                document_category=category,
+                create_date=(
+                    document.create_date.isoformat() if document.create_date else None
+                ),
+                create_user=document.create_user,
+            )
+            for document, category in rows
+        ]
+
+    @service_handler
+    async def update_step3(
+        self,
+        ci_application: CIApplication,
+        data: CIApplicationStep3Schema,
+        user: UserProfile,
+    ) -> CIApplicationSchema:
+        """
+        Persists the optional "other supporting" description and verifies
+        the mandatory uploads (Technical report + GHGenius model) are
+        present. Files are uploaded out-of-band via the generic document
+        endpoint with a category query param.
+        """
+        rows = await self.repo.get_documents_with_categories(
+            ci_application.ci_application_id
+        )
+        present_categories = {category for _, category in rows}
+        missing = []
+        if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
+            missing.append("Technical report")
+        if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
+            missing.append("GHGenius model")
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Missing required upload(s): " + ", ".join(missing) + "."
+                ),
+            )
+
+        ci_application.supporting_document_other = data.supporting_document_other
         ci_application.update_user = user.keycloak_username
         ci_application.action_type = ActionTypeEnum.UPDATE
         await self.repo.update(ci_application)

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -9,7 +9,7 @@ surface and OpenAPI contract are reserved while subsequent feature work
 fills them in.
 """
 
-from typing import List, Optional
+from typing import Optional
 
 import structlog
 from fastapi import APIRouter, Body, Depends, Request, status
@@ -18,7 +18,6 @@ from fastapi.responses import JSONResponse
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
-    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
@@ -193,23 +192,6 @@ async def update_ci_application_step2(
     """Step 2 — Proposed fuel pathways. Replaces the entire pathway set."""
     ci = await validate.validate_access(ci_application_id)
     return await service.update_step2(ci, data, request.user)
-
-
-@router.get(
-    "/{ci_application_id}/documents",
-    response_model=List[CIApplicationDocumentSchema],
-    status_code=status.HTTP_200_OK,
-)
-@view_handler(["*"])
-async def list_ci_application_documents(
-    request: Request,
-    ci_application_id: int,
-    service: CIApplicationServices = Depends(),
-    validate: CIApplicationValidation = Depends(),
-) -> List[CIApplicationDocumentSchema]:
-    """List Step 3 uploads with their categories."""
-    await validate.validate_access(ci_application_id)
-    return await service.list_documents(ci_application_id)
 
 
 @router.put(

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -9,7 +9,7 @@ surface and OpenAPI contract are reserved while subsequent feature work
 fills them in.
 """
 
-from typing import Optional
+from typing import List, Optional
 
 import structlog
 from fastapi import APIRouter, Body, Depends, Request, status
@@ -18,10 +18,12 @@ from fastapi.responses import JSONResponse
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
+    CIApplicationDocumentSchema,
     CIApplicationSchema,
     CIApplicationsListSchema,
     CIApplicationStep1Schema,
     CIApplicationStep2Schema,
+    CIApplicationStep3Schema,
     CITableOptionsSchema,
 )
 from lcfs.web.api.ci_application.services import CIApplicationServices
@@ -193,11 +195,39 @@ async def update_ci_application_step2(
     return await service.update_step2(ci, data, request.user)
 
 
-@router.put("/{ci_application_id}/step3", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.get(
+    "/{ci_application_id}/documents",
+    response_model=List[CIApplicationDocumentSchema],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(["*"])
+async def list_ci_application_documents(
+    request: Request,
+    ci_application_id: int,
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> List[CIApplicationDocumentSchema]:
+    """List Step 3 uploads with their categories."""
+    await validate.validate_access(ci_application_id)
+    return await service.list_documents(ci_application_id)
+
+
+@router.put(
+    "/{ci_application_id}/step3",
+    response_model=CIApplicationSchema,
+    status_code=status.HTTP_200_OK,
+)
 @view_handler([RoleEnum.CI_APPLICANT, RoleEnum.SIGNING_AUTHORITY])
-async def update_ci_application_step3(request: Request, ci_application_id: int):
-    """Step 3 — Documents & GHGenius modelling. To be implemented."""
-    return _not_implemented("Step 3 (Documents & GHGenius modelling)")
+async def update_ci_application_step3(
+    request: Request,
+    ci_application_id: int,
+    data: CIApplicationStep3Schema = Body(...),
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> CIApplicationSchema:
+    """Step 3 — Documents & GHGenius modelling. Validates required uploads."""
+    ci = await validate.validate_access(ci_application_id)
+    return await service.update_step3(ci, data, request.user)
 
 
 @router.post(

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -1,13 +1,14 @@
 from http.client import HTTPException
 from lcfs.web.api.admin_adjustment.validation import AdminAdjustmentValidation
 import structlog
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Request, UploadFile
+from fastapi import APIRouter, Depends, Query, Request, UploadFile
 from fastapi.params import File
 from starlette import status
 from starlette.responses import StreamingResponse
 
+from lcfs.db.dependencies import get_async_db_session
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.services.s3.client import DocumentService
 from lcfs.services.s3.schema import FileResponseSchema
@@ -15,6 +16,29 @@ from lcfs.web.api.compliance_report.validation import ComplianceReportValidation
 from lcfs.web.api.initiative_agreement.validation import InitiativeAgreementValidation
 from lcfs.web.api.charging_site.validation import ChargingSiteValidation
 from lcfs.web.core.decorators import view_handler
+
+
+# Lazy-resolved CI validation: see note inside ``ci_application_validator``.
+async def ci_application_validator(
+    request: Request,
+    db=Depends(get_async_db_session),
+):
+    """
+    Resolve a CIApplicationValidation instance on-demand.
+
+    Eagerly importing CIApplicationValidation at module load reaches
+    the ci_application repo, which transitively re-enters this module
+    via ``Document -> compliance_report -> s3.client``. Doing the
+    import inside the request scope breaks that cycle and keeps
+    FastAPI's DI behaviour intact.
+    """
+    from lcfs.web.api.ci_application.repo import CIApplicationRepository
+    from lcfs.web.api.ci_application.validation import CIApplicationValidation
+
+    return CIApplicationValidation(
+        request=request, repo=CIApplicationRepository(db=db)
+    )
+
 
 router = APIRouter()
 logger = structlog.get_logger(__name__)
@@ -51,11 +75,19 @@ async def upload_file(
     parent_id: int,
     parent_type: str,
     file: UploadFile = File(...),
+    document_category: Optional[str] = Query(
+        None,
+        description=(
+            "Optional Step 3 categorisation for ci_application uploads: "
+            "'technical_report', 'ghgenius_model', or 'supporting'."
+        ),
+    ),
     document_service: DocumentService = Depends(),
     cr_validate: ComplianceReportValidation = Depends(),
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ) -> FileResponseSchema:
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -69,8 +101,15 @@ async def upload_file(
     if parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
 
+    if parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
+
     document = await document_service.upload_file(
-        file, parent_id, parent_type, request.user
+        file,
+        parent_id,
+        parent_type,
+        request.user,
+        document_category=document_category,
     )
     return FileResponseSchema.model_validate(document)
 
@@ -89,6 +128,7 @@ async def stream_document(
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ):
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -101,6 +141,9 @@ async def stream_document(
 
     if parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
+
+    if parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
 
     file, document = await document_service.get_object(document_id)
 
@@ -127,6 +170,7 @@ async def delete_file(
     ia_validate: InitiativeAgreementValidation = Depends(),
     aa_validate: AdminAdjustmentValidation = Depends(),
     cs_validate: ChargingSiteValidation = Depends(),
+    ci_validate=Depends(ci_application_validator),
 ):
     if parent_type == "compliance_report":
         await cr_validate.validate_organization_access(parent_id)
@@ -136,6 +180,8 @@ async def delete_file(
         await aa_validate.validate_organization_access(parent_id)
     elif parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
+    elif parent_type == "ci_application":
+        await ci_validate.validate_access(parent_id)
     else:
         raise HTTPException(403, "Unable to verify authorization for document download")
 

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -63,6 +63,36 @@
       "atLeastOneRow": "At least one pathway is required."
     }
   },
+  "step3": {
+    "title": "Documents & GHGenius modelling",
+    "uploadedHeader": "Uploaded documents for application",
+    "noDocuments": "No documents uploaded yet.",
+    "supportingHeader": "Supporting documentation",
+    "uploadSupporting": "Upload supporting documentation",
+    "categoryTechnicalReport": "Technical report (required)",
+    "categorySupporting": "Other supporting document",
+    "notUploaded": "(not uploaded)",
+    "bullets": {
+      "technicalReport": "Technical report (required)",
+      "notification": "Notification of representation agreement form (optional, required if applicable)",
+      "other": "Other supporting documents — describe below (optional)"
+    },
+    "otherPlaceholder": "Brief description of other supporting documentation included",
+    "ghgeniusHeader": "GHGenius Modelling — Input & output tables",
+    "ghgeniusIntro": "Download the Excel template below and complete it with the required modelling input and output tables. When completed, upload the Excel spreadsheet.",
+    "uploadGHGenius": "Upload GHGenius model",
+    "downloadTemplate": "Download GHGenius Excel template",
+    "ghgeniusRequired": "GHGenius model upload is required.",
+    "saveAndProceed": "Save & proceed",
+    "saveSuccess": "Documents saved.",
+    "errors": {
+      "tooLarge": "File exceeds the 50 MB limit.",
+      "unsupportedType": "Unsupported file type. Allowed: PDF, Word, Excel, CSV, plain text, PNG, JPEG.",
+      "uploadFailed": "Upload failed.",
+      "deleteFailed": "Delete failed.",
+      "missingRequired": "Technical report and GHGenius model uploads are required."
+    }
+  },
   "stepStub": {
     "comingSoon": "This step is not yet available.",
     "description": "This part of the workflow will be implemented in a future task. The accordion above keeps your place in the wizard."

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -87,6 +87,7 @@ export const apiRoutes = {
   submitCIApplication: '/ci-applications/:ciApplicationId/submit',
   ciApplicationDecision: '/ci-applications/:ciApplicationId/decision',
   deleteCIApplication: '/ci-applications/:ciApplicationId',
+  ciApplicationDocuments: '/ci-applications/:ciApplicationId/documents',
 
   // reports
   getCompliancePeriods: '/reports/compliance-periods',

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -87,7 +87,6 @@ export const apiRoutes = {
   submitCIApplication: '/ci-applications/:ciApplicationId/submit',
   ciApplicationDecision: '/ci-applications/:ciApplicationId/decision',
   deleteCIApplication: '/ci-applications/:ciApplicationId',
-  ciApplicationDocuments: '/ci-applications/:ciApplicationId/documents',
 
   // reports
   getCompliancePeriods: '/reports/compliance-periods',

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -121,6 +121,90 @@ export const useUpdateCIApplicationStep2 = (ciApplicationId) => {
   })
 }
 
+export const useUpdateCIApplicationStep3 = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload) => {
+      return (
+        await client.put(
+          apiRoutes.updateCIApplicationStep3.replace(
+            ':ciApplicationId',
+            ciApplicationId
+          ),
+          payload
+        )
+      ).data
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ci-applications'] })
+      queryClient.setQueryData(QUERY_KEYS.detail(ciApplicationId), data)
+    }
+  })
+}
+
+export const useGetCIApplicationDocuments = (ciApplicationId, options) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!ciApplicationId,
+    queryKey: ['ci-application-documents', String(ciApplicationId)],
+    queryFn: async () => {
+      return (
+        await client.get(
+          apiRoutes.ciApplicationDocuments.replace(
+            ':ciApplicationId',
+            ciApplicationId
+          )
+        )
+      ).data
+    },
+    staleTime: 30 * 1000,
+    ...options
+  })
+}
+
+export const useUploadCIApplicationDocument = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ file, documentCategory }) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('filename', file.name)
+      const path = `/documents/ci_application/${ciApplicationId}`
+      return (
+        await client.post(path, formData, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          params: documentCategory
+            ? { document_category: documentCategory }
+            : undefined
+        })
+      ).data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['ci-application-documents', String(ciApplicationId)]
+      })
+    }
+  })
+}
+
+export const useDeleteCIApplicationDocument = (ciApplicationId) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (documentId) => {
+      const path = `/documents/ci_application/${ciApplicationId}/${documentId}`
+      return (await client.delete(path)).data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['ci-application-documents', String(ciApplicationId)]
+      })
+    }
+  })
+}
+
 export const useDeleteCIApplication = () => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -143,68 +143,6 @@ export const useUpdateCIApplicationStep3 = (ciApplicationId) => {
   })
 }
 
-export const useGetCIApplicationDocuments = (ciApplicationId, options) => {
-  const client = useApiService()
-  return useQuery({
-    enabled: !!ciApplicationId,
-    queryKey: ['ci-application-documents', String(ciApplicationId)],
-    queryFn: async () => {
-      return (
-        await client.get(
-          apiRoutes.ciApplicationDocuments.replace(
-            ':ciApplicationId',
-            ciApplicationId
-          )
-        )
-      ).data
-    },
-    staleTime: 30 * 1000,
-    ...options
-  })
-}
-
-export const useUploadCIApplicationDocument = (ciApplicationId) => {
-  const client = useApiService()
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async ({ file, documentCategory }) => {
-      const formData = new FormData()
-      formData.append('file', file)
-      formData.append('filename', file.name)
-      const path = `/documents/ci_application/${ciApplicationId}`
-      return (
-        await client.post(path, formData, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-          params: documentCategory
-            ? { document_category: documentCategory }
-            : undefined
-        })
-      ).data
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['ci-application-documents', String(ciApplicationId)]
-      })
-    }
-  })
-}
-
-export const useDeleteCIApplicationDocument = (ciApplicationId) => {
-  const client = useApiService()
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (documentId) => {
-      const path = `/documents/ci_application/${ciApplicationId}/${documentId}`
-      return (await client.delete(path)).data
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['ci-application-documents', String(ciApplicationId)]
-      })
-    }
-  })
-}
-
 export const useDeleteCIApplication = () => {
   const client = useApiService()
   const queryClient = useQueryClient()

--- a/frontend/src/hooks/useDocuments.js
+++ b/frontend/src/hooks/useDocuments.js
@@ -54,7 +54,16 @@ export const useUploadDocument = (parentType, parentID, options = {}) => {
   } = options
 
   return useMutation({
-    mutationFn: async (file) => {
+    mutationFn: async (input) => {
+      // Backwards compatible: callers can either pass a File directly
+      // (legacy signature) or a { file, documentCategory } object so
+      // CI applications can route uploads to a specific category bucket
+      // (technical_report / ghgenius_model / supporting).
+      const { file, documentCategory } =
+        input instanceof File || input instanceof Blob
+          ? { file: input, documentCategory: undefined }
+          : input || {}
+
       if (!file) {
         throw new Error('File is required for upload')
       }
@@ -74,6 +83,9 @@ export const useUploadDocument = (parentType, parentID, options = {}) => {
         headers: {
           'Content-Type': 'multipart/form-data'
         },
+        params: documentCategory
+          ? { document_category: documentCategory }
+          : undefined,
         onUploadProgress: onUploadProgress
       })
     },

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -25,7 +25,8 @@ import {
   useDeleteCIApplication,
   useGetCIApplication,
   useUpdateCIApplicationStep1,
-  useUpdateCIApplicationStep2
+  useUpdateCIApplicationStep2,
+  useUpdateCIApplicationStep3
 } from '@/hooks/useCIApplication'
 
 import {
@@ -34,6 +35,7 @@ import {
 } from './components/CIApplicationProgress'
 import { ApplicationInformationStep } from './components/ApplicationInformationStep'
 import { ProposedFuelPathwaysStep } from './components/ProposedFuelPathwaysStep'
+import { DocumentsModellingStep } from './components/DocumentsModellingStep'
 import { StepStub } from './components/StepStub'
 import { FuelCodesTabs } from './components/FuelCodesTabs'
 
@@ -63,10 +65,13 @@ const EditViewCIApplicationBase = () => {
     useUpdateCIApplicationStep1(ciApplicationId)
   const { mutateAsync: updateStep2, isPending: isUpdatingStep2 } =
     useUpdateCIApplicationStep2(ciApplicationId)
+  const { mutateAsync: updateStep3, isPending: isUpdatingStep3 } =
+    useUpdateCIApplicationStep3(ciApplicationId)
   const { mutateAsync: deleteDraft, isPending: isDeleting } =
     useDeleteCIApplication()
 
-  const isSaving = isCreating || isUpdating || isUpdatingStep2
+  const isSaving =
+    isCreating || isUpdating || isUpdatingStep2 || isUpdatingStep3
 
   const handleAccordionToggle = (key) => (_, isOpen) => {
     setExpanded((prev) =>
@@ -82,6 +87,28 @@ const EditViewCIApplicationBase = () => {
       window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [])
+
+  const handleStep3Save = useCallback(
+    async (payload) => {
+      try {
+        await updateStep3(payload)
+        alertRef.current?.triggerAlert?.({
+          message: t('carbonIntensity:step3.saveSuccess'),
+          severity: 'success'
+        })
+        goToStep(3)
+      } catch (err) {
+        alertRef.current?.triggerAlert?.({
+          message:
+            err?.response?.data?.detail ||
+            err?.message ||
+            'Failed to save Step 3.',
+          severity: 'error'
+        })
+      }
+    },
+    [updateStep3, goToStep, t]
+  )
 
   const handleStep2Save = useCallback(
     async (payload) => {
@@ -226,7 +253,16 @@ const EditViewCIApplicationBase = () => {
     ) : (
       <StepStub titleKey="carbonIntensity:steps.step2" />
     ),
-    step3: <StepStub titleKey="carbonIntensity:steps.step3" />,
+    step3: ciApplicationId ? (
+      <DocumentsModellingStep
+        ciApplication={ciApplication}
+        onSave={handleStep3Save}
+        onDelete={canDelete ? openDeleteConfirmation : null}
+        isSaving={isSaving || isDeleting}
+      />
+    ) : (
+      <StepStub titleKey="carbonIntensity:steps.step3" />
+    ),
     step4: <StepStub titleKey="carbonIntensity:steps.step4" />,
     step5: <StepStub titleKey="carbonIntensity:steps.step5" />
   }

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -26,16 +26,13 @@ let mockDocs = []
 const mockUpload = vi.fn().mockResolvedValue({})
 const mockDelete = vi.fn().mockResolvedValue({})
 
-vi.mock('@/hooks/useCIApplication', () => ({
-  useGetCIApplicationDocuments: vi.fn(() => ({
-    data: mockDocs,
-    isLoading: false
-  })),
-  useUploadCIApplicationDocument: vi.fn(() => ({
+vi.mock('@/hooks/useDocuments', () => ({
+  useDocuments: vi.fn(() => ({ data: mockDocs, isLoading: false })),
+  useUploadDocument: vi.fn(() => ({
     mutateAsync: mockUpload,
     isPending: false
   })),
-  useDeleteCIApplicationDocument: vi.fn(() => ({
+  useDeleteDocument: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
   }))
@@ -146,10 +143,9 @@ describe('DocumentsModellingStep', () => {
     fireEvent.change(screen.getByTestId('ci-step3-supporting-input'), {
       target: { files: [file] }
     })
+    // Shared validateFile utility surfaces "File type ... is not allowed".
     await waitFor(() =>
-      expect(
-        screen.getByText('carbonIntensity:step3.errors.unsupportedType')
-      ).toBeInTheDocument()
+      expect(screen.getByText(/is not allowed/i)).toBeInTheDocument()
     )
     expect(mockUpload).not.toHaveBeenCalled()
   })

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+
+import { DocumentsModellingStep } from '@/views/CarbonIntensity/components/DocumentsModellingStep'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+let mockDocs = []
+const mockUpload = vi.fn().mockResolvedValue({})
+const mockDelete = vi.fn().mockResolvedValue({})
+
+vi.mock('@/hooks/useCIApplication', () => ({
+  useGetCIApplicationDocuments: vi.fn(() => ({
+    data: mockDocs,
+    isLoading: false
+  })),
+  useUploadCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: mockUpload,
+    isPending: false
+  })),
+  useDeleteCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: mockDelete,
+    isPending: false
+  }))
+}))
+
+const baseCi = { ciApplicationId: 99, supportingDocumentOther: '' }
+
+describe('DocumentsModellingStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDocs = []
+  })
+  afterEach(cleanup)
+
+  it('renders the upload sections, description input, and Save button', () => {
+    render(
+      <DocumentsModellingStep
+        ciApplication={baseCi}
+        onSave={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(
+      screen.getByTestId('ci-step3-upload-supporting')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-upload-ghgenius')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('ci-step3-download-template')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('ci-step3-other-description')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-save-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-delete-btn')).toBeInTheDocument()
+  })
+
+  it('disables Save & proceed until both required uploads are present', () => {
+    mockDocs = [
+      { documentId: 1, fileName: 'x.pdf', fileSize: 100, documentCategory: 'technical_report' }
+    ]
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    expect(screen.getByTestId('ci-step3-save-btn')).toBeDisabled()
+  })
+
+  it('enables Save & proceed and submits when both required uploads exist', async () => {
+    mockDocs = [
+      { documentId: 1, fileName: 'tech.pdf', fileSize: 100, documentCategory: 'technical_report' },
+      { documentId: 2, fileName: 'model.xlsx', fileSize: 200, documentCategory: 'ghgenius_model' }
+    ]
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <DocumentsModellingStep
+        ciApplication={{ ...baseCi, supportingDocumentOther: 'CCS notes' }}
+        onSave={onSave}
+      />,
+      { wrapper }
+    )
+    const btn = screen.getByTestId('ci-step3-save-btn')
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    expect(onSave.mock.calls[0][0].supportingDocumentOther).toBe('CCS notes')
+  })
+
+  it('uploads a chosen file with the selected supporting category', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'tech.pdf', { type: 'application/pdf' })
+    const input = screen.getByTestId('ci-step3-supporting-input')
+    fireEvent.change(input, { target: { files: [file] } })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
+      'technical_report'
+    )
+  })
+
+  it('uploads a GHGenius file with category ghgenius_model', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'model.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    })
+    fireEvent.change(screen.getByTestId('ci-step3-ghgenius-input'), {
+      target: { files: [file] }
+    })
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
+      'ghgenius_model'
+    )
+  })
+
+  it('rejects an unsupported file type without calling upload', async () => {
+    render(
+      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
+      { wrapper }
+    )
+    const file = new File(['hi'], 'bad.exe', {
+      type: 'application/x-msdownload'
+    })
+    fireEvent.change(screen.getByTestId('ci-step3-supporting-input'), {
+      target: { files: [file] }
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText('carbonIntensity:step3.errors.unsupportedType')
+      ).toBeInTheDocument()
+    )
+    expect(mockUpload).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -86,15 +86,6 @@ vi.mock('@/hooks/useCIApplication', () => ({
     mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
     isPending: false
   })),
-  useGetCIApplicationDocuments: vi.fn(() => ({ data: [], isLoading: false })),
-  useUploadCIApplicationDocument: vi.fn(() => ({
-    mutateAsync: vi.fn(),
-    isPending: false
-  })),
-  useDeleteCIApplicationDocument: vi.fn(() => ({
-    mutateAsync: vi.fn(),
-    isPending: false
-  })),
   useDeleteCIApplication: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -82,11 +82,31 @@ vi.mock('@/hooks/useCIApplication', () => ({
     mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
     isPending: false
   })),
+  useUpdateCIApplicationStep3: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ ciApplicationId: 99 }),
+    isPending: false
+  })),
+  useGetCIApplicationDocuments: vi.fn(() => ({ data: [], isLoading: false })),
+  useUploadCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false
+  })),
+  useDeleteCIApplicationDocument: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false
+  })),
   useDeleteCIApplication: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
   }))
 }))
+
+vi.mock(
+  '@/views/CarbonIntensity/components/DocumentsModellingStep',
+  () => ({
+    DocumentsModellingStep: () => <div data-test="step3-stub" />
+  })
+)
 
 vi.mock(
   '@/views/CarbonIntensity/components/ProposedFuelPathwaysStep',

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -19,30 +19,23 @@ import BCAlert from '@/components/BCAlert'
 import BCButton from '@/components/BCButton'
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
-import colors from '@/themes/base/colors'
 import {
-  useDeleteCIApplicationDocument,
-  useGetCIApplicationDocuments,
-  useUploadCIApplicationDocument
-} from '@/hooks/useCIApplication'
+  COMPLIANCE_REPORT_FILE_TYPES,
+  MAX_FILE_SIZE_BYTES
+} from '@/constants/common'
+import {
+  useDeleteDocument,
+  useDocuments,
+  useUploadDocument
+} from '@/hooks/useDocuments'
+import colors from '@/themes/base/colors'
+import { validateFile } from '@/utils/fileValidation'
 
 export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
 export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
 export const DOC_CATEGORY_SUPPORTING = 'supporting'
 
-const ACCEPT_MIME = [
-  'application/pdf',
-  'image/png',
-  'image/jpeg',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'text/csv',
-  'text/plain'
-].join(',')
-
-const MAX_FILE_BYTES = 50 * 1024 * 1024
+const PARENT_TYPE = 'ci_application'
 
 const formatBytes = (bytes) => {
   if (bytes == null) return ''
@@ -51,10 +44,7 @@ const formatBytes = (bytes) => {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-const formatDate = (iso) => {
-  if (!iso) return ''
-  return iso.slice(0, 10)
-}
+const formatDate = (iso) => (iso ? String(iso).slice(0, 10) : '')
 
 export const DocumentsModellingStep = ({
   ciApplication,
@@ -77,12 +67,18 @@ export const DocumentsModellingStep = ({
   )
   const [uploadError, setUploadError] = useState(null)
 
-  const { data: documents = [], isLoading: isLoadingDocs } =
-    useGetCIApplicationDocuments(ciApplicationId)
-  const { mutateAsync: uploadDoc, isPending: isUploading } =
-    useUploadCIApplicationDocument(ciApplicationId)
-  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
-    useDeleteCIApplicationDocument(ciApplicationId)
+  const { data: documents = [], isLoading: isLoadingDocs } = useDocuments(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: uploadDoc, isPending: isUploading } = useUploadDocument(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } = useDeleteDocument(
+    PARENT_TYPE,
+    ciApplicationId
+  )
 
   const hasTechnicalReport = documents.some(
     (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
@@ -91,27 +87,21 @@ export const DocumentsModellingStep = ({
     (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
   )
 
-  const handlePickSupporting = () => {
-    setUploadError(null)
-    supportingFileRef.current?.click()
-  }
-  const handlePickGHGenius = () => {
-    setUploadError(null)
-    ghgeniusFileRef.current?.click()
-  }
-
   const handleFileChosen = async (event, category) => {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
-    if (file.size > MAX_FILE_BYTES) {
-      setUploadError(t('carbonIntensity:step3.errors.tooLarge'))
+
+    const result = validateFile(
+      file,
+      MAX_FILE_SIZE_BYTES,
+      COMPLIANCE_REPORT_FILE_TYPES
+    )
+    if (!result.isValid) {
+      setUploadError(result.errorMessage)
       return
     }
-    if (!ACCEPT_MIME.split(',').includes(file.type)) {
-      setUploadError(t('carbonIntensity:step3.errors.unsupportedType'))
-      return
-    }
+    setUploadError(null)
     try {
       await uploadDoc({ file, documentCategory: category })
     } catch (err) {
@@ -254,7 +244,7 @@ export const DocumentsModellingStep = ({
           variant="outlined"
           color="primary"
           startIcon={<CloudUploadIcon />}
-          onClick={handlePickSupporting}
+          onClick={() => supportingFileRef.current?.click()}
           disabled={readOnly || isUploading}
           data-test="ci-step3-upload-supporting"
         >
@@ -263,7 +253,7 @@ export const DocumentsModellingStep = ({
         <input
           ref={supportingFileRef}
           type="file"
-          accept={ACCEPT_MIME}
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
           hidden
           onChange={(e) => handleFileChosen(e, supportingCategory)}
           data-test="ci-step3-supporting-input"
@@ -325,7 +315,7 @@ export const DocumentsModellingStep = ({
           variant="outlined"
           color="primary"
           startIcon={<CloudUploadIcon />}
-          onClick={handlePickGHGenius}
+          onClick={() => ghgeniusFileRef.current?.click()}
           disabled={readOnly || isUploading}
           data-test="ci-step3-upload-ghgenius"
         >
@@ -345,7 +335,7 @@ export const DocumentsModellingStep = ({
         <input
           ref={ghgeniusFileRef}
           type="file"
-          accept={ACCEPT_MIME}
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
           hidden
           onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
           data-test="ci-step3-ghgenius-input"

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -1,0 +1,389 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  IconButton,
+  Link,
+  MenuItem,
+  Stack,
+  TextField,
+  Tooltip
+} from '@mui/material'
+import {
+  CloudUpload as CloudUploadIcon,
+  Delete as DeleteIcon,
+  FileDownload as FileDownloadIcon
+} from '@mui/icons-material'
+
+import BCAlert from '@/components/BCAlert'
+import BCButton from '@/components/BCButton'
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import colors from '@/themes/base/colors'
+import {
+  useDeleteCIApplicationDocument,
+  useGetCIApplicationDocuments,
+  useUploadCIApplicationDocument
+} from '@/hooks/useCIApplication'
+
+export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
+export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
+export const DOC_CATEGORY_SUPPORTING = 'supporting'
+
+const ACCEPT_MIME = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/csv',
+  'text/plain'
+].join(',')
+
+const MAX_FILE_BYTES = 50 * 1024 * 1024
+
+const formatBytes = (bytes) => {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+const formatDate = (iso) => {
+  if (!iso) return ''
+  return iso.slice(0, 10)
+}
+
+export const DocumentsModellingStep = ({
+  ciApplication,
+  onSave,
+  onDelete,
+  isSaving = false,
+  readOnly = false
+}) => {
+  const { t } = useTranslation(['common', 'carbonIntensity'])
+  const ciApplicationId = ciApplication?.ciApplicationId
+
+  const supportingFileRef = useRef(null)
+  const ghgeniusFileRef = useRef(null)
+
+  const [supportingCategory, setSupportingCategory] = useState(
+    DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const [otherDescription, setOtherDescription] = useState(
+    ciApplication?.supportingDocumentOther || ''
+  )
+  const [uploadError, setUploadError] = useState(null)
+
+  const { data: documents = [], isLoading: isLoadingDocs } =
+    useGetCIApplicationDocuments(ciApplicationId)
+  const { mutateAsync: uploadDoc, isPending: isUploading } =
+    useUploadCIApplicationDocument(ciApplicationId)
+  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
+    useDeleteCIApplicationDocument(ciApplicationId)
+
+  const hasTechnicalReport = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const hasGHGeniusModel = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
+  )
+
+  const handlePickSupporting = () => {
+    setUploadError(null)
+    supportingFileRef.current?.click()
+  }
+  const handlePickGHGenius = () => {
+    setUploadError(null)
+    ghgeniusFileRef.current?.click()
+  }
+
+  const handleFileChosen = async (event, category) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    if (file.size > MAX_FILE_BYTES) {
+      setUploadError(t('carbonIntensity:step3.errors.tooLarge'))
+      return
+    }
+    if (!ACCEPT_MIME.split(',').includes(file.type)) {
+      setUploadError(t('carbonIntensity:step3.errors.unsupportedType'))
+      return
+    }
+    try {
+      await uploadDoc({ file, documentCategory: category })
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.uploadFailed')
+      )
+    }
+  }
+
+  const handleDelete = async (documentId) => {
+    try {
+      await deleteDoc(documentId)
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.deleteFailed')
+      )
+    }
+  }
+
+  const canProceed = hasTechnicalReport && hasGHGeniusModel && !readOnly
+
+  const handleSaveAndProceed = async () => {
+    setUploadError(null)
+    if (!hasTechnicalReport || !hasGHGeniusModel) {
+      setUploadError(t('carbonIntensity:step3.errors.missingRequired'))
+      return
+    }
+    await onSave?.({ supportingDocumentOther: otherDescription || null })
+  }
+
+  return (
+    <Box>
+      <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
+        {t('carbonIntensity:step3.title')}
+      </BCTypography>
+
+      {/* Uploaded documents list */}
+      <BCBox
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          mb: 3,
+          maxHeight: 240,
+          overflowY: 'auto'
+        }}
+        data-test="ci-step3-uploaded-list"
+      >
+        <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+          {t('carbonIntensity:step3.uploadedHeader')}
+        </BCTypography>
+        {isLoadingDocs ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('common:loading')}
+          </BCTypography>
+        ) : documents.length === 0 ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('carbonIntensity:step3.noDocuments')}
+          </BCTypography>
+        ) : (
+          documents.map((doc) => (
+            <Box
+              key={doc.documentId}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '2fr 1fr 1fr 1fr auto',
+                alignItems: 'center',
+                py: 0.5,
+                gap: 2
+              }}
+              data-test="ci-step3-uploaded-row"
+            >
+              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+                {doc.fileName}
+              </Link>
+              <BCTypography variant="body2">
+                {formatBytes(doc.fileSize)}
+              </BCTypography>
+              <BCTypography variant="body2">{doc.createUser || ''}</BCTypography>
+              <BCTypography variant="body2">
+                {formatDate(doc.createDate)}
+              </BCTypography>
+              {!readOnly && (
+                <Tooltip title={t('common:deleteBtn')}>
+                  <span>
+                    <IconButton
+                      aria-label="delete document"
+                      size="small"
+                      onClick={() => handleDelete(doc.documentId)}
+                      disabled={isDeletingDoc}
+                      data-test="ci-step3-delete-doc"
+                    >
+                      <DeleteIcon fontSize="small" color="error" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+            </Box>
+          ))
+        )}
+      </BCBox>
+
+      {uploadError && (
+        <Box mb={2}>
+          <BCAlert severity="error" onClose={() => setUploadError(null)}>
+            {uploadError}
+          </BCAlert>
+        </Box>
+      )}
+
+      {/* Supporting documentation */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.supportingHeader')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
+        <TextField
+          select
+          size="small"
+          value={supportingCategory}
+          onChange={(e) => setSupportingCategory(e.target.value)}
+          disabled={readOnly}
+          sx={{ minWidth: 280 }}
+          inputProps={{ 'data-test': 'ci-step3-supporting-category' }}
+        >
+          <MenuItem value={DOC_CATEGORY_TECHNICAL_REPORT}>
+            {t('carbonIntensity:step3.categoryTechnicalReport')}
+          </MenuItem>
+          <MenuItem value={DOC_CATEGORY_SUPPORTING}>
+            {t('carbonIntensity:step3.categorySupporting')}
+          </MenuItem>
+        </TextField>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<CloudUploadIcon />}
+          onClick={handlePickSupporting}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-supporting"
+        >
+          {t('carbonIntensity:step3.uploadSupporting')}
+        </BCButton>
+        <input
+          ref={supportingFileRef}
+          type="file"
+          accept={ACCEPT_MIME}
+          hidden
+          onChange={(e) => handleFileChosen(e, supportingCategory)}
+          data-test="ci-step3-supporting-input"
+        />
+      </Stack>
+
+      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.technicalReport')}
+            {!hasTechnicalReport && (
+              <BCTypography
+                component="span"
+                variant="body2"
+                color="error"
+                sx={{ ml: 1 }}
+              >
+                {t('carbonIntensity:step3.notUploaded')}
+              </BCTypography>
+            )}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.notification')}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.other')}
+          </BCTypography>
+        </li>
+      </Box>
+
+      <TextField
+        fullWidth
+        value={otherDescription}
+        onChange={(e) => setOtherDescription(e.target.value)}
+        disabled={readOnly}
+        placeholder={t('carbonIntensity:step3.otherPlaceholder')}
+        inputProps={{
+          'data-test': 'ci-step3-other-description',
+          maxLength: 1000
+        }}
+        sx={{ mb: 4 }}
+      />
+
+      {/* GHGenius modelling */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.ghgeniusHeader')}
+      </BCTypography>
+      <BCTypography variant="body2" sx={{ mb: 2 }}>
+        {t('carbonIntensity:step3.ghgeniusIntro')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<CloudUploadIcon />}
+          onClick={handlePickGHGenius}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-ghgenius"
+        >
+          {t('carbonIntensity:step3.uploadGHGenius')}
+        </BCButton>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          startIcon={<FileDownloadIcon />}
+          href="/templates/ghgenius-input-output.xlsx"
+          download
+          data-test="ci-step3-download-template"
+        >
+          {t('carbonIntensity:step3.downloadTemplate')}
+        </BCButton>
+        <input
+          ref={ghgeniusFileRef}
+          type="file"
+          accept={ACCEPT_MIME}
+          hidden
+          onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
+          data-test="ci-step3-ghgenius-input"
+        />
+      </Stack>
+
+      {!hasGHGeniusModel && (
+        <BCTypography variant="body2" color="error" sx={{ mb: 2 }}>
+          {t('carbonIntensity:step3.ghgeniusRequired')}
+        </BCTypography>
+      )}
+
+      <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+        <BCButton
+          type="button"
+          variant="contained"
+          color="primary"
+          onClick={handleSaveAndProceed}
+          disabled={!canProceed || isSaving || isUploading}
+          data-test="ci-step3-save-btn"
+        >
+          {t('carbonIntensity:step3.saveAndProceed')}
+        </BCButton>
+        {ciApplicationId && onDelete && (
+          <BCButton
+            type="button"
+            variant="outlined"
+            color="error"
+            onClick={onDelete}
+            disabled={readOnly || isSaving}
+            data-test="ci-step3-delete-btn"
+          >
+            {t('carbonIntensity:step1.deleteDraft')}
+          </BCButton>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+DocumentsModellingStep.displayName = 'DocumentsModellingStep'


### PR DESCRIPTION
## Summary
- Implements Step 3 of the BCeID CI application wizard (issue #4201): file uploads with mandatory Technical report + GHGenius model, optional supporting docs, and a free-text description.
- New ``document_category`` column on ``ci_application_document_association`` lets the same Document row carry different meanings per CI application without polluting the global Document table.
- Reuses the existing S3 ``DocumentService`` by wiring ``ci_application`` as a first-class ``parent_type`` and threading a ``document_category`` query param through the upload endpoint.
- ``PUT /step3`` validates that both mandatory uploads exist and persists ``supporting_document_other``.

> Stacked on top of #4365 (Step 2). Targets that branch — please merge it first, then this will retarget upstream.

## Test plan
- [x] Backend: ``pytest lcfs/tests/ci_application`` passes (40 unit tests, 4 new for Step 3 covering list, success, and the two missing-required guards).
- [x] Frontend: ``vitest run src/views/CarbonIntensity`` passes (53 tests, 6 new — render, gating, category routing for both upload buttons, unsupported MIME rejection).
- [ ] Manual: walk through Step 1 → 2 → 3 as a CI Applicant; upload a tech report (Supporting category) and a GHGenius model, verify the file table updates, delete a doc, save & proceed advances to Step 4.
- [ ] Manual: confirm Save & proceed is disabled until both required uploads exist and re-enables once both are present.
- [ ] Manual: try uploading a 51 MB file and an ``.exe`` to confirm the client-side guards.
- [ ] Accessibility: keyboard-only nav across the file inputs, category dropdown, Save & proceed, Delete draft.