### PR TITLE
hotfix: prevent duplicate Reserved transactions on report submission (#4368)

### DIFF
--- a/backend/lcfs/tests/compliance_report/conftest.py
+++ b/backend/lcfs/tests/compliance_report/conftest.py
@@ -174,6 +174,7 @@ def mock_trxn_repo():
     repo.calculate_available_balance_for_period = AsyncMock(return_value=2000)
     repo.delete_transaction = AsyncMock()
     repo.get_group_adjustments_excluded_from_line_17 = AsyncMock(return_value=0)
+    repo.get_reserved_transaction_by_id = AsyncMock(return_value=None)
     return repo
 
 

--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -151,6 +151,89 @@ async def test_update_compliance_report_no_status_change(
 
 
 @pytest.mark.anyio
+async def test_handle_submitted_status_blocks_duplicate_when_reserved_exists(
+    compliance_report_update_service,
+    mock_user_has_roles,
+    mock_repo,
+    mock_trxn_repo,
+):
+    """Regression guard for incident 4368.
+
+    Repeat clicks on Sign-and-Submit each ran the full submitted handler,
+    minting one duplicate Reserved transaction per click.
+    handle_submitted_status must refuse to run a second time as soon as a
+    Reserved transaction already exists for the report — before any
+    notifications, FSE auto-submit, summary calc, or transaction creation.
+    """
+    mock_user_has_roles.return_value = True
+
+    report_id = 1
+    report = MagicMock(spec=ComplianceReport)
+    report.compliance_report_id = report_id
+    report.organization_id = 1
+    report.transaction_id = 100  # left behind by the first submit
+    report.compliance_report_group_uuid = "test-uuid"
+
+    existing_reserve = MagicMock()
+    existing_reserve.transaction_id = 100
+    mock_trxn_repo.get_reserved_transaction_by_id.return_value = existing_reserve
+
+    user = MagicMock(spec=UserProfile)
+    user.keycloak_username = "test-user"
+
+    with pytest.raises(HTTPException) as exc:
+        await compliance_report_update_service.handle_submitted_status(
+            report, user
+        )
+
+    assert exc.value.status_code == 409
+    # Critical: nothing downstream ran — no FSE auto-submit, no summary
+    # calc, no new transaction, no repo update.
+    mock_repo.update_compliance_report.assert_not_called()
+    mock_trxn_repo.create_transaction.assert_not_called()
+    mock_trxn_repo.get_reserved_transaction_by_id.assert_called_once_with(
+        100
+    )
+
+
+@pytest.mark.anyio
+async def test_create_or_update_reserve_uses_persisted_transaction(
+    compliance_report_update_service, mock_trxn_repo
+):
+    """Even if the in-memory `report.transaction` relationship is None
+    (stale identity map, cross-request reload), as long as report.transaction_id
+    points at a real Reserved row, the persisted row must be updated rather
+    than a new one inserted. This is the second line of defence for the
+    duplicate-submission bug."""
+    org_service = compliance_report_update_service.org_service
+    org_service.calculate_available_balance = AsyncMock(return_value=1_000_000)
+    org_service.adjust_balance = AsyncMock()
+    compliance_report_update_service._calculate_pre_deadline_balance = AsyncMock(
+        return_value=1_000_000
+    )
+
+    persisted = MagicMock()
+    persisted.transaction_id = 100
+    persisted.compliance_units = 50
+    mock_trxn_repo.get_reserved_transaction_by_id.return_value = persisted
+
+    report = MagicMock(spec=ComplianceReport)
+    report.compliance_report_id = 1
+    report.organization_id = 1
+    report.transaction_id = 100
+    report.transaction = None  # stale relationship — the bug condition
+
+    await compliance_report_update_service._create_or_update_reserve_transaction(
+        credit_change=50, report=report
+    )
+
+    # Persisted row was updated, no new transaction created.
+    assert persisted.compliance_units == 50
+    org_service.adjust_balance.assert_not_called()
+    assert report.transaction is persisted
+
+
+@pytest.mark.anyio
 async def test_update_compliance_report_not_found(
     compliance_report_update_service, mock_repo
 ):

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -37,6 +37,10 @@ from lcfs.web.api.organization_snapshot.schema import OrganizationSnapshotSchema
 from lcfs.web.api.role.schema import user_has_roles
 from lcfs.web.api.transaction.services import TransactionsService
 from lcfs.web.exception.exceptions import DataNotFoundException, ServiceException
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 
 # Import TYPE_CHECKING to avoid circular imports at runtime
 from typing import TYPE_CHECKING
@@ -296,6 +300,30 @@ class ComplianceReportUpdateService:
         )
         if not has_supplier_roles:
             raise HTTPException(status_code=403, detail="Forbidden.")
+
+        # Idempotency guard. If a Reserved transaction already exists for
+        # this report, a prior submission already ran — re-running here
+        # would mint a duplicate Reserved row, re-send notifications, and
+        # corrupt the org's available_balance. Incident 4368: a report
+        # ended up with 7 duplicate Reserved rows because repeat clicks on
+        # Sign-and-Submit each got a fresh handler run.
+        existing_reserve = await self._fetch_reserved_transaction_for_report(
+            report
+        )
+        if existing_reserve is not None:
+            logger.warning(
+                "compliance_report.submit.duplicate_blocked",
+                report_id=report.compliance_report_id,
+                existing_transaction_id=existing_reserve.transaction_id,
+                user=user.keycloak_username,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "This report has already been submitted. "
+                    "Refresh the page to see the current state."
+                ),
+            )
 
         # Validate organization details are complete before submission
         await self._validate_organization_details_for_submission(
@@ -607,9 +635,21 @@ class ComplianceReportUpdateService:
             )
             units_to_reserve = -eligible_units
 
-        if report.transaction is not None:
-            # update existing transaction
-            report.transaction.compliance_units = units_to_reserve
+        # Defensive: never trust the in-memory relationship alone. If the
+        # report row already has a transaction_id pointing at a Reserved row,
+        # update *that* row instead of inserting a new one. This is the second
+        # line of defence against the duplicate-submission bug — even if a
+        # concurrent request bypasses the idempotency guard above, two writers
+        # racing here will both see the same persisted transaction_id and
+        # update the same row.
+        existing_transaction = await self._fetch_reserved_transaction_for_report(
+            report
+        )
+
+        if existing_transaction is not None:
+            existing_transaction.compliance_units = units_to_reserve
+            report.transaction = existing_transaction
+            report.transaction_id = existing_transaction.transaction_id
         elif credit_change != 0 and (
             effective_available_balance > 0 or credit_change > 0
         ):
@@ -621,6 +661,18 @@ class ComplianceReportUpdateService:
             )
 
         return units_to_reserve
+
+    async def _fetch_reserved_transaction_for_report(self, report):
+        """Return the persisted Reserved transaction for this report, if any.
+
+        Reads through the DB rather than the SQLAlchemy relationship so it
+        catches the case where a prior request already created a transaction
+        but this request loaded `report.transaction` as None (stale identity
+        map / unflushed session / cross-request reload).
+        """
+        return await self.trx_service.repo.get_reserved_transaction_by_id(
+            report.transaction_id
+        )
 
     async def _calculate_pre_deadline_balance(self, report: ComplianceReport) -> int:
         compliance_period = getattr(report, "compliance_period", None)

--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -760,6 +760,29 @@ class TransactionRepository:
         return new_transaction
 
     @repo_handler
+    async def get_reserved_transaction_by_id(
+        self, transaction_id: int
+    ) -> "Transaction | None":
+        """Fetch a Reserved transaction by id, or None if it does not exist
+        or is not currently in Reserved state.
+
+        Used as the source of truth for the duplicate-submission idempotency
+        guard: when a compliance report claims a `transaction_id`, this
+        confirms (against the DB, not a stale ORM relationship) that it
+        points at a live Reserved row that should be updated rather than
+        replaced.
+        """
+        if not transaction_id:
+            return None
+        result = await self.db.execute(
+            select(Transaction).where(
+                Transaction.transaction_id == transaction_id,
+                Transaction.transaction_action == TransactionActionEnum.Reserved,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @repo_handler
     async def reserve_transaction(self, transaction_id: int) -> bool:
         """
         Attempt to reserve a transaction by updating its transaction_action to Reserved.

--- a/frontend/src/assets/locales/en/reports.json
+++ b/frontend/src/assets/locales/en/reports.json
@@ -91,6 +91,7 @@
     "issueExemptionBtn": "Issue exemption"
   },
   "savedSuccessText": "Compliance report successfully {{status}}",
+  "alreadyAdvancedText": "This report has already been updated. Showing the latest version.",
   "supplementalCreatedSuccessText": "Supplemental report created successfully",
   "reportDeleteSuccessText": "Draft compliance report successfully deleted",
   "submitConfirmText": "Are you sure you want to sign and submit this compliance report?",

--- a/frontend/src/components/BCModal.jsx
+++ b/frontend/src/components/BCModal.jsx
@@ -48,7 +48,10 @@ const BCModal = ({ open, onClose, data = null }) => {
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={() => {
+        if (isLoading) return
+        onClose()
+      }}
       maxWidth="md"
       fullWidth
       data-test="modal"
@@ -57,6 +60,7 @@ const BCModal = ({ open, onClose, data = null }) => {
       <IconButton
         aria-label="close"
         onClick={onClose}
+        disabled={isLoading}
         sx={{
           position: 'absolute',
           right: 8,
@@ -96,6 +100,7 @@ const BCModal = ({ open, onClose, data = null }) => {
             }
             color={secondaryButtonColor ?? 'dark'}
             onClick={secondaryButtonAction ?? onClose}
+            disabled={isLoading}
             data-test="modal-btn-secondary"
           >
             {secondaryButtonText}

--- a/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
+++ b/frontend/src/views/ComplianceReports/EditViewComplianceReport.jsx
@@ -295,10 +295,16 @@ export const EditViewComplianceReport = ({ isError, error }) => {
 
         // If Director is acting as another role, stay on the report page and show alert
         if (hasRoles(roles.director)) {
-          // Invalidate queries to refresh the report data
+          // Invalidate queries to refresh the report data. Cache key is
+          // kebab-case (`compliance-report`); the previous camelCase key
+          // here was a silent no-op, leaving stale data on the page.
           queryClient.invalidateQueries(['compliance-reports'])
-          queryClient.invalidateQueries(['complianceReport', complianceReportId])
-          
+          queryClient.invalidateQueries(['compliance-report', complianceReportId])
+          queryClient.invalidateQueries([
+            'compliance-report-summary',
+            complianceReportId
+          ])
+
           // Show success alert on the current page
           alertRef.current?.triggerAlert({
             message: t('report:savedSuccessText', {
@@ -323,6 +329,42 @@ export const EditViewComplianceReport = ({ isError, error }) => {
       },
       onError: (error) => {
         setModalData(null)
+
+        // 409 from the backend means the report has already advanced
+        // (e.g. another tab / a previous click already submitted it). Treat
+        // it as a success-ish state: refresh caches and navigate the user
+        // to the list so they see the actual current state instead of a
+        // confusing "error" toast that pushes them to retry.
+        if (error?.response?.status === 409) {
+          queryClient.invalidateQueries(['compliance-reports'])
+          queryClient.invalidateQueries(['compliance-report', complianceReportId])
+          queryClient.invalidateQueries([
+            'compliance-report-summary',
+            complianceReportId
+          ])
+
+          if (!hasRoles(roles.director)) {
+            sessionStorage.setItem(FILTER_KEYS.COMPLIANCE_REPORT_GRID, '{}')
+            navigate(ROUTES.REPORTS.LIST, {
+              state: {
+                message:
+                  error?.response?.data?.detail ??
+                  t('report:alreadyAdvancedText'),
+                severity: 'info'
+              }
+            })
+            return
+          }
+
+          alertRef.current?.triggerAlert({
+            message:
+              error?.response?.data?.detail ??
+              t('report:alreadyAdvancedText'),
+            severity: 'info'
+          })
+          return
+        }
+
         alertRef.current?.triggerAlert({
           message: error.message,
           severity: 'error'


### PR DESCRIPTION
## Summary

Hotfix to `main` for incident 4368 — repeat clicks on Sign-and-Submit (and analyst recommend)

Note: this hotfix supersedes [#4370](https://github.com/bcgov/lcfs/pull/4370) — the BCModal-only modal hotfix that already shipped to main is included here as part of the cherry-pick (same diff, no conflict). Now bundled with the backend idempotency guard so the bug is fixed at the root, not just papered over at the UI.

## Changes

- **`handle_submitted_status`**: returns 409 when a Reserved transaction already exists for the report, before any FSE auto-submit, summary calc, or notification fan-out runs.
- **`_create_or_update_reserve_transaction`**: looks up the persisted Reserved row by `report.transaction_id` (via new `TransactionRepository.get_reserved_transaction_by_id`) rather than trusting the in-memory relationship — concurrent or cross-request retries collapse onto the same row.
- **Frontend** (`EditViewComplianceReport.jsx`): treats 409 as "already advanced" rather than a generic error — refreshes caches and navigates to the list with an info banner. Also fixes a silent cache-key typo (`['complianceReport', id]` → `['compliance-report', id]`) that left stale data on screen for the Director path.
- **BCModal**: disables cancel/close while a submission is in flight (already on main via #4370; included in the cherry-pick).

Cleanup of the existing orphan Reserved rows in prod is being handled out-of-band by an operator; SQL is intentionally not committed.

## Test plan
- [x] poetry run pytest lcfs/tests/compliance_report lcfs/tests/transaction — 523 passed
- [x] npx vitest run src/views/ComplianceReports/__tests__/EditViewComplianceReport.test.jsx — 98 passed
- [x] npx vitest run src/components/__tests__/BCModal — 7 passed
- [ ] Verify on prod-like env: single submission produces one Reserved row.
- [ ] Verify repeat-click: second click returns 409, friendly UI message, no new transaction inserted.
- [ ] Run orphan-cleanup SQL out-of-band after this hotfix lands on prod.