### PR TITLE
hotfix: disable cancel/close in BCModal while submitting (#4367)

### DIFF
--- a/frontend/src/components/BCModal.jsx
+++ b/frontend/src/components/BCModal.jsx
@@ -48,7 +48,10 @@ const BCModal = ({ open, onClose, data = null }) => {
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={() => {
+        if (isLoading) return
+        onClose()
+      }}
       maxWidth="md"
       fullWidth
       data-test="modal"
@@ -57,6 +60,7 @@ const BCModal = ({ open, onClose, data = null }) => {
       <IconButton
         aria-label="close"
         onClick={onClose}
+        disabled={isLoading}
         sx={{
           position: 'absolute',
           right: 8,
@@ -96,6 +100,7 @@ const BCModal = ({ open, onClose, data = null }) => {
             }
             color={secondaryButtonColor ?? 'dark'}
             onClick={secondaryButtonAction ?? onClose}
+            disabled={isLoading}
             data-test="modal-btn-secondary"
           >
             {secondaryButtonText}


### PR DESCRIPTION
## Summary
- Cherry-picks 9cc484b08 from [fix/alex-duplicate-submission-4367](https://github.com/bcgov/lcfs/tree/fix/alex-duplicate-submission-4367) onto main as a hotfix.
- Disables the cancel and close buttons in `BCModal` while a submission is in flight to prevent duplicate submissions seen in production.

## Test plan
- [ ] Verify cancel/close buttons are disabled during submission
- [ ] Verify buttons re-enable after submission completes or errors
- [ ] Smoke test on prod-like environment