### PR TITLE
Feat: Add CI Applications Page - 4167

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-05-14-08-30_c1a2b3c4d5e6.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-14-08-30_c1a2b3c4d5e6.py
@@ -1,0 +1,69 @@
+"""Add IDIR-side list view columns to CI applications.
+
+Revision ID: c1a2b3c4d5e6
+Revises: b8f9c0d1e2a3
+Create Date: 2026-05-14 08:30:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "c1a2b3c4d5e6"
+down_revision = "b8f9c0d1e2a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "assigned_analyst_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "user_profile.user_profile_id",
+                name="fk_ci_application_assigned_analyst_id_user_profile",
+            ),
+            nullable=True,
+            comment="IDIR Analyst assigned to review this CI application.",
+        ),
+    )
+    op.create_index(
+        "ix_ci_application_assigned_analyst_id",
+        "ci_application",
+        ["assigned_analyst_id"],
+    )
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "priority_score",
+            sa.Integer(),
+            nullable=True,
+            comment="Analyst-facing triage score for the IDIR CI applications inbox.",
+        ),
+    )
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "verification_level",
+            sa.String(length=50),
+            nullable=True,
+            comment="Verification level label (e.g. 'VX1 - Low', 'VX2 - High').",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ci_application", "verification_level")
+    op.drop_column("ci_application", "priority_score")
+    op.drop_index(
+        "ix_ci_application_assigned_analyst_id",
+        table_name="ci_application",
+    )
+    op.drop_constraint(
+        "fk_ci_application_assigned_analyst_id_user_profile",
+        "ci_application",
+        type_="foreignkey",
+    )
+    op.drop_column("ci_application", "assigned_analyst_id")

--- a/backend/lcfs/db/models/ci_application/CIApplication.py
+++ b/backend/lcfs/db/models/ci_application/CIApplication.py
@@ -85,6 +85,18 @@ class CIApplication(BaseModel, Auditable, Versioning):
         comment="Organization submitting the CI application",
     )
 
+    # ---------- Assigned IDIR analyst ----------
+    assigned_analyst_id = Column(
+        Integer,
+        ForeignKey(
+            "user_profile.user_profile_id",
+            name="fk_ci_application_assigned_analyst_id_user_profile",
+        ),
+        nullable=True,
+        index=True,
+        comment="IDIR Analyst assigned to review this CI application.",
+    )
+
     # ---------- Facility location ----------
     facility_city = Column(
         String(500),
@@ -118,6 +130,18 @@ class CIApplication(BaseModel, Auditable, Versioning):
         ForeignKey("unit_of_measure.uom_id"),
         nullable=False,
         comment="Unit of measure for the facility nameplate capacity",
+    )
+
+    # ---------- Analyst triage (IDIR-only display) ----------
+    priority_score = Column(
+        Integer,
+        nullable=True,
+        comment="Analyst-facing triage score for the IDIR CI applications inbox.",
+    )
+    verification_level = Column(
+        String(50),
+        nullable=True,
+        comment="Verification level label (e.g. 'VX1 - Low', 'VX2 - High').",
     )
 
     # ---------- Fuel code / pathway ----------
@@ -175,6 +199,11 @@ class CIApplication(BaseModel, Auditable, Versioning):
     organization = relationship(
         "Organization",
         back_populates="ci_applications",
+        lazy="selectin",
+    )
+    assigned_analyst = relationship(
+        "UserProfile",
+        foreign_keys=[assigned_analyst_id],
         lazy="selectin",
     )
     facility_nameplate_capacity_unit = relationship(

--- a/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
@@ -1,0 +1,480 @@
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lcfs.db.models.ci_application import (
+    CIApplication,
+    CIApplicationStatus,
+)
+from lcfs.web.api.base import (
+    FilterModel,
+    PaginationRequestSchema,
+    SortOrder,
+)
+from lcfs.web.api.ci_application.repo import (
+    CIApplicationRepository,
+    _DIRECT_FILTER_COLUMNS,
+    _NESTED_FILTER_BUILDERS,
+    _resolve_value,
+)
+from lcfs.web.api.ci_application.schema import (
+    AssignedAnalystSchema,
+    CIApplicationBaseSchema,
+    LatestCommentSchema,
+)
+from lcfs.web.api.ci_application.services import (
+    CIApplicationServices,
+    _initials,
+    _to_assigned_analyst,
+    _to_list_item,
+)
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def repo(mock_db):
+    r = CIApplicationRepository()
+    r.db = mock_db
+    return r
+
+
+def _status(name="Submitted", ident=2):
+    return CIApplicationStatus(
+        ci_application_status_id=ident,
+        status=name,
+        description=name,
+        display_order=ident,
+    )
+
+
+def _organization(name="Acme Fuels", organization_id=1):
+    return SimpleNamespace(
+        organization_id=organization_id,
+        name=name,
+        operating_name=name,
+        email="ops@example.org",
+        phone="555-0100",
+    )
+
+
+def _user(user_profile_id=42, first="Alex", last="Zorkin"):
+    return SimpleNamespace(
+        user_profile_id=user_profile_id,
+        first_name=first,
+        last_name=last,
+        keycloak_username="ALZORKIN",
+    )
+
+
+def _internal_comment(comment_id=99, text="LGTM", create_date=None):
+    return SimpleNamespace(
+        internal_comment_id=comment_id,
+        comment=text,
+        create_user="ALZORKIN",
+        create_date=create_date or datetime(2026, 5, 14, 16, 0, tzinfo=timezone.utc),
+    )
+
+
+def _application(
+    ci_application_id=100,
+    organization_id=1,
+    status_id=2,
+    assigned_analyst=None,
+    organization=None,
+    priority_score=None,
+    verification_level=None,
+):
+    ci = CIApplication(
+        ci_application_id=ci_application_id,
+        organization_id=organization_id,
+        status_id=status_id,
+        facility_city="San Martin",
+        facility_province_state="Santa Fe",
+        facility_country="Argentina",
+        facility_iso="AR",
+        facility_nameplate_capacity=1000,
+        facility_nameplate_capacity_unit_id=1,
+        proposed_fuel_code_effective_date=date(2026, 6, 1),
+        priority_score=priority_score,
+        verification_level=verification_level,
+        group_uuid="abc",
+        version=0,
+    )
+    ci.update_date = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    ci.create_date = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    # Attach eager-loaded relationships via __dict__ to bypass SQLAlchemy's
+    # descriptors (SimpleNamespace stand-ins lack _sa_instance_state).
+    ci.__dict__["ci_application_status"] = _status(ident=status_id)
+    ci.__dict__["organization"] = organization or _organization(
+        organization_id=organization_id
+    )
+    ci.__dict__["assigned_analyst"] = assigned_analyst
+    return ci
+
+
+class TestFilterResolver:
+    def test_direct_filter_columns_cover_grid_fields(self):
+        expected = {
+            "ci_application_id",
+            "facility_city",
+            "facility_country",
+            "facility_province_state",
+            "facility_nameplate_capacity",
+            "proposed_fuel_code_effective_date",
+            "priority_score",
+            "verification_level",
+            "update_date",
+            "create_date",
+        }
+        assert expected.issubset(_DIRECT_FILTER_COLUMNS.keys())
+
+    def test_nested_filter_builders_cover_grid_fields(self):
+        assert set(_NESTED_FILTER_BUILDERS.keys()) == {
+            "status.status",
+            "organization.name",
+            "production_facility_location",
+        }
+
+    def test_resolve_value_picks_filter_for_non_set_filters(self):
+        f = FilterModel(
+            filter_type="text", type="contains", filter="Acme", field="anything"
+        )
+        assert _resolve_value(f) == "Acme"
+
+    def test_resolve_value_picks_values_list_for_set_filters(self):
+        f = FilterModel(
+            filter_type="set", type="set", values=["A", "B"], field="anything"
+        )
+        assert _resolve_value(f) == ["A", "B"]
+
+    def test_resolve_value_for_empty_set_filter(self):
+        f = FilterModel(filter_type="set", type="set", values=None, field="anything")
+        assert _resolve_value(f) == []
+
+    def test_camel_to_snake_conversion_normalises_grid_field_names(self):
+        # Pin the validator-side conversion the resolver lookup relies on.
+        f = FilterModel(
+            filter_type="text",
+            type="contains",
+            filter="x",
+            field="priorityScore",
+        )
+        assert f.field == "priority_score"
+        f2 = FilterModel(
+            filter_type="text",
+            type="contains",
+            filter="x",
+            field="productionFacilityLocation",
+        )
+        assert f2.field == "production_facility_location"
+
+    def test_apply_filters_skips_unknown_field_silently(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[],
+            filters=[
+                FilterModel(
+                    filter_type="text",
+                    type="contains",
+                    filter="AZ",
+                    field="assignedAnalyst",
+                )
+            ],
+        )
+        assert repo._apply_filters(pagination) == []
+
+    def test_apply_filters_returns_clause_for_known_direct_field(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[],
+            filters=[
+                FilterModel(
+                    filter_type="number",
+                    type="equals",
+                    filter=511,
+                    field="priorityScore",
+                )
+            ],
+        )
+        conds = repo._apply_filters(pagination)
+        assert len(conds) == 1
+        assert "priority_score" in str(conds[0]).lower()
+
+    def test_apply_filters_returns_clause_for_nested_status_field(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[],
+            filters=[
+                FilterModel(
+                    filter_type="text",
+                    type="equals",
+                    filter="Submitted",
+                    field="status.status",
+                )
+            ],
+        )
+        conds = repo._apply_filters(pagination)
+        assert len(conds) == 1
+        rendered = str(conds[0]).lower()
+        assert "exists" in rendered
+        assert "ci_application_status" in rendered
+
+    def test_apply_filters_returns_clause_for_organization_name_field(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[],
+            filters=[
+                FilterModel(
+                    filter_type="text",
+                    type="contains",
+                    filter="Acme",
+                    field="organization.name",
+                )
+            ],
+        )
+        conds = repo._apply_filters(pagination)
+        assert len(conds) == 1
+        rendered = str(conds[0]).lower()
+        assert "exists" in rendered
+        assert "organization" in rendered
+
+    def test_apply_filters_returns_clause_for_production_facility_location(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[],
+            filters=[
+                FilterModel(
+                    filter_type="text",
+                    type="contains",
+                    filter="Argentina",
+                    field="productionFacilityLocation",
+                )
+            ],
+        )
+        conds = repo._apply_filters(pagination)
+        assert len(conds) == 1
+        rendered = str(conds[0]).lower()
+        assert "concat_ws" in rendered
+        assert "facility_city" in rendered
+        assert "facility_country" in rendered
+
+    def test_apply_sorting_uses_default_when_no_orders(self, repo):
+        pagination = PaginationRequestSchema(page=1, size=10, sort_orders=[], filters=[])
+        clauses = repo._apply_sorting(pagination)
+        assert len(clauses) == 1
+        rendered = str(clauses[0]).lower()
+        assert "update_date" in rendered
+        assert "desc" in rendered
+
+    def test_apply_sorting_skips_unknown_field(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[SortOrder(field="lastComment", direction="asc")],
+            filters=[],
+        )
+        clauses = repo._apply_sorting(pagination)
+        assert len(clauses) == 1
+        assert "update_date" in str(clauses[0]).lower()
+
+    def test_apply_sorting_uses_direct_column(self, repo):
+        pagination = PaginationRequestSchema(
+            page=1,
+            size=10,
+            sort_orders=[SortOrder(field="priorityScore", direction="desc")],
+            filters=[],
+        )
+        clauses = repo._apply_sorting(pagination)
+        assert len(clauses) == 1
+        rendered = str(clauses[0]).lower()
+        assert "priority_score" in rendered
+        assert "desc" in rendered
+
+
+class TestGetLatestComments:
+    @pytest.mark.anyio
+    async def test_empty_input_short_circuits_without_db_call(self, repo, mock_db):
+        out = await repo.get_latest_comments_by_ci_application_ids([])
+        assert out == {}
+        mock_db.execute.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_returns_comment_keyed_by_application_id(self, repo, mock_db):
+        comment_a = _internal_comment(comment_id=1, text="ping")
+        comment_b = _internal_comment(comment_id=2, text="follow-up")
+
+        result = MagicMock()
+        result.all.return_value = [
+            (10, comment_a, "Alex", "Zorkin"),
+            (11, comment_b, "Lindsy", "Grunert"),
+        ]
+        mock_db.execute.return_value = result
+
+        out = await repo.get_latest_comments_by_ci_application_ids([10, 11])
+
+        assert set(out.keys()) == {10, 11}
+        first_comment, first_full_name = out[10]
+        assert first_comment is comment_a
+        assert first_full_name == "Alex Zorkin"
+        _, second_full_name = out[11]
+        assert second_full_name == "Lindsy Grunert"
+
+    @pytest.mark.anyio
+    async def test_missing_user_profile_falls_back_to_empty_name(self, repo, mock_db):
+        comment = _internal_comment(comment_id=1)
+        result = MagicMock()
+        result.all.return_value = [(10, comment, None, None)]
+        mock_db.execute.return_value = result
+
+        out = await repo.get_latest_comments_by_ci_application_ids([10])
+        assert list(out.keys()) == [10]
+        _, full_name = out[10]
+        assert full_name == ""
+
+
+class TestInitials:
+    @pytest.mark.parametrize(
+        "first,last,expected",
+        [
+            ("Alex", "Zorkin", "AZ"),
+            ("alex", "zorkin", "AZ"),
+            ("Alex", None, "A"),
+            (None, "Zorkin", "Z"),
+            (" Alex ", " Zorkin ", "AZ"),
+            ("", "", None),
+            (None, None, None),
+            ("   ", "   ", None),
+        ],
+    )
+    def test_initials(self, first, last, expected):
+        assert _initials(first, last) == expected
+
+
+class TestToAssignedAnalyst:
+    def test_returns_none_for_unassigned(self):
+        assert _to_assigned_analyst(None) is None
+
+    def test_serializes_user_into_analyst_pill_payload(self):
+        analyst = _to_assigned_analyst(_user(user_profile_id=7, first="Hamed", last="Bayeki"))
+        assert isinstance(analyst, AssignedAnalystSchema)
+        assert analyst.user_profile_id == 7
+        assert analyst.first_name == "Hamed"
+        assert analyst.last_name == "Bayeki"
+        assert analyst.initials == "HB"
+        assert analyst.full_name == "Hamed Bayeki"
+
+    def test_handles_partial_name(self):
+        analyst = _to_assigned_analyst(_user(first="Alex", last=None))
+        assert analyst.initials == "A"
+        assert analyst.full_name == "Alex"
+
+
+class TestToListItem:
+    def test_minimum_row_serialises_without_optional_fields(self):
+        ci = _application(assigned_analyst=None, priority_score=None, verification_level=None)
+        out = _to_list_item(ci, last_comment_entry=None)
+        assert isinstance(out, CIApplicationBaseSchema)
+        assert out.ci_application_id == 100
+        assert out.assigned_analyst is None
+        assert out.last_comment is None
+        assert out.priority_score is None
+        assert out.verification_level is None
+        assert out.organization is not None
+        assert out.organization.name == "Acme Fuels"
+
+    def test_populates_analyst_and_triage_fields(self):
+        ci = _application(
+            assigned_analyst=_user(user_profile_id=2, first="Hamed", last="Bayeki"),
+            priority_score=511,
+            verification_level="VX2 - High",
+        )
+        out = _to_list_item(ci, last_comment_entry=None)
+        assert out.assigned_analyst.initials == "HB"
+        assert out.priority_score == 511
+        assert out.verification_level == "VX2 - High"
+
+    def test_populates_last_comment_when_provided(self):
+        ci = _application()
+        comment = _internal_comment(text="Needs follow-up")
+        out = _to_list_item(ci, last_comment_entry=(comment, "Alex Zorkin"))
+        assert isinstance(out.last_comment, LatestCommentSchema)
+        assert out.last_comment.comment == "Needs follow-up"
+        assert out.last_comment.full_name == "Alex Zorkin"
+        assert out.last_comment.create_date == comment.create_date
+
+    def test_empty_full_name_becomes_none_on_last_comment(self):
+        ci = _application()
+        comment = _internal_comment()
+        out = _to_list_item(ci, last_comment_entry=(comment, ""))
+        assert out.last_comment is not None
+        assert out.last_comment.full_name is None
+
+
+class TestListCiApplications:
+    @pytest.fixture
+    def service_with_mocks(self):
+        repo = AsyncMock()
+        # total_pages is sync; AsyncMock would return a coroutine and trip Pydantic.
+        repo.total_pages = MagicMock(return_value=0)
+        user_repo = AsyncMock()
+        return CIApplicationServices(repo=repo, user_repo=user_repo), repo
+
+    @pytest.mark.anyio
+    async def test_skips_latest_comments_lookup_when_page_is_empty(
+        self, service_with_mocks
+    ):
+        service, repo = service_with_mocks
+        repo.list_paginated.return_value = ([], 0)
+
+        pagination = PaginationRequestSchema(page=1, size=10, sort_orders=[], filters=[])
+        out = await service.list_ci_applications(pagination, organization_id=None)
+
+        assert out.ci_applications == []
+        repo.get_latest_comments_by_ci_application_ids.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_attaches_latest_comment_to_matching_row(self, service_with_mocks):
+        service, repo = service_with_mocks
+        ci_with_comment = _application(ci_application_id=100)
+        ci_without_comment = _application(ci_application_id=101)
+        repo.list_paginated.return_value = (
+            [ci_with_comment, ci_without_comment],
+            2,
+        )
+        repo.total_pages.return_value = 1
+
+        comment = _internal_comment(text="Triage notes")
+        repo.get_latest_comments_by_ci_application_ids.return_value = {
+            100: (comment, "Alex Zorkin"),
+        }
+
+        pagination = PaginationRequestSchema(page=1, size=10, sort_orders=[], filters=[])
+        out = await service.list_ci_applications(pagination, organization_id=None)
+
+        repo.get_latest_comments_by_ci_application_ids.assert_awaited_once_with(
+            [100, 101]
+        )
+        assert out.ci_applications[0].last_comment.comment == "Triage notes"
+        assert out.ci_applications[1].last_comment is None
+
+    @pytest.mark.anyio
+    async def test_propagates_organization_scope_to_repo(self, service_with_mocks):
+        service, repo = service_with_mocks
+        repo.list_paginated.return_value = ([], 0)
+
+        pagination = PaginationRequestSchema(page=1, size=10, sort_orders=[], filters=[])
+        await service.list_ci_applications(pagination, organization_id=42)
+        repo.list_paginated.assert_awaited_once_with(pagination, 42)

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -163,6 +163,7 @@ async def test_get_table_options_returns_lookup_data(service, repo):
 async def test_list_ci_applications_returns_pagination(service, repo):
     repo.list_paginated.return_value = ([_ci_application(), _ci_application(11)], 2)
     repo.total_pages = MagicMock(return_value=1)
+    repo.get_latest_comments_by_ci_application_ids.return_value = {}
 
     pagination = PaginationRequestSchema(page=1, size=10)
     result = await service.list_ci_applications(pagination, organization_id=1)
@@ -178,6 +179,7 @@ async def test_list_ci_applications_returns_pagination(service, repo):
 async def test_list_ci_applications_passes_org_id(service, repo):
     repo.list_paginated.return_value = ([], 0)
     repo.total_pages = MagicMock(return_value=0)
+    repo.get_latest_comments_by_ci_application_ids.return_value = {}
 
     pagination = PaginationRequestSchema(page=1, size=10)
     await service.list_ci_applications(pagination, organization_id=99)

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -8,7 +8,7 @@ Government decision) plug into the same data-access surface.
 """
 
 import math
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import structlog
 from fastapi import Depends
@@ -28,19 +28,78 @@ from lcfs.db.models.ci_application import (
 from lcfs.db.models.ci_application.CIApplication import (
     ci_application_document_association,
 )
+from lcfs.db.models.comment.CIApplicationInternalComment import (
+    CIApplicationInternalComment,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
 from lcfs.db.models.fuel.TransportMode import TransportMode
 from lcfs.db.models.fuel.UnitOfMeasure import UnitOfMeasure
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.web.api.base import (
     PaginationRequestSchema,
     apply_filter_conditions,
-    get_field_for_filter,
 )
 from lcfs.web.core.decorators import repo_handler
 
 logger = structlog.get_logger(__name__)
+
+# Grid-facing filter / sort resolvers. Keys use the post-validation
+# snake_case form (FilterModel.field / SortOrder.field route incoming
+# values through camel_to_snake). Unknown fields are silently dropped.
+_DIRECT_FILTER_COLUMNS = {
+    "ci_application_id": CIApplication.ci_application_id,
+    "facility_city": CIApplication.facility_city,
+    "facility_country": CIApplication.facility_country,
+    "facility_province_state": CIApplication.facility_province_state,
+    "facility_nameplate_capacity": CIApplication.facility_nameplate_capacity,
+    "proposed_fuel_code_effective_date": CIApplication.proposed_fuel_code_effective_date,
+    "priority_score": CIApplication.priority_score,
+    "verification_level": CIApplication.verification_level,
+    "update_date": CIApplication.update_date,
+    "create_date": CIApplication.create_date,
+}
+
+
+def _resolve_value(f):
+    if f.filter_type == "set":
+        return f.values or []
+    return f.filter
+
+
+def _build_status_condition(f):
+    inner = apply_filter_conditions(
+        CIApplicationStatus.status, _resolve_value(f), f.type, f.filter_type
+    )
+    return CIApplication.ci_application_status.has(inner) if inner is not None else None
+
+
+def _build_organization_condition(f):
+    inner = apply_filter_conditions(
+        Organization.name, _resolve_value(f), f.type, f.filter_type
+    )
+    return CIApplication.organization.has(inner) if inner is not None else None
+
+
+def _build_production_facility_location_condition(f):
+    # concat_ws skips NULLs so rows with partial data still match.
+    expr = func.concat_ws(
+        " ",
+        CIApplication.facility_city,
+        CIApplication.facility_province_state,
+        CIApplication.facility_country,
+    )
+    return apply_filter_conditions(expr, _resolve_value(f), f.type, f.filter_type)
+
+
+_NESTED_FILTER_BUILDERS = {
+    "status.status": _build_status_condition,
+    "organization.name": _build_organization_condition,
+    "production_facility_location": _build_production_facility_location_condition,
+}
 
 
 class CIApplicationRepository:
@@ -298,15 +357,22 @@ class CIApplicationRepository:
     def _apply_filters(self, pagination: PaginationRequestSchema) -> list:
         conditions = []
         for f in pagination.filters:
-            field = get_field_for_filter(CIApplication, f.field)
-            if field is None:
+            nested_builder = _NESTED_FILTER_BUILDERS.get(f.field)
+            if nested_builder is not None:
+                cond = nested_builder(f)
+                if cond is not None:
+                    conditions.append(cond)
                 continue
-            value = f.filter
-            if f.filter_type == "set":
-                value = f.values or []
-            conditions.append(
-                apply_filter_conditions(field, value, f.type, f.filter_type)
+
+            column = _DIRECT_FILTER_COLUMNS.get(f.field)
+            if column is None:
+                continue
+
+            cond = apply_filter_conditions(
+                column, _resolve_value(f), f.type, f.filter_type
             )
+            if cond is not None:
+                conditions.append(cond)
         return conditions
 
     def _apply_sorting(self, pagination: PaginationRequestSchema):
@@ -315,11 +381,11 @@ class CIApplicationRepository:
 
         order_clauses = []
         for s in pagination.sort_orders:
-            field = get_field_for_filter(CIApplication, s.field)
-            if field is None:
+            column = _DIRECT_FILTER_COLUMNS.get(s.field)
+            if column is None:
                 continue
             order_clauses.append(
-                asc(field) if s.direction.lower() == "asc" else desc(field)
+                asc(column) if s.direction.lower() == "asc" else desc(column)
             )
         return order_clauses or [desc(CIApplication.update_date)]
 
@@ -351,6 +417,7 @@ class CIApplicationRepository:
             .options(
                 selectinload(CIApplication.ci_application_status),
                 selectinload(CIApplication.organization),
+                selectinload(CIApplication.assigned_analyst),
             )
             .order_by(*order_clauses)
             .offset(offset)
@@ -361,6 +428,67 @@ class CIApplicationRepository:
 
         result = await self.db.execute(stmt)
         return list(result.scalars().all()), total
+
+    @repo_handler
+    async def get_latest_comments_by_ci_application_ids(
+        self,
+        ci_application_ids: Sequence[int],
+    ) -> Dict[int, Tuple[InternalComment, str]]:
+        if not ci_application_ids:
+            return {}
+
+        ranked_subq = (
+            select(
+                CIApplicationInternalComment.ci_application_id.label(
+                    "ci_application_id"
+                ),
+                InternalComment.internal_comment_id.label("internal_comment_id"),
+                func.row_number()
+                .over(
+                    partition_by=CIApplicationInternalComment.ci_application_id,
+                    order_by=desc(InternalComment.create_date),
+                )
+                .label("rn"),
+            )
+            .join(
+                InternalComment,
+                InternalComment.internal_comment_id
+                == CIApplicationInternalComment.internal_comment_id,
+            )
+            .where(
+                CIApplicationInternalComment.ci_application_id.in_(
+                    list(ci_application_ids)
+                )
+            )
+            .subquery()
+        )
+
+        stmt = (
+            select(
+                ranked_subq.c.ci_application_id,
+                InternalComment,
+                UserProfile.first_name,
+                UserProfile.last_name,
+            )
+            .join(
+                InternalComment,
+                InternalComment.internal_comment_id
+                == ranked_subq.c.internal_comment_id,
+            )
+            .join(
+                UserProfile,
+                UserProfile.keycloak_username == InternalComment.create_user,
+                isouter=True,
+            )
+            .where(ranked_subq.c.rn == 1)
+        )
+        result = await self.db.execute(stmt)
+
+        out: Dict[int, Tuple[InternalComment, str]] = {}
+        for ci_app_id, comment, first, last in result.all():
+            full_name = " ".join(p for p in (first, last) if p).strip()
+            out[ci_app_id] = (comment, full_name)
+        return out
 
     @staticmethod
     def total_pages(total: int, size: int) -> int:

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -60,6 +60,24 @@ class OrganizationInfoSchema(BaseSchema):
     address_line: Optional[str] = None
 
 
+class AssignedAnalystSchema(BaseSchema):
+    """IDIR analyst currently assigned to a CI application."""
+
+    user_profile_id: int
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    initials: Optional[str] = None
+    full_name: Optional[str] = None
+
+
+class LatestCommentSchema(BaseSchema):
+    """Most-recent internal comment on a CI application, for the list grid."""
+
+    comment: Optional[str] = None
+    full_name: Optional[str] = None
+    create_date: Optional[datetime] = None
+
+
 class PathwayApplicationTypeSchema(BaseSchema):
     pathway_application_type_id: int
     type: str
@@ -218,6 +236,7 @@ class CIApplicationBaseSchema(BaseSchema):
 
     ci_application_id: int
     organization_id: int
+    organization: Optional[OrganizationInfoSchema] = None
     status: CIApplicationStatusSchema
     facility_city: Optional[str] = None
     facility_province_state: Optional[str] = None
@@ -227,6 +246,10 @@ class CIApplicationBaseSchema(BaseSchema):
     proposed_fuel_code_effective_date: Optional[date] = None
     update_date: Optional[str] = None
     create_date: Optional[str] = None
+    assigned_analyst: Optional[AssignedAnalystSchema] = None
+    last_comment: Optional[LatestCommentSchema] = None
+    priority_score: Optional[int] = None
+    verification_level: Optional[str] = None
 
 
 class CIApplicationSchema(BaseSchema):

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -8,7 +8,7 @@ decision (with the comments thread).
 
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import structlog
 from fastapi import Depends, HTTPException, status
@@ -29,6 +29,7 @@ from lcfs.web.api.base import (
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 from lcfs.web.api.user.repo import UserRepository
 from lcfs.web.api.ci_application.schema import (
+    AssignedAnalystSchema,
     CIApplicationBaseSchema,
     CIApplicationDecisionSchema,
     CIApplicationSchema,
@@ -42,6 +43,7 @@ from lcfs.web.api.ci_application.schema import (
     CITableOptionsSchema,
     FuelCodeOptionSchema,
     FuelTypeOptionSchema,
+    LatestCommentSchema,
     OrganizationInfoSchema,
     PathwayApplicationTypeSchema,
     PathwayFuelCodeTypeSchema,
@@ -159,10 +161,46 @@ def _to_full_schema(
     )
 
 
-def _to_list_item(ci: CIApplication) -> CIApplicationBaseSchema:
+def _initials(first: Optional[str], last: Optional[str]) -> Optional[str]:
+    first_part = (first or "").strip()
+    last_part = (last or "").strip()
+    if not first_part and not last_part:
+        return None
+    return f"{first_part[:1]}{last_part[:1]}".upper()
+
+
+def _to_assigned_analyst(user) -> Optional[AssignedAnalystSchema]:
+    if user is None:
+        return None
+    first = getattr(user, "first_name", None)
+    last = getattr(user, "last_name", None)
+    full = " ".join(p for p in (first, last) if p).strip() or None
+    return AssignedAnalystSchema(
+        user_profile_id=user.user_profile_id,
+        first_name=first,
+        last_name=last,
+        initials=_initials(first, last),
+        full_name=full,
+    )
+
+
+def _to_list_item(
+    ci: CIApplication,
+    last_comment_entry: Optional[Tuple] = None,
+) -> CIApplicationBaseSchema:
+    last_comment: Optional[LatestCommentSchema] = None
+    if last_comment_entry is not None:
+        comment, full_name = last_comment_entry
+        last_comment = LatestCommentSchema(
+            comment=comment.comment,
+            full_name=full_name or None,
+            create_date=comment.create_date,
+        )
+
     return CIApplicationBaseSchema(
         ci_application_id=ci.ci_application_id,
         organization_id=ci.organization_id,
+        organization=_to_org_info(ci.organization),
         status=CIApplicationStatusSchema.model_validate(ci.ci_application_status),
         facility_city=ci.facility_city,
         facility_province_state=ci.facility_province_state,
@@ -172,6 +210,12 @@ def _to_list_item(ci: CIApplication) -> CIApplicationBaseSchema:
         proposed_fuel_code_effective_date=ci.proposed_fuel_code_effective_date,
         update_date=ci.update_date.isoformat() if ci.update_date else None,
         create_date=ci.create_date.isoformat() if ci.create_date else None,
+        assigned_analyst=_to_assigned_analyst(
+            getattr(ci, "assigned_analyst", None)
+        ),
+        last_comment=last_comment,
+        priority_score=getattr(ci, "priority_score", None),
+        verification_level=getattr(ci, "verification_level", None),
     )
 
 
@@ -241,8 +285,23 @@ class CIApplicationServices:
         organization_id: Optional[int],
     ) -> CIApplicationsListSchema:
         items, total = await self.repo.list_paginated(pagination, organization_id)
+
+        latest_comments = (
+            await self.repo.get_latest_comments_by_ci_application_ids(
+                [ci.ci_application_id for ci in items]
+            )
+            if items
+            else {}
+        )
+
         return CIApplicationsListSchema(
-            ci_applications=[_to_list_item(ci) for ci in items],
+            ci_applications=[
+                _to_list_item(
+                    ci,
+                    last_comment_entry=latest_comments.get(ci.ci_application_id),
+                )
+                for ci in items
+            ],
             pagination=PaginationResponseSchema(
                 total=total,
                 page=pagination.page,

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -1,11 +1,13 @@
 {
   "ciApplications": "CI applications",
+  "myOrgCIApplications": "My organization's CI applications",
   "carbonIntensityApplication": "Carbon intensity application",
   "newCIApplicationBtn": "New CI application",
   "noCIApplicationsFound": "No CI applications found",
   "tabs": {
     "ciApplications": "CI applications",
     "myFuelCodes": "My fuel codes",
+    "fuelCodes": "Fuel codes",
     "currentFuelCodes": "Current fuel codes",
     "archivedFuelCodes": "Archived fuel codes"
   },
@@ -169,11 +171,14 @@
   "columns": {
     "ciApplicationId": "ID",
     "status": "Status",
-    "facilityCountry": "Country",
-    "facilityCity": "City",
-    "facilityCapacity": "Nameplate capacity",
-    "proposedEffectiveDate": "Proposed effective date",
-    "lastUpdated": "Last updated"
+    "organization": "Organization",
+    "priorityScore": "Priority score",
+    "verification": "Verification",
+    "productionFacilityLocation": "Production facility Location",
+    "proposedEffectiveDate": "Proposed fuel code effective date",
+    "lastUpdated": "Last updated",
+    "assignedAnalyst": "Assigned analyst",
+    "lastComment": "Last comment"
   },
   "labels": {
     "required": "(required)",

--- a/frontend/src/hooks/useCIApplication.js
+++ b/frontend/src/hooks/useCIApplication.js
@@ -19,6 +19,17 @@ export const useCIApplicationOptions = (options) => {
   })
 }
 
+export const useCIApplicationStatuses = (options) => {
+  const query = useCIApplicationOptions({
+    select: (data) => data?.statuses ?? [],
+    ...options
+  })
+  return {
+    ...query,
+    data: query.data ?? []
+  }
+}
+
 export const useGetCIApplications = (
   { page = 1, size = 10, sortOrders = [], filters = [] } = {},
   options

--- a/frontend/src/views/CarbonIntensity/CIApplications.jsx
+++ b/frontend/src/views/CarbonIntensity/CIApplications.jsx
@@ -12,7 +12,8 @@ import BCButton from '@/components/BCButton'
 import BCTypography from '@/components/BCTypography'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer'
 import { Role } from '@/components/Role'
-import { roles } from '@/constants/roles'
+import { govRoles, roles } from '@/constants/roles'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import withRole from '@/utils/withRole'
 import { LinkRenderer } from '@/utils/grid/cellRenderers.jsx'
 import ROUTES from '@/routes/routes'
@@ -37,6 +38,8 @@ const CIApplicationsBase = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const gridRef = useRef(null)
+  const { hasAnyRole } = useCurrentUser()
+  const isGovernment = hasAnyRole(...govRoles)
 
   const [paginationOptions, setPaginationOptions] = useState(
     initialPaginationOptions
@@ -45,6 +48,11 @@ const CIApplicationsBase = () => {
   const [alertSeverity, setAlertSeverity] = useState('info')
 
   const queryData = useGetCIApplications(paginationOptions)
+
+  const columnDefs = useMemo(
+    () => ciApplicationsColDefs(t, { isGovernment }),
+    [t, isGovernment]
+  )
 
   useEffect(() => {
     if (location.state?.message) {
@@ -89,7 +97,9 @@ const CIApplicationsBase = () => {
       )}
 
       <BCTypography variant="h5" color="primary" data-test="title">
-        {t('carbonIntensity:ciApplications')}
+        {isGovernment
+          ? t('carbonIntensity:ciApplications')
+          : t('carbonIntensity:myOrgCIApplications')}
       </BCTypography>
 
       <Stack
@@ -122,7 +132,7 @@ const CIApplicationsBase = () => {
         <BCGridViewer
           gridRef={gridRef}
           gridKey="ci-applications-grid"
-          columnDefs={ciApplicationsColDefs(t)}
+          columnDefs={columnDefs}
           getRowId={getRowId}
           overlayNoRowsTemplate={t('carbonIntensity:noCIApplicationsFound')}
           defaultColDef={defaultColDef}

--- a/frontend/src/views/CarbonIntensity/__tests__/CIApplications.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/CIApplications.test.jsx
@@ -62,7 +62,8 @@ let mockListData = {
 }
 
 vi.mock('@/hooks/useCIApplication', () => ({
-  useGetCIApplications: vi.fn(() => mockListData)
+  useGetCIApplications: vi.fn(() => mockListData),
+  useCIApplicationStatuses: vi.fn(() => ({ data: [], isLoading: false }))
 }))
 
 // ---------------- Tests ----------------

--- a/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
@@ -92,6 +92,58 @@ describe('FuelCodesTabs', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows the IDIR-only Fuel codes (manage) tab for government users', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.government)
+    render(<FuelCodesTabs />, { wrapper })
+
+    expect(
+      screen.getByText('carbonIntensity:tabs.fuelCodes')
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to /fuel-codes when the IDIR Fuel codes tab is clicked', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.government)
+    render(<FuelCodesTabs />, { wrapper })
+
+    fireEvent.click(screen.getByText('carbonIntensity:tabs.fuelCodes'))
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.FUEL_CODES.LIST)
+  })
+
+  it('hides Current and Archived bulletin tabs from government users', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.government)
+    render(<FuelCodesTabs />, { wrapper })
+
+    expect(
+      screen.queryByText('carbonIntensity:tabs.currentFuelCodes')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('carbonIntensity:tabs.archivedFuelCodes')
+    ).not.toBeInTheDocument()
+  })
+
+  it('marks the Fuel codes (manage) tab active on /fuel-codes for IDIR', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.government)
+    mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+    render(<FuelCodesTabs />, { wrapper })
+
+    const tab = screen
+      .getByText('carbonIntensity:tabs.fuelCodes')
+      .closest('[role="tab"]')
+    expect(tab.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('shows CI applicants the My fuel codes tab (not the IDIR Fuel codes tab)', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.ci_applicant)
+    render(<FuelCodesTabs />, { wrapper })
+
+    expect(
+      screen.getByText('carbonIntensity:tabs.myFuelCodes')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('carbonIntensity:tabs.fuelCodes')
+    ).not.toBeInTheDocument()
+  })
+
   it('navigates to the corresponding route when a tab is clicked', () => {
     mockHasAnyRole = (...names) => names.includes(roles.ci_applicant)
     mockLocation = { pathname: ROUTES.FUEL_CODES.BULLETINS, search: '' }
@@ -141,5 +193,17 @@ describe('FuelCodesTabs', () => {
       .getByText('carbonIntensity:tabs.archivedFuelCodes')
       .closest('[role="tab"]')
     expect(tab.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('does not highlight any tab when the current path matches none', () => {
+    mockHasAnyRole = (...names) => names.includes(roles.ci_applicant)
+    mockLocation = { pathname: '/some/other/route', search: '' }
+    render(<FuelCodesTabs />, { wrapper })
+
+    const allTabs = screen.getAllByRole('tab')
+    expect(allTabs.length).toBeGreaterThan(0)
+    for (const tab of allTabs) {
+      expect(tab.getAttribute('aria-selected')).toBe('false')
+    }
   })
 })

--- a/frontend/src/views/CarbonIntensity/__tests__/_schema.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/_schema.test.jsx
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ciApplicationsColDefs,
+  defaultSortModel,
+  getResumeStep
+} from '@/views/CarbonIntensity/_schema'
+
+vi.mock('@/hooks/useCIApplication', () => ({
+  useCIApplicationStatuses: () => ({ data: [] })
+}))
+
+const t = (key) => key
+
+describe('ciApplicationsColDefs (BCeID)', () => {
+  it('returns exactly five columns in the wireframe order', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: false })
+    expect(cols.map((c) => c.field)).toEqual([
+      'status.status',
+      'ciApplicationId',
+      'proposedFuelCodeEffectiveDate',
+      'productionFacilityLocation',
+      'updateDate'
+    ])
+  })
+
+  it('drops IDIR-only triage columns', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: false })
+    const fields = cols.map((c) => c.field)
+    for (const idirField of [
+      'organization.name',
+      'priorityScore',
+      'verificationLevel',
+      'assignedAnalyst',
+      'lastComment'
+    ]) {
+      expect(fields).not.toContain(idirField)
+    }
+  })
+
+  it('omitting the options object defaults to the BCeID layout', () => {
+    expect(ciApplicationsColDefs(t)).toHaveLength(5)
+  })
+})
+
+describe('ciApplicationsColDefs (IDIR)', () => {
+  it('returns the full ten-column inbox in wireframe order', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: true })
+    expect(cols.map((c) => c.field)).toEqual([
+      'status.status',
+      'ciApplicationId',
+      'organization.name',
+      'priorityScore',
+      'verificationLevel',
+      'assignedAnalyst',
+      'lastComment',
+      'proposedFuelCodeEffectiveDate',
+      'productionFacilityLocation',
+      'updateDate'
+    ])
+  })
+
+  it('renders the Status column with a select-based floating filter', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: true })
+    const status = cols.find((c) => c.field === 'status.status')
+    expect(status).toBeDefined()
+    expect(status.floatingFilterComponent).toBeDefined()
+    expect(status.floatingFilterComponentParams).toMatchObject({
+      valueKey: 'status',
+      labelKey: 'status'
+    })
+    expect(status.sortable).toBe(false)
+  })
+
+  it('Assigned analyst / Last comment columns are non-sortable display pills', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: true })
+    const analyst = cols.find((c) => c.field === 'assignedAnalyst')
+    const comment = cols.find((c) => c.field === 'lastComment')
+    expect(analyst.sortable).toBe(false)
+    expect(comment.sortable).toBe(false)
+    expect(typeof analyst.cellRenderer).toBe('function')
+    expect(typeof comment.cellRenderer).toBe('function')
+  })
+})
+
+describe('productionFacilityLocation column', () => {
+  const getter = ciApplicationsColDefs(t, { isGovernment: false }).find(
+    (c) => c.field === 'productionFacilityLocation'
+  ).valueGetter
+
+  const call = (data) => getter({ data })
+
+  it('joins city, province/state, and country in the expected layout', () => {
+    expect(
+      call({
+        facilityCity: 'San Martin',
+        facilityProvinceState: 'Santa Fe',
+        facilityCountry: 'Argentina'
+      })
+    ).toBe('San Martin Santa Fe, Argentina')
+  })
+
+  it('drops the province segment when not provided', () => {
+    expect(
+      call({
+        facilityCity: 'Vancouver',
+        facilityProvinceState: null,
+        facilityCountry: 'Canada'
+      })
+    ).toBe('Vancouver, Canada')
+  })
+
+  it('handles a country-only row without a leading comma', () => {
+    expect(
+      call({
+        facilityCity: null,
+        facilityProvinceState: null,
+        facilityCountry: 'Argentina'
+      })
+    ).toBe('Argentina')
+  })
+
+  it('returns empty string for an empty row', () => {
+    expect(call(undefined)).toBe('')
+    expect(call({})).toBe('')
+  })
+})
+
+describe('defaultSortModel', () => {
+  it('sorts by update date descending so the inbox is newest-first', () => {
+    expect(defaultSortModel).toEqual([
+      { field: 'updateDate', direction: 'desc' }
+    ])
+  })
+})
+
+describe('getResumeStep', () => {
+  it('routes drafts to the Step 2 fuel-pathways editor', () => {
+    expect(getResumeStep({ status: { status: 'Draft' } })).toBe(2)
+  })
+
+  it.each(['Submitted', 'Completed', 'Withdrawn'])(
+    'routes %s applications to the Step 5 decision panel',
+    (status) => {
+      expect(getResumeStep({ status: { status } })).toBe(5)
+    }
+  )
+
+  it('falls back to Step 1 for unknown / missing status', () => {
+    expect(getResumeStep({})).toBe(1)
+    expect(getResumeStep({ status: { status: 'Unknown' } })).toBe(1)
+    expect(getResumeStep(null)).toBe(1)
+  })
+})

--- a/frontend/src/views/CarbonIntensity/_schema.jsx
+++ b/frontend/src/views/CarbonIntensity/_schema.jsx
@@ -1,50 +1,270 @@
-import { dateFormatter, numberFormatter } from '@/utils/formatters'
+import { Box, Chip, Tooltip } from '@mui/material'
 
-export const ciApplicationsColDefs = (t) => [
-  {
-    field: 'ciApplicationId',
-    headerName: t('carbonIntensity:columns.ciApplicationId'),
-    minWidth: 80,
-    maxWidth: 110,
-    sortable: true
-  },
-  {
-    field: 'status.status',
-    headerName: t('carbonIntensity:columns.status'),
-    valueGetter: (params) => params.data?.status?.status,
-    minWidth: 130,
-    sortable: false
-  },
-  {
-    field: 'facilityCountry',
-    headerName: t('carbonIntensity:columns.facilityCountry'),
-    minWidth: 140
-  },
-  {
-    field: 'facilityCity',
-    headerName: t('carbonIntensity:columns.facilityCity'),
-    minWidth: 140
-  },
-  {
-    field: 'facilityNameplateCapacity',
-    headerName: t('carbonIntensity:columns.facilityCapacity'),
-    minWidth: 160,
-    valueFormatter: (p) => (p?.value != null ? numberFormatter(p) : '')
-  },
-  {
-    field: 'proposedFuelCodeEffectiveDate',
-    headerName: t('carbonIntensity:columns.proposedEffectiveDate'),
-    minWidth: 170,
-    valueFormatter: dateFormatter
-  },
-  {
-    field: 'updateDate',
-    headerName: t('carbonIntensity:columns.lastUpdated'),
-    minWidth: 170,
-    valueFormatter: dateFormatter,
-    sort: 'desc'
+import BCBox from '@/components/BCBox'
+import BCUserInitials from '@/components/BCUserInitials/BCUserInitials'
+import {
+  BCDateFloatingFilter,
+  BCSelectFloatingFilter
+} from '@/components/BCDataGrid/components'
+import { dateFormatter } from '@/utils/formatters'
+import { useCIApplicationStatuses } from '@/hooks/useCIApplication'
+
+const ANALYST_CHIP_SX = {
+  bgcolor: '#606060',
+  color: 'common.white',
+  borderRadius: '50%',
+  width: 32,
+  height: 32,
+  minWidth: 32,
+  '& .MuiChip-label': { padding: 0 },
+  '&:hover': { bgcolor: '#505050' }
+}
+
+// Centered chip wrapper so analyst / last-comment pills sit visually
+// centered in their grid cell regardless of the row's natural height.
+const PillCell = ({ children }) => (
+  <BCBox
+    component="div"
+    sx={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      py: 1
+    }}
+  >
+    {children}
+  </BCBox>
+)
+
+const AssignedAnalystRenderer = ({ data }) => {
+  const analyst = data?.assignedAnalyst
+  if (!analyst?.initials) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <span>-</span>
+      </Box>
+    )
   }
-]
+  return (
+    <PillCell>
+      <Tooltip
+        title={analyst.fullName || `${analyst.firstName || ''} ${analyst.lastName || ''}`.trim()}
+      >
+        <Chip label={analyst.initials} size="small" sx={ANALYST_CHIP_SX} />
+      </Tooltip>
+    </PillCell>
+  )
+}
+
+const LastCommentRenderer = ({ data }) => {
+  const last = data?.lastComment
+  if (!last?.fullName) {
+    return <BCBox component="div" sx={{ width: '100%', height: '100%' }} />
+  }
+  return (
+    <PillCell>
+      <BCUserInitials
+        fullName={last.fullName}
+        tooltipText={last.comment}
+        maxLength={500}
+        variant="filled"
+        sx={ANALYST_CHIP_SX}
+      />
+    </PillCell>
+  )
+}
+
+const TEXT_FILTER_PARAMS = {
+  filterOptions: ['contains', 'startsWith', 'equals'],
+  buttons: ['clear']
+}
+
+const NUMBER_FILTER_PARAMS = {
+  filterOptions: ['equals', 'greaterThan', 'lessThan'],
+  buttons: ['clear']
+}
+
+const DATE_FILTER_PARAMS = {
+  filterOptions: ['inRange', 'equals', 'lessThan', 'greaterThan'],
+  defaultOption: 'inRange',
+  buttons: ['clear']
+}
+
+// "Production facility Location" matches the wireframe: city + optional
+// province/state, then country. We bake this in the frontend rather than on
+// the API because each piece is already on the row.
+const productionFacilityLocation = (data) => {
+  if (!data) return ''
+  const cityProvince = [data.facilityCity, data.facilityProvinceState]
+    .filter(Boolean)
+    .join(' ')
+    .trim()
+  const country = (data.facilityCountry || '').trim()
+  if (cityProvince && country) return `${cityProvince}, ${country}`
+  return cityProvince || country
+}
+
+const statusCol = (t) => ({
+  field: 'status.status',
+  headerName: t('carbonIntensity:columns.status'),
+  valueGetter: (params) => params.data?.status?.status,
+  minWidth: 140,
+  sortable: false,
+  floatingFilterComponent: BCSelectFloatingFilter,
+  floatingFilterComponentParams: {
+    valueKey: 'status',
+    labelKey: 'status',
+    optionsQuery: useCIApplicationStatuses
+  },
+  suppressFloatingFilterButton: true
+})
+
+const idCol = (t) => ({
+  field: 'ciApplicationId',
+  headerName: t('carbonIntensity:columns.ciApplicationId'),
+  minWidth: 90,
+  maxWidth: 110,
+  sortable: true,
+  filter: 'agNumberColumnFilter',
+  filterParams: NUMBER_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+const proposedEffectiveCol = (t) => ({
+  field: 'proposedFuelCodeEffectiveDate',
+  headerName: t('carbonIntensity:columns.proposedEffectiveDate'),
+  minWidth: 180,
+  valueFormatter: dateFormatter,
+  filter: 'agDateColumnFilter',
+  filterParams: DATE_FILTER_PARAMS,
+  floatingFilterComponent: BCDateFloatingFilter,
+  suppressFloatingFilterButton: true
+})
+
+// Single composite column replacing the previous Country / City / Capacity
+// trio so we match the wireframe layout. Filterable by free text against
+// the displayed string.
+const productionFacilityLocationCol = (t) => ({
+  field: 'productionFacilityLocation',
+  headerName: t('carbonIntensity:columns.productionFacilityLocation'),
+  valueGetter: ({ data }) => productionFacilityLocation(data),
+  minWidth: 220,
+  sortable: false,
+  filter: 'agTextColumnFilter',
+  filterParams: TEXT_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+const lastUpdatedCol = (t) => ({
+  field: 'updateDate',
+  headerName: t('carbonIntensity:columns.lastUpdated'),
+  minWidth: 180,
+  valueFormatter: dateFormatter,
+  sort: 'desc',
+  filter: 'agDateColumnFilter',
+  filterParams: DATE_FILTER_PARAMS,
+  floatingFilterComponent: BCDateFloatingFilter,
+  suppressFloatingFilterButton: true
+})
+
+const organizationCol = (t) => ({
+  field: 'organization.name',
+  headerName: t('carbonIntensity:columns.organization'),
+  valueGetter: (params) => params.data?.organization?.name,
+  minWidth: 220,
+  filter: 'agTextColumnFilter',
+  filterParams: TEXT_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+// IDIR triage columns. Backed by simple nullable columns on the
+// ci_application table; filterable via the standard pipeline.
+const priorityScoreCol = (t) => ({
+  field: 'priorityScore',
+  headerName: t('carbonIntensity:columns.priorityScore'),
+  minWidth: 140,
+  type: 'numericColumn',
+  filter: 'agNumberColumnFilter',
+  filterParams: NUMBER_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+const verificationCol = (t) => ({
+  field: 'verificationLevel',
+  headerName: t('carbonIntensity:columns.verification'),
+  minWidth: 160,
+  filter: 'agTextColumnFilter',
+  filterParams: TEXT_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+const assignedAnalystCol = (t) => ({
+  field: 'assignedAnalyst',
+  headerName: t('carbonIntensity:columns.assignedAnalyst'),
+  minWidth: 170,
+  valueGetter: ({ data }) => data?.assignedAnalyst?.initials || '',
+  cellRenderer: AssignedAnalystRenderer,
+  filter: 'agTextColumnFilter',
+  filterParams: TEXT_FILTER_PARAMS,
+  suppressFloatingFilterButton: true,
+  sortable: false
+})
+
+const lastCommentCol = (t) => ({
+  field: 'lastComment',
+  headerName: t('carbonIntensity:columns.lastComment'),
+  minWidth: 150,
+  valueGetter: ({ data }) => data?.lastComment?.comment || '',
+  cellRenderer: LastCommentRenderer,
+  sortable: false,
+  filter: 'agTextColumnFilter',
+  filterParams: TEXT_FILTER_PARAMS,
+  suppressFloatingFilterButton: true
+})
+
+/**
+ * Column definitions for the CI applications list, ordered to match the
+ * UXPin wireframes.
+ *
+ * BCeID view (5 cols):
+ *   Status, ID, Proposed effective date, Production facility Location, Last updated
+ *
+ * IDIR view (10 cols):
+ *   Status, ID, Organization, Priority score, Verification,
+ *   Assigned analyst, Last comment, Proposed effective date,
+ *   Production facility Location, Last updated
+ *
+ * Priority score and Verification are backed by simple nullable columns
+ * on ci_application. The verification taxonomy (VX1/VX2 + Low/Moderate/
+ * High) isn't formalised yet, so it's stored as free text for now and
+ * filterable by string contains; tighten to an enum / FK lookup once
+ * the verification workflow is specced.
+ */
+export const ciApplicationsColDefs = (t, { isGovernment = false } = {}) => {
+  if (!isGovernment) {
+    return [
+      statusCol(t),
+      idCol(t),
+      proposedEffectiveCol(t),
+      productionFacilityLocationCol(t),
+      lastUpdatedCol(t)
+    ]
+  }
+  return [
+    statusCol(t),
+    idCol(t),
+    organizationCol(t),
+    priorityScoreCol(t),
+    verificationCol(t),
+    assignedAnalystCol(t),
+    lastCommentCol(t),
+    proposedEffectiveCol(t),
+    productionFacilityLocationCol(t),
+    lastUpdatedCol(t)
+  ]
+}
 
 export const defaultSortModel = [{ field: 'updateDate', direction: 'desc' }]
 

--- a/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
+++ b/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
@@ -29,21 +29,31 @@ const buildTabs = ({ isCiApplicant, isSigningAuthority, isGovernment }) => {
       path: ROUTES.FUEL_CODES.LIST,
       isActive: (loc) => loc.pathname === ROUTES.FUEL_CODES.LIST
     })
+  } else if (isGovernment) {
+    tabs.push({
+      key: 'manage',
+      labelKey: 'carbonIntensity:tabs.fuelCodes',
+      path: ROUTES.FUEL_CODES.LIST,
+      isActive: (loc) => loc.pathname === ROUTES.FUEL_CODES.LIST
+    })
   }
-  tabs.push(
-    {
-      key: 'current',
-      labelKey: 'carbonIntensity:tabs.currentFuelCodes',
-      path: BULLETINS_PATH,
-      isActive: (loc) => isOnBulletins(loc) && !isArchivedQuery(loc)
-    },
-    {
-      key: 'archived',
-      labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
-      path: `${BULLETINS_PATH}?type=archived`,
-      isActive: (loc) => isOnBulletins(loc) && isArchivedQuery(loc)
-    }
-  )
+
+  if (!isGovernment) {
+    tabs.push(
+      {
+        key: 'current',
+        labelKey: 'carbonIntensity:tabs.currentFuelCodes',
+        path: BULLETINS_PATH,
+        isActive: (loc) => isOnBulletins(loc) && !isArchivedQuery(loc)
+      },
+      {
+        key: 'archived',
+        labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
+        path: `${BULLETINS_PATH}?type=archived`,
+        isActive: (loc) => isOnBulletins(loc) && isArchivedQuery(loc)
+      }
+    )
+  }
   return tabs
 }
 
@@ -63,10 +73,8 @@ export const FuelCodesTabs = () => {
     [hasAnyRole]
   )
 
-  const activeIndex = Math.max(
-    0,
-    tabs.findIndex((tab) => tab.isActive(location))
-  )
+  const matchedIndex = tabs.findIndex((tab) => tab.isActive(location))
+  const activeIndex = matchedIndex === -1 ? false : matchedIndex
 
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { fuelCodeColDefs, defaultSortModel } from './_schema'
 import { defaultInitialPagination } from '@/constants/schedules'
+import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
 
 const convertToBackendFilters = (model = {}) =>
   Object.entries(model).map(([field, cfg]) => ({
@@ -122,6 +123,7 @@ const FuelCodesBase = () => {
 
   return (
     <Grid2 className="fuel-code-container" mx={-1}>
+      <FuelCodesTabs />
       <div>
         {alertMessage && (
           <BCAlert data-test="alert-box" severity={alertSeverity}>

--- a/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
+++ b/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
@@ -44,11 +44,16 @@ vi.mock('@react-keycloak/web', () => ({
 
 // Mock Current User
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({
-    data: {
-      roles: [{ name: roles.government }, { name: roles.analyst }]
+  useCurrentUser: () => {
+    const userRoles = [{ name: roles.government }, { name: roles.analyst }]
+    return {
+      data: { roles: userRoles },
+      hasAnyRole: (...names) =>
+        names.some((n) => userRoles.some((r) => r.name === n)),
+      hasRoles: (...names) =>
+        names.every((n) => userRoles.some((r) => r.name === n))
     }
-  })
+  }
 }))
 
 // Mock BCGridViewer
@@ -66,7 +71,11 @@ vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
 
 // Mock React Router
 const mockNavigate = vi.fn()
-const mockLocationState = { state: null }
+const mockLocationState = {
+  state: null,
+  pathname: ROUTES.FUEL_CODES.LIST,
+  search: ''
+}
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocationState,


### PR DESCRIPTION
This PR adds a role-based CI Applications page under Fuel Codes.

- Add CI Applications sub tab
- Restrict access by application roles
- Scope BCeID data by organization
- Display cross-organization IDIR results

Closes #4167