### PR TITLE
fix: lock compliance_report row to prevent concurrent submission duplicates (release)

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -172,6 +172,10 @@ async def test_handle_submitted_status_blocks_duplicate_when_reserved_exists(
     report.transaction_id = 100  # left behind by the first submit
     report.compliance_report_group_uuid = "test-uuid"
 
+    # The lock returns the persisted transaction_id — what the row-level
+    # lock acquires and what the idempotency guard then reads against.
+    mock_repo.lock_compliance_report_row.return_value = 100
+
     existing_reserve = MagicMock()
     existing_reserve.transaction_id = 100
     mock_trxn_repo.get_reserved_transaction_by_id.return_value = existing_reserve
@@ -192,6 +196,56 @@ async def test_handle_submitted_status_blocks_duplicate_when_reserved_exists(
     mock_trxn_repo.get_reserved_transaction_by_id.assert_called_once_with(
         100
     )
+
+
+@pytest.mark.anyio
+async def test_handle_submitted_status_lock_resyncs_transaction_id(
+    compliance_report_update_service,
+    mock_user_has_roles,
+    mock_repo,
+    mock_trxn_repo,
+):
+    """Concurrent-race regression for incident 4368.
+
+    Two in-flight submit requests both read the report with
+    transaction_id=NULL. The first commits, the second blocks on the row
+    lock. When the second wakes up its in-memory `report.transaction_id`
+    is still NULL — but the lock returns the freshly-persisted value, and
+    the handler must trust *that* (not the stale ORM attribute) for the
+    idempotency check. Without this resync the second writer would mint
+    a duplicate Reserved row and leave the first one orphaned.
+    """
+    mock_user_has_roles.return_value = True
+
+    report_id = 1
+    report = MagicMock(spec=ComplianceReport)
+    report.compliance_report_id = report_id
+    report.organization_id = 1
+    report.transaction_id = None  # stale — loaded before the lock
+    report.compliance_report_group_uuid = "test-uuid"
+
+    # First writer already committed transaction 200; our lock acquisition
+    # returns that fresh value.
+    mock_repo.lock_compliance_report_row.return_value = 200
+
+    existing_reserve = MagicMock()
+    existing_reserve.transaction_id = 200
+    mock_trxn_repo.get_reserved_transaction_by_id.return_value = existing_reserve
+
+    user = MagicMock(spec=UserProfile)
+    user.keycloak_username = "test-user"
+
+    with pytest.raises(HTTPException) as exc:
+        await compliance_report_update_service.handle_submitted_status(
+            report, user
+        )
+
+    assert exc.value.status_code == 409
+    # The idempotency check must use the lock-returned id (200), not the
+    # stale in-memory None.
+    mock_trxn_repo.get_reserved_transaction_by_id.assert_called_once_with(200)
+    mock_trxn_repo.create_transaction.assert_not_called()
+    mock_repo.update_compliance_report.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -653,6 +653,24 @@ class ComplianceReportRepository:
         return compliance_report
 
     @repo_handler
+    async def lock_compliance_report_row(self, report_id: int) -> Optional[int]:
+        """Take a row-level lock on the compliance_report row and return its
+        current persisted transaction_id.
+
+        Serialises concurrent handlers that mint a Reserved transaction for
+        the same report (incident 4368). Returns the freshly-read
+        transaction_id so the caller can detect a sibling writer that
+        already committed a Reserved row — using the in-memory ORM value
+        would defeat the lock, since it was loaded before we blocked.
+        """
+        result = await self.db.execute(
+            select(ComplianceReport.transaction_id)
+            .where(ComplianceReport.compliance_report_id == report_id)
+            .with_for_update()
+        )
+        return result.scalar_one_or_none()
+
+    @repo_handler
     async def get_compliance_report_schema_by_id(
         self, report_id: int
     ) -> ComplianceReportBaseSchema | None:

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -303,12 +303,23 @@ class ComplianceReportUpdateService:
         if not has_supplier_roles:
             raise HTTPException(status_code=403, detail="Forbidden.")
 
+        # Serialise concurrent submissions of the same report. Without this
+        # lock the idempotency check below is a TOCTOU race: two in-flight
+        # requests both read transaction_id=NULL, both create a Reserved
+        # transaction, and the second UPDATE leaves the first row orphaned
+        # (incident 4368 follow-up — the original hotfix only closed the
+        # sequential repeat-click window). The lock returns the freshly
+        # persisted transaction_id; we sync it back onto the report so the
+        # rest of the handler can't act on a stale in-memory value.
+        persisted_transaction_id = await self.repo.lock_compliance_report_row(
+            report.compliance_report_id
+        )
+        report.transaction_id = persisted_transaction_id
+
         # Idempotency guard. If a Reserved transaction already exists for
         # this report, a prior submission already ran — re-running here
         # would mint a duplicate Reserved row, re-send notifications, and
-        # corrupt the org's available_balance. Incident 4368: a report
-        # ended up with 7 duplicate Reserved rows because repeat clicks on
-        # Sign-and-Submit each got a fresh handler run.
+        # corrupt the org's available_balance.
         existing_reserve = await self._fetch_reserved_transaction_for_report(
             report
         )
@@ -423,6 +434,17 @@ class ComplianceReportUpdateService:
         ):
             credit_change = report.summary.line_20_surplus_deficit_units
             if credit_change != 0:
+                # Same TOCTOU race as supplier submission — two analysts
+                # (or one analyst clicking twice) both reading
+                # transaction_id=NULL would each mint a Reserved row.
+                # Serialise via the same row lock and resync the
+                # in-memory transaction_id from the persisted value.
+                persisted_transaction_id = (
+                    await self.repo.lock_compliance_report_row(
+                        report.compliance_report_id
+                    )
+                )
+                report.transaction_id = persisted_transaction_id
                 await self._create_or_update_reserve_transaction(
                     credit_change, report
                 )


### PR DESCRIPTION
## Summary

Release-branch counterpart of #4393 (which targets `main`). Cherry-pick of the same commit.

Follow-up hotfix to #4368. The original idempotency fix closed the sequential repeat-click window but left a TOCTOU race open for genuinely concurrent submissions — two in-flight requests both read `compliance_report.transaction_id = NULL`, both create a Reserved transaction, and the second `UPDATE` orphans the first. The orphaned row surfaces in the transactions UI as a "Legacy Transaction" (display label for `StandaloneTransaction` in `mv_transaction_aggregate`).

- New `ComplianceReportRepository.lock_compliance_report_row` issues `SELECT compliance_report.transaction_id … FOR UPDATE` and returns the persisted `transaction_id`.
- `handle_submitted_status` and `handle_recommended_by_analyst_status` (government reassessment path) take the lock **before** the idempotency check and resync `report.transaction_id` from the lock's return value.
- Existing orphans in prod will be cleaned up via the out-of-band SQL script previously used for incident #4368.

## Race this closes

```
T0  Req A: SELECT compliance_report   -> transaction_id = NULL
T0  Req B: SELECT compliance_report   -> transaction_id = NULL   (A uncommitted)
T1  Req A: idempotency check          -> None
T1  Req B: idempotency check          -> None
T2  Req A: org_service.adjust_balance -> Transaction N   (Reserved)
T2  Req B: org_service.adjust_balance -> Transaction N+1 (Reserved)
T3  Req A: UPDATE compliance_report SET transaction_id = N   commit
T3  Req B: UPDATE compliance_report SET transaction_id = N+1 commit  (last writer wins)
           -> Transaction N is now an orphan
```

With the lock, Req B blocks at T0 until Req A commits at T3, then wakes, reads the now-persisted `transaction_id`, and 409s out via the existing idempotency guard.

## Test plan

- [x] Updated `test_handle_submitted_status_blocks_duplicate_when_reserved_exists` (regression for sequential repeat clicks still passes).
- [x] New `test_handle_submitted_status_lock_resyncs_transaction_id` covers the concurrent-race path.
- [ ] Manual: two browser tabs to the same draft report, hit Sign-and-Submit in rapid succession from both — verify only one Reserved transaction is created and the second request returns 409.
- [ ] Post-merge: run the orphan-cleanup SQL script against prod.