### PR TITLE
Feat: Add Fuel Code Navigation Tabs - 4380

### DIFF
--- a/backend/lcfs/db/seeders/seed_database.py
+++ b/backend/lcfs/db/seeders/seed_database.py
@@ -25,7 +25,7 @@ async def seed_database(environment):
                 logger.info("Database seeding started.")
 
                 if environment == "dev":
-                    # await seed_dev(session)
+                    await seed_dev(session)
                     pass
                 elif environment == "prod":
                     await seed_prod(session)

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_exporter.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_exporter.py
@@ -55,7 +55,11 @@ async def test_export_success():
     expected_pagination = PaginationRequestSchema(
         page=1, size=10000, filters=[], sort_orders=[]
     )
-    repo_mock.get_fuel_codes_paginated.assert_called_once_with(expected_pagination)
+    repo_mock.get_fuel_codes_paginated.assert_called_once_with(
+        expected_pagination,
+        exclude_archived=False,
+        compliance_period_start=None,
+    )
 
     # Verify file content
     headers = await response.body_iterator.__anext__()

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -430,6 +430,77 @@ async def test_get_fuel_codes_paginated(fuel_code_repo, mock_db):
     assert count == 1
 
 
+def _make_paginate_side_effect():
+    return [
+        MagicMock(scalar=MagicMock(return_value=0)),
+        MagicMock(
+            unique=MagicMock(
+                return_value=MagicMock(
+                    scalars=MagicMock(
+                        return_value=MagicMock(all=MagicMock(return_value=[]))
+                    )
+                )
+            )
+        ),
+    ]
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_exclude_archived_filters_by_date(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    result, count = await fuel_code_repo.get_fuel_codes_paginated(
+        pagination,
+        exclude_archived=True,
+        compliance_period_start=date(2026, 3, 31),
+    )
+
+    assert result == []
+    assert count == 0
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "effective_date" in stmt_sql
+    assert "expiration_date" in stmt_sql
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_no_date_filter_by_default(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    await fuel_code_repo.get_fuel_codes_paginated(pagination)
+
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    # effective_date appears as a column name in the SELECT clause but should
+    # not appear as a WHERE-clause filter parameter when no date filter is active
+    assert ":effective_date_1" not in stmt_sql
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_compliance_period_end_is_march_31(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    await fuel_code_repo.get_fuel_codes_paginated(
+        pagination,
+        exclude_archived=True,
+        compliance_period_start=date(2025, 3, 31),
+    )
+
+    # SQLAlchemy uses parameter binding, so compile with literal_binds to
+    # verify the computed compliance_period_end date (2025+1 = 2026-03-31)
+    stmt = mock_db.execute.call_args_list[0].args[0]
+    compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+    stmt_sql = str(compiled)
+    assert "2026-03-31" in stmt_sql
+
+
 @pytest.mark.anyio
 async def test_get_fuel_code_statuses(fuel_code_repo, mock_db):
     fcs = FuelCodeStatus(fuel_code_status_id=1, status=FuelCodeStatusEnum.Approved)

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -430,6 +430,71 @@ async def test_get_fuel_codes_paginated(fuel_code_repo, mock_db):
     assert count == 1
 
 
+def _make_paginate_side_effect():
+    return [
+        MagicMock(scalar=MagicMock(return_value=0)),
+        MagicMock(
+            unique=MagicMock(
+                return_value=MagicMock(
+                    scalars=MagicMock(
+                        return_value=MagicMock(all=MagicMock(return_value=[]))
+                    )
+                )
+            )
+        ),
+    ]
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_exclude_archived_filters_by_date(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    result, count = await fuel_code_repo.get_fuel_codes_paginated(
+        pagination,
+        exclude_archived=True,
+        compliance_period_start=date(2026, 3, 31),
+    )
+
+    assert result == []
+    assert count == 0
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "effective_date" in stmt_sql
+    assert "expiration_date" in stmt_sql
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_no_date_filter_by_default(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    await fuel_code_repo.get_fuel_codes_paginated(pagination)
+
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "effective_date" not in stmt_sql
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_paginated_compliance_period_end_is_march_31(
+    fuel_code_repo, mock_db
+):
+    mock_db.execute.side_effect = _make_paginate_side_effect()
+    pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
+
+    await fuel_code_repo.get_fuel_codes_paginated(
+        pagination,
+        exclude_archived=True,
+        compliance_period_start=date(2025, 3, 31),
+    )
+
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "2026-03-31" in stmt_sql
+
+
 @pytest.mark.anyio
 async def test_get_fuel_code_statuses(fuel_code_repo, mock_db):
     fcs = FuelCodeStatus(fuel_code_status_id=1, status=FuelCodeStatusEnum.Approved)

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -475,7 +475,9 @@ async def test_get_fuel_codes_paginated_no_date_filter_by_default(
     await fuel_code_repo.get_fuel_codes_paginated(pagination)
 
     stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
-    assert "effective_date" not in stmt_sql
+    # effective_date appears as a column name in the SELECT clause but should
+    # not appear as a WHERE-clause filter parameter when no date filter is active
+    assert ":effective_date_1" not in stmt_sql
 
 
 @pytest.mark.anyio
@@ -491,7 +493,11 @@ async def test_get_fuel_codes_paginated_compliance_period_end_is_march_31(
         compliance_period_start=date(2025, 3, 31),
     )
 
-    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    # SQLAlchemy uses parameter binding, so compile with literal_binds to
+    # verify the computed compliance_period_end date (2025+1 = 2026-03-31)
+    stmt = mock_db.execute.call_args_list[0].args[0]
+    compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+    stmt_sql = str(compiled)
     assert "2026-03-31" in stmt_sql
 
 

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_service.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_service.py
@@ -20,7 +20,6 @@ from lcfs.web.api.fuel_code.services import FuelCodeServices
 
 @pytest.mark.anyio
 async def test_get_fuel_codes_success():
-    # Arrange
     repo_mock = AsyncMock()
     service = FuelCodeServices(repo=repo_mock)
 
@@ -47,14 +46,44 @@ async def test_get_fuel_codes_success():
 
     pagination = PaginationRequestSchema(page=1, size=10)
 
-    # Act
     result = await service.search_fuel_codes(pagination)
 
-    # Assert
     assert isinstance(result.pagination, PaginationResponseSchema)
     assert len(result.fuel_codes) == 1
     assert result.fuel_codes[0].company == "XYZ Corp"
-    repo_mock.get_fuel_codes_paginated.assert_called_once_with(pagination)
+    repo_mock.get_fuel_codes_paginated.assert_called_once_with(
+        pagination,
+        exclude_archived=False,
+        compliance_period_start=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_search_fuel_codes_exclude_archived_derives_compliance_period():
+    repo_mock = AsyncMock()
+    service = FuelCodeServices(repo=repo_mock)
+    repo_mock.get_fuel_codes_paginated.return_value = ([], 0)
+
+    await service.search_fuel_codes(PaginationRequestSchema(page=1, size=10), exclude_archived=True)
+
+    kwargs = repo_mock.get_fuel_codes_paginated.call_args.kwargs
+    assert kwargs["exclude_archived"] is True
+    assert kwargs["compliance_period_start"] is not None
+    assert kwargs["compliance_period_start"].month == 3
+    assert kwargs["compliance_period_start"].day == 31
+
+
+@pytest.mark.anyio
+async def test_search_fuel_codes_no_compliance_period_when_not_excluding():
+    repo_mock = AsyncMock()
+    service = FuelCodeServices(repo=repo_mock)
+    repo_mock.get_fuel_codes_paginated.return_value = ([], 0)
+
+    await service.search_fuel_codes(PaginationRequestSchema(page=1, size=10), exclude_archived=False)
+
+    kwargs = repo_mock.get_fuel_codes_paginated.call_args.kwargs
+    assert kwargs["exclude_archived"] is False
+    assert kwargs["compliance_period_start"] is None
 
 
 def create_mock_fuel_code_model():

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
@@ -328,7 +328,36 @@ async def test_get_fuel_codes_success(
         assert isinstance(result, dict)
         assert "pagination" in result
         assert "fuelCodes" in result
-        mock_get_fuel_codes.assert_called_once_with(pagination_request_schema)
+        mock_get_fuel_codes.assert_called_once_with(
+            pagination_request_schema, exclude_archived=False
+        )
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_with_exclude_archived(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_user_role,
+    pagination_request_schema,
+):
+    with patch(
+        "lcfs.web.api.fuel_code.services.FuelCodeServices.search_fuel_codes"
+    ) as mock_search:
+        set_user_role(RoleEnum.GOVERNMENT)
+        mock_search.return_value = {
+            "fuel_codes": [],
+            "pagination": {"total": 0, "page": 1, "size": 10, "total_pages": 0},
+        }
+
+        url = "/api/fuel-codes/list?excludeArchived=true"
+        response = await client.post(
+            url, json=pagination_request_schema.dict(by_alias=True)
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_search.assert_called_once_with(
+            pagination_request_schema, exclude_archived=True
+        )
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
@@ -466,7 +466,9 @@ async def test_export_fuel_codes_success(
         )
 
     assert response.status_code == status.HTTP_200_OK
-    mock_export.assert_called_once_with("csv", pagination_request_schema)
+    mock_export.assert_called_once_with(
+        "csv", pagination_request_schema, exclude_archived=False
+    )
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_views.py
@@ -328,7 +328,36 @@ async def test_get_fuel_codes_success(
         assert isinstance(result, dict)
         assert "pagination" in result
         assert "fuelCodes" in result
-        mock_get_fuel_codes.assert_called_once_with(pagination_request_schema)
+        mock_get_fuel_codes.assert_called_once_with(
+            pagination_request_schema, exclude_archived=False
+        )
+
+
+@pytest.mark.anyio
+async def test_get_fuel_codes_with_exclude_archived(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_user_role,
+    pagination_request_schema,
+):
+    with patch(
+        "lcfs.web.api.fuel_code.services.FuelCodeServices.search_fuel_codes"
+    ) as mock_search:
+        set_user_role(RoleEnum.GOVERNMENT)
+        mock_search.return_value = {
+            "fuel_codes": [],
+            "pagination": {"total": 0, "page": 1, "size": 10, "total_pages": 0},
+        }
+
+        url = "/api/fuel-codes/list?excludeArchived=true"
+        response = await client.post(
+            url, json=pagination_request_schema.dict(by_alias=True)
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_search.assert_called_once_with(
+            pagination_request_schema, exclude_archived=True
+        )
 
 
 @pytest.mark.anyio
@@ -437,7 +466,9 @@ async def test_export_fuel_codes_success(
         )
 
     assert response.status_code == status.HTTP_200_OK
-    mock_export.assert_called_once_with("csv", pagination_request_schema)
+    mock_export.assert_called_once_with(
+        "csv", pagination_request_schema, exclude_archived=False
+    )
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/fuel_code/export.py
+++ b/backend/lcfs/web/api/fuel_code/export.py
@@ -1,5 +1,5 @@
 import io
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from fastapi import Depends
 from starlette.responses import StreamingResponse
@@ -53,6 +53,7 @@ class FuelCodeExporter:
         self,
         export_format: str,
         pagination: PaginationRequestSchema | None = None,
+        exclude_archived: bool = False,
     ) -> StreamingResponse:
         """
         Prepares a list of users in a file that is downloadable
@@ -68,7 +69,17 @@ class FuelCodeExporter:
         # Ignore client-side paging but preserve sorting
         pagination.page, pagination.size = 1, 10000
 
-        results = await self.repo.get_fuel_codes_paginated(pagination)
+        compliance_period_start = None
+        if exclude_archived:
+            today = date.today()
+            anchor = date(today.year, 3, 31)
+            compliance_period_start = anchor if today >= anchor else date(today.year - 1, 3, 31)
+
+        results = await self.repo.get_fuel_codes_paginated(
+            pagination,
+            exclude_archived=exclude_archived,
+            compliance_period_start=compliance_period_start,
+        )
 
         # Prepare data for the spreadsheet
         data = []

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -546,18 +546,36 @@ class FuelCodeRepository:
 
     @repo_handler
     async def get_fuel_codes_paginated(
-        self, pagination: PaginationRequestSchema
+        self,
+        pagination: PaginationRequestSchema,
+        exclude_archived: bool = False,
+        compliance_period_start: Optional[date] = None,
     ) -> tuple[Sequence[FuelCode], int]:
         """
-        Queries fuel codes from the database with optional filters. Supports pagination and sorting.
+        Queries fuel codes from the database with optional filters, pagination, and sorting.
 
-        Args:
-            pagination (dict): Pagination and sorting parameters.
-
-        Returns:
-            List[FuelCodeBaseSchema]: A list of fuel codes matching the query.
+        When exclude_archived is True, Approved fuel codes outside the current compliance
+        period are omitted. Non-Approved codes (Draft, Recommended, Deleted) are unaffected.
         """
         conditions = []
+
+        if exclude_archived and compliance_period_start is not None:
+            compliance_period_end = date(compliance_period_start.year + 1, 3, 31)
+            is_current_approved = and_(
+                FuelCodeListView.effective_date < compliance_period_end,
+                or_(
+                    FuelCodeListView.expiration_date.is_(None),
+                    FuelCodeListView.expiration_date > compliance_period_start,
+                ),
+            )
+            conditions.append(
+                or_(
+                    cast(FuelCodeListView.status, String)
+                    != FuelCodeStatusEnum.Approved.value,
+                    is_current_approved,
+                )
+            )
+
         query = select(FuelCodeListView)
         for filter in pagination.filters:
 

--- a/backend/lcfs/web/api/fuel_code/services.py
+++ b/backend/lcfs/web/api/fuel_code/services.py
@@ -183,12 +183,22 @@ class FuelCodeServices:
 
     @service_handler
     async def search_fuel_codes(
-        self, pagination: PaginationRequestSchema
+        self,
+        pagination: PaginationRequestSchema,
+        exclude_archived: bool = False,
     ) -> FuelCodesSchema:
-        """
-        Gets the list of fuel codes.
-        """
-        fuel_codes, total_count = await self.repo.get_fuel_codes_paginated(pagination)
+        """Gets the list of fuel codes, optionally excluding archived approved codes."""
+        compliance_period_start = None
+        if exclude_archived:
+            compliance_period_start, _ = self._get_compliance_period_bounds(
+                date.today()
+            )
+
+        fuel_codes, total_count = await self.repo.get_fuel_codes_paginated(
+            pagination,
+            exclude_archived=exclude_archived,
+            compliance_period_start=compliance_period_start,
+        )
         return FuelCodesSchema(
             pagination=PaginationResponseSchema(
                 total=total_count,

--- a/backend/lcfs/web/api/fuel_code/views.py
+++ b/backend/lcfs/web/api/fuel_code/views.py
@@ -150,11 +150,18 @@ async def search_table_options_strings(
 async def get_fuel_codes(
     request: Request,
     pagination: PaginationRequestSchema = Body(..., embed=False),
+    exclude_archived: bool = Query(
+        default=False,
+        alias="excludeArchived",
+        description="Omit Approved fuel codes outside the current compliance period.",
+    ),
     response: Response = None,
     service: FuelCodeServices = Depends(),
 ):
     """Endpoint to get list of fuel codes with pagination options"""
-    return await service.search_fuel_codes(pagination)
+    return await service.search_fuel_codes(
+        pagination, exclude_archived=exclude_archived
+    )
 
 
 @router.post(
@@ -164,6 +171,11 @@ async def get_fuel_codes(
 async def export_fuel_codes(
     request: Request,
     format: str = Query(default="xlsx", description="File export format"),
+    exclude_archived: bool = Query(
+        default=False,
+        alias="excludeArchived",
+        description="Omit Approved fuel codes outside the current compliance period.",
+    ),
     pagination: PaginationRequestSchema | None = Body(None),
     exporter: FuelCodeExporter = Depends(),
 ):
@@ -185,7 +197,9 @@ async def export_fuel_codes(
     Note: Only the first sheet data is used for the CSV format,
         as CSV files do not support multiple sheets.
     """
-    return await exporter.export(format, pagination)
+    return await exporter.export(
+        format, pagination, exclude_archived=exclude_archived
+    )
 
 
 @router.post(

--- a/frontend/src/assets/locales/en/bulletins.json
+++ b/frontend/src/assets/locales/en/bulletins.json
@@ -6,12 +6,14 @@
   "current": {
     "bulletinLabel": "Bulletin 12",
     "title": "Approved carbon intensities - Current",
+    "idirTitle": "Current fuel codes",
     "description": "This table contains carbon intensities that have been approved by the director under section 20(1) of the Low Carbon Fuels Act or the former Greenhouse Gas (Renewable and Low Carbon Fuels Requirements) Act (Repealed) with effective dates after {{cutoffLabel}}, and that remain active beyond {{cutoffLabel}}.",
     "cutoffLabel": "March 31, 2025"
   },
   "archived": {
     "bulletinLabel": "Bulletin 12a",
     "title": "Approved carbon intensities - Archived",
+    "idirTitle": "Archived fuel codes",
     "description": "This table is an archive of all carbon intensities that have been approved by the director under section 20(1) of the Low Carbon Fuels Act or the former Greenhouse Gas (Renewable and Low Carbon Fuels Requirements) Act (Repealed)."
   },
   "common": {

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -8,8 +8,8 @@
     "ciApplications": "CI applications",
     "myFuelCodes": "My fuel codes",
     "fuelCodes": "Fuel codes",
-    "currentFuelCodes": "Current fuel codes",
-    "archivedFuelCodes": "Archived fuel codes"
+    "currentFuelCodes": "Current",
+    "archivedFuelCodes": "Archived"
   },
   "steps": {
     "step1": "Application information",

--- a/frontend/src/assets/locales/en/fuelCode.json
+++ b/frontend/src/assets/locales/en/fuelCode.json
@@ -1,4 +1,5 @@
 {
+  "currentFuelCodes": "Current fuel codes",
   "newFuelCodeBtn": "New fuel code",
   "noFuelCodesFound": "No fuel codes found",
   "fuelCodeDownloadBtn": "Download as Excel",

--- a/frontend/src/assets/locales/en/fuelCode.json
+++ b/frontend/src/assets/locales/en/fuelCode.json
@@ -1,4 +1,6 @@
 {
+  "fuelCodes": "Fuel codes",
+  "currentFuelCodes": "Current fuel codes",
   "newFuelCodeBtn": "New fuel code",
   "noFuelCodesFound": "No fuel codes found",
   "fuelCodeDownloadBtn": "Download as Excel",

--- a/frontend/src/hooks/__tests__/useFuelCode.test.js
+++ b/frontend/src/hooks/__tests__/useFuelCode.test.js
@@ -185,12 +185,16 @@ describe('useFuelCode', () => {
       })
 
       expect(result.current.data).toEqual(mockData)
-      expect(mockPost).toHaveBeenCalledWith('/fuel-codes/list', {
-        page: 1,
-        size: 10,
-        sortOrders: [],
-        filters: []
-      })
+      expect(mockPost).toHaveBeenCalledWith(
+        '/fuel-codes/list',
+        {
+          page: 1,
+          size: 10,
+          sortOrders: [],
+          filters: []
+        },
+        { params: undefined }
+      )
     })
 
     it('should fetch fuel codes with custom parameters', async () => {
@@ -212,7 +216,9 @@ describe('useFuelCode', () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      expect(mockPost).toHaveBeenCalledWith('/fuel-codes/list', params)
+      expect(mockPost).toHaveBeenCalledWith('/fuel-codes/list', params, {
+        params: undefined
+      })
     })
 
     it('should handle API errors', async () => {

--- a/frontend/src/hooks/useCIApplication.ts
+++ b/frontend/src/hooks/useCIApplication.ts
@@ -9,7 +9,7 @@ const QUERY_KEYS = {
   detail: (id: any) => ['ci-application', String(id)]
 }
 
-export const useCIApplicationOptions = (options: QueryOptions<unknown>) => {
+export const useCIApplicationOptions = (options: QueryOptions<unknown> = {}) => {
   const client = useApiService()
   return useQuery({
     queryKey: QUERY_KEYS.options,
@@ -18,6 +18,14 @@ export const useCIApplicationOptions = (options: QueryOptions<unknown>) => {
     gcTime: 60 * 60 * 1000,
     ...options
   })
+}
+
+export const useCIApplicationStatuses = (options: QueryOptions<unknown> = {}) => {
+  const result = useCIApplicationOptions(options)
+  return {
+    ...result,
+    data: result.data?.statuses ?? []
+  }
 }
 
 export const useGetCIApplications = ({ page = 1, size = 10, sortOrders = [], filters = [] }: any = {}, options: QueryOptions<unknown>) => {

--- a/frontend/src/hooks/useCIApplication.ts
+++ b/frontend/src/hooks/useCIApplication.ts
@@ -20,17 +20,6 @@ export const useCIApplicationOptions = (options: QueryOptions<unknown>) => {
   })
 }
 
-export const useCIApplicationStatuses = (options?: QueryOptions<unknown>) => {
-  const query = useCIApplicationOptions({
-    select: (data: any) => data?.statuses ?? [],
-    ...options
-  })
-  return {
-    ...query,
-    data: query.data ?? []
-  }
-}
-
 export const useGetCIApplications = ({ page = 1, size = 10, sortOrders = [], filters = [] }: any = {}, options: QueryOptions<unknown>) => {
   const client = useApiService()
   return useQuery({

--- a/frontend/src/hooks/useFuelCode.js
+++ b/frontend/src/hooks/useFuelCode.js
@@ -32,20 +32,30 @@ export const useGetFuelCode = (fuelCodeID, options) => {
 }
 
 export const useGetFuelCodes = (
-  { page = 1, size = 10, sortOrders = [], filters = [] } = {},
+  {
+    page = 1,
+    size = 10,
+    sortOrders = [],
+    filters = [],
+    excludeArchived = false
+  } = {},
   options
 ) => {
   const client = useApiService()
   return useQuery({
-    queryKey: ['fuel-codes', page, size, sortOrders, filters],
+    queryKey: ['fuel-codes', page, size, sortOrders, filters, excludeArchived],
     queryFn: async () => {
       return (
-        await client.post(apiRoutes.getFuelCodes, {
-          page,
-          size,
-          sortOrders,
-          filters
-        })
+        await client.post(
+          apiRoutes.getFuelCodes,
+          {
+            page,
+            size,
+            sortOrders,
+            filters
+          },
+          { params: excludeArchived ? { excludeArchived: true } : undefined }
+        )
       ).data
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -161,7 +171,10 @@ export const useFuelCodeMutation = (options = {}) => {
           return await client.download({
             url: apiRoutes.exportFuelCodes,
             method: 'post',
-            params: { format: data.format },
+            params: {
+              format: data.format,
+              ...(data.excludeArchived ? { excludeArchived: true } : {})
+            },
             data: data.body
           })
 

--- a/frontend/src/hooks/useFuelCode.ts
+++ b/frontend/src/hooks/useFuelCode.ts
@@ -32,18 +32,22 @@ export const useGetFuelCode = (fuelCodeID: any, options: QueryOptions<unknown>) 
   })
 }
 
-export const useGetFuelCodes = ({ page = 1, size = 10, sortOrders = [], filters = [] }: any = {}, options: QueryOptions<unknown>) => {
+export const useGetFuelCodes = ({ page = 1, size = 10, sortOrders = [], filters = [], excludeArchived = false }: any = {}, options: QueryOptions<unknown>) => {
   const client = useApiService()
   return useQuery({
-    queryKey: ['fuel-codes', page, size, sortOrders, filters],
+    queryKey: ['fuel-codes', page, size, sortOrders, filters, excludeArchived],
     queryFn: async () => {
       return (
-        await client.post(apiRoutes.getFuelCodes, {
-          page,
-          size,
-          sortOrders,
-          filters
-        })
+        await client.post(
+          apiRoutes.getFuelCodes,
+          {
+            page,
+            size,
+            sortOrders,
+            filters
+          },
+          { params: excludeArchived ? { excludeArchived: true } : undefined }
+        )
       ).data
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -159,7 +163,10 @@ export const useFuelCodeMutation = (options: ExtMutationOptions<unknown, any> = 
           return await client.download({
             url: apiRoutes.exportFuelCodes,
             method: 'post',
-            params: { format: data.format },
+            params: {
+              format: data.format,
+              ...(data.excludeArchived ? { excludeArchived: true } : {})
+            },
             data: data.body
           })
 

--- a/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
@@ -92,6 +92,119 @@ describe('FuelCodesTabs', () => {
     ).not.toBeInTheDocument()
   })
 
+  describe('government user on bulletins page (route-based internal detection)', () => {
+    beforeEach(() => {
+      mockHasAnyRole = (...names) => names.includes(roles.government)
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.BULLETINS,
+        search: '?type=archived'
+      }
+    })
+
+    it('shows only Current and Archived tabs (no CI applications / My fuel codes)', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      expect(
+        screen.getByText('carbonIntensity:tabs.currentFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('carbonIntensity:tabs.archivedFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.ciApplications')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.myFuelCodes')
+      ).not.toBeInTheDocument()
+    })
+
+    it('defaults to Current tab active when on the bulletins page', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.currentFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('Archived tab navigates to /fuel-codes?type=archived', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.archivedFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.FUEL_CODES.LIST}?type=archived`
+      )
+    })
+  })
+
+  describe('variant="internal" (IDIR Fuel codes page)', () => {
+    beforeEach(() => {
+      mockHasAnyRole = (...names) => names.includes(roles.government)
+    })
+
+    it('renders only Current and Archived tabs (no CI applications / My fuel codes)', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      expect(
+        screen.getByText('carbonIntensity:tabs.currentFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('carbonIntensity:tabs.archivedFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.ciApplications')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.myFuelCodes')
+      ).not.toBeInTheDocument()
+    })
+
+    it('marks the Current tab active on /fuel-codes', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.currentFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('marks the Archived tab active on /fuel-codes?type=archived', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=archived'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.archivedFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('Current tab navigates to /fuel-codes', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=archived'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.currentFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.FUEL_CODES.LIST)
+    })
+
+    it('Archived tab navigates to /fuel-codes?type=archived', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.archivedFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.FUEL_CODES.LIST}?type=archived`
+      )
+    })
+  })
+
   it('navigates to the corresponding route when a tab is clicked', () => {
     mockHasAnyRole = (...names) => names.includes(roles.ci_applicant)
     mockLocation = { pathname: ROUTES.FUEL_CODES.BULLETINS, search: '' }

--- a/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/FuelCodesTabs.test.jsx
@@ -92,47 +92,7 @@ describe('FuelCodesTabs', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('shows the IDIR-only Fuel codes (manage) tab for government users', () => {
-    mockHasAnyRole = (...names) => names.includes(roles.government)
-    render(<FuelCodesTabs />, { wrapper })
-
-    expect(
-      screen.getByText('carbonIntensity:tabs.fuelCodes')
-    ).toBeInTheDocument()
-  })
-
-  it('navigates to /fuel-codes when the IDIR Fuel codes tab is clicked', () => {
-    mockHasAnyRole = (...names) => names.includes(roles.government)
-    render(<FuelCodesTabs />, { wrapper })
-
-    fireEvent.click(screen.getByText('carbonIntensity:tabs.fuelCodes'))
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.FUEL_CODES.LIST)
-  })
-
-  it('hides Current and Archived bulletin tabs from government users', () => {
-    mockHasAnyRole = (...names) => names.includes(roles.government)
-    render(<FuelCodesTabs />, { wrapper })
-
-    expect(
-      screen.queryByText('carbonIntensity:tabs.currentFuelCodes')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('carbonIntensity:tabs.archivedFuelCodes')
-    ).not.toBeInTheDocument()
-  })
-
-  it('marks the Fuel codes (manage) tab active on /fuel-codes for IDIR', () => {
-    mockHasAnyRole = (...names) => names.includes(roles.government)
-    mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
-    render(<FuelCodesTabs />, { wrapper })
-
-    const tab = screen
-      .getByText('carbonIntensity:tabs.fuelCodes')
-      .closest('[role="tab"]')
-    expect(tab.getAttribute('aria-selected')).toBe('true')
-  })
-
-  it('shows CI applicants the My fuel codes tab (not the IDIR Fuel codes tab)', () => {
+  it('shows CI applicants the My fuel codes tab (not the internal Fuel codes tab)', () => {
     mockHasAnyRole = (...names) => names.includes(roles.ci_applicant)
     render(<FuelCodesTabs />, { wrapper })
 
@@ -142,6 +102,148 @@ describe('FuelCodesTabs', () => {
     expect(
       screen.queryByText('carbonIntensity:tabs.fuelCodes')
     ).not.toBeInTheDocument()
+  })
+
+  describe('government user on bulletins page (route-based internal detection)', () => {
+    beforeEach(() => {
+      mockHasAnyRole = (...names) => names.includes(roles.government)
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.BULLETINS,
+        search: '?type=archived'
+      }
+    })
+
+    it('shows only Current and Archived tabs (no CI applications / My fuel codes)', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      expect(
+        screen.getByText('carbonIntensity:tabs.currentFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('carbonIntensity:tabs.archivedFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.ciApplications')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.myFuelCodes')
+      ).not.toBeInTheDocument()
+    })
+
+    it('defaults to Current tab active when on the bulletins page', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.currentFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('Archived tab navigates to /fuel-codes?type=archived', () => {
+      render(<FuelCodesTabs />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.archivedFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.FUEL_CODES.LIST}?type=archived`
+      )
+    })
+  })
+
+  describe('variant="internal" (IDIR Fuel codes page)', () => {
+    beforeEach(() => {
+      mockHasAnyRole = (...names) => names.includes(roles.government)
+    })
+
+    it('renders Fuel codes, Current and Archived tabs (no CI applications / My fuel codes)', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      expect(
+        screen.getByText('carbonIntensity:tabs.fuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('carbonIntensity:tabs.currentFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('carbonIntensity:tabs.archivedFuelCodes')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.ciApplications')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('carbonIntensity:tabs.myFuelCodes')
+      ).not.toBeInTheDocument()
+    })
+
+    it('marks the Fuel codes tab active on /fuel-codes (no type param)', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.fuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('marks the Current tab active on /fuel-codes?type=current', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=current'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.currentFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('marks the Archived tab active on /fuel-codes?type=archived', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=archived'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      const tab = screen
+        .getByText('carbonIntensity:tabs.archivedFuelCodes')
+        .closest('[role="tab"]')
+      expect(tab.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('Fuel codes tab navigates to /fuel-codes', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=archived'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.fuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.FUEL_CODES.LIST)
+    })
+
+    it('Current tab navigates to /fuel-codes?type=current', () => {
+      mockLocation = {
+        pathname: ROUTES.FUEL_CODES.LIST,
+        search: '?type=archived'
+      }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.currentFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.FUEL_CODES.LIST}?type=current`
+      )
+    })
+
+    it('Archived tab navigates to /fuel-codes?type=archived', () => {
+      mockLocation = { pathname: ROUTES.FUEL_CODES.LIST, search: '' }
+      render(<FuelCodesTabs variant="internal" />, { wrapper })
+
+      fireEvent.click(screen.getByText('carbonIntensity:tabs.archivedFuelCodes'))
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.FUEL_CODES.LIST}?type=archived`
+      )
+    })
   })
 
   it('navigates to the corresponding route when a tab is clicked', () => {

--- a/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
+++ b/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
@@ -9,17 +9,45 @@ import ROUTES from '@/routes/routes'
 import breakpoints from '@/themes/base/breakpoints'
 
 const BULLETINS_PATH = ROUTES.FUEL_CODES.BULLETINS
+const FUEL_CODES_PATH = ROUTES.FUEL_CODES.LIST
 
 const isOnBulletins = (loc) => loc.pathname === BULLETINS_PATH
+const isOnInternalFuelCodes = (loc) => loc.pathname === FUEL_CODES_PATH
+const isOnFuelCodesArea = (loc) =>
+  isOnInternalFuelCodes(loc) || isOnBulletins(loc)
 const isArchivedQuery = (loc) =>
   new URLSearchParams(loc.search).get('type') === 'archived'
+
+const INTERNAL_FUEL_CODES_TABS = [
+  {
+    key: 'current',
+    labelKey: 'carbonIntensity:tabs.currentFuelCodes',
+    path: FUEL_CODES_PATH,
+    isActive: (loc) => isOnInternalFuelCodes(loc) && !isArchivedQuery(loc)
+  },
+  {
+    key: 'archived',
+    labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
+    path: `${FUEL_CODES_PATH}?type=archived`,
+    isActive: (loc) => isOnInternalFuelCodes(loc) && isArchivedQuery(loc)
+  }
+]
 
 const buildTabs = ({
   isCiApplicant,
   isSigningAuthority,
   isGovernment,
-  ciApplicationsEnabled
+  ciApplicationsEnabled,
+  variant,
+  location
 }) => {
+  if (
+    variant === 'internal' ||
+    (isGovernment && isOnFuelCodesArea(location))
+  ) {
+    return INTERNAL_FUEL_CODES_TABS
+  }
+
   const tabs = []
   if (
     ciApplicationsEnabled &&
@@ -36,8 +64,8 @@ const buildTabs = ({
     tabs.push({
       key: 'mine',
       labelKey: 'carbonIntensity:tabs.myFuelCodes',
-      path: ROUTES.FUEL_CODES.LIST,
-      isActive: (loc) => loc.pathname === ROUTES.FUEL_CODES.LIST
+      path: FUEL_CODES_PATH,
+      isActive: isOnInternalFuelCodes
     })
   }
   tabs.push(
@@ -57,7 +85,7 @@ const buildTabs = ({
   return tabs
 }
 
-export const FuelCodesTabs = () => {
+export const FuelCodesTabs = ({ variant = 'default' } = {}) => {
   const { t } = useTranslation(['common', 'carbonIntensity'])
   const navigate = useNavigate()
   const location = useLocation()
@@ -71,9 +99,11 @@ export const FuelCodesTabs = () => {
         isCiApplicant: hasAnyRole(roles.ci_applicant),
         isSigningAuthority: hasAnyRole(roles.signing_authority),
         isGovernment: hasAnyRole(...govRoles),
-        ciApplicationsEnabled
+        ciApplicationsEnabled,
+        variant,
+        location
       }),
-    [hasAnyRole, ciApplicationsEnabled]
+    [hasAnyRole, ciApplicationsEnabled, variant, location]
   )
 
   const activeIndex = Math.max(

--- a/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
+++ b/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
@@ -41,6 +41,21 @@ const INTERNAL_FUEL_CODES_TABS = [
   }
 ]
 
+const GOVERNMENT_BULLETINS_TABS = [
+  {
+    key: 'current',
+    labelKey: 'carbonIntensity:tabs.currentFuelCodes',
+    path: FUEL_CODES_PATH,
+    isActive: (loc) => isOnBulletins(loc)
+  },
+  {
+    key: 'archived',
+    labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
+    path: `${FUEL_CODES_PATH}?type=archived`,
+    isActive: () => false
+  }
+]
+
 const buildTabs = ({
   isCiApplicant,
   isSigningAuthority,
@@ -49,10 +64,11 @@ const buildTabs = ({
   variant,
   location
 }) => {
-  if (
-    variant === 'internal' ||
-    (isGovernment && isOnFuelCodesArea(location))
-  ) {
+  if (isGovernment && isOnBulletins(location)) {
+    return GOVERNMENT_BULLETINS_TABS
+  }
+
+  if (variant === 'internal' || (isGovernment && isOnInternalFuelCodes(location))) {
     return INTERNAL_FUEL_CODES_TABS
   }
 

--- a/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
+++ b/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
@@ -9,17 +9,53 @@ import ROUTES from '@/routes/routes'
 import breakpoints from '@/themes/base/breakpoints'
 
 const BULLETINS_PATH = ROUTES.FUEL_CODES.BULLETINS
+const FUEL_CODES_PATH = ROUTES.FUEL_CODES.LIST
 
 const isOnBulletins = (loc) => loc.pathname === BULLETINS_PATH
-const isArchivedQuery = (loc) =>
-  new URLSearchParams(loc.search).get('type') === 'archived'
+const isOnInternalFuelCodes = (loc) => loc.pathname === FUEL_CODES_PATH
+const isOnFuelCodesArea = (loc) =>
+  isOnInternalFuelCodes(loc) || isOnBulletins(loc)
+const getTypeQuery = (loc) => new URLSearchParams(loc.search).get('type')
+const isArchivedQuery = (loc) => getTypeQuery(loc) === 'archived'
+const isCurrentQuery = (loc) => getTypeQuery(loc) === 'current'
+
+const INTERNAL_FUEL_CODES_TABS = [
+  {
+    key: 'fuelCodes',
+    labelKey: 'carbonIntensity:tabs.fuelCodes',
+    path: FUEL_CODES_PATH,
+    isActive: (loc) =>
+      isOnInternalFuelCodes(loc) && !isArchivedQuery(loc) && !isCurrentQuery(loc)
+  },
+  {
+    key: 'current',
+    labelKey: 'carbonIntensity:tabs.currentFuelCodes',
+    path: `${FUEL_CODES_PATH}?type=current`,
+    isActive: (loc) => isOnInternalFuelCodes(loc) && isCurrentQuery(loc)
+  },
+  {
+    key: 'archived',
+    labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
+    path: `${FUEL_CODES_PATH}?type=archived`,
+    isActive: (loc) => isOnInternalFuelCodes(loc) && isArchivedQuery(loc)
+  }
+]
 
 const buildTabs = ({
   isCiApplicant,
   isSigningAuthority,
   isGovernment,
-  ciApplicationsEnabled
+  ciApplicationsEnabled,
+  variant,
+  location
 }) => {
+  if (
+    variant === 'internal' ||
+    (isGovernment && isOnFuelCodesArea(location))
+  ) {
+    return INTERNAL_FUEL_CODES_TABS
+  }
+
   const tabs = []
   if (
     ciApplicationsEnabled &&
@@ -36,8 +72,8 @@ const buildTabs = ({
     tabs.push({
       key: 'mine',
       labelKey: 'carbonIntensity:tabs.myFuelCodes',
-      path: ROUTES.FUEL_CODES.LIST,
-      isActive: (loc) => loc.pathname === ROUTES.FUEL_CODES.LIST
+      path: FUEL_CODES_PATH,
+      isActive: isOnInternalFuelCodes
     })
   } else if (isGovernment) {
     tabs.push({
@@ -67,7 +103,7 @@ const buildTabs = ({
   return tabs
 }
 
-export const FuelCodesTabs = () => {
+export const FuelCodesTabs = ({ variant = 'default' } = {}) => {
   const { t } = useTranslation(['common', 'carbonIntensity'])
   const navigate = useNavigate()
   const location = useLocation()
@@ -81,9 +117,11 @@ export const FuelCodesTabs = () => {
         isCiApplicant: hasAnyRole(roles.ci_applicant),
         isSigningAuthority: hasAnyRole(roles.signing_authority),
         isGovernment: hasAnyRole(...govRoles),
-        ciApplicationsEnabled
+        ciApplicationsEnabled,
+        variant,
+        location
       }),
-    [hasAnyRole, ciApplicationsEnabled]
+    [hasAnyRole, ciApplicationsEnabled, variant, location]
   )
 
   const matchedIndex = tabs.findIndex((tab) => tab.isActive(location))

--- a/frontend/src/views/FuelCodeBulletins/FuelCodeBulletins.tsx
+++ b/frontend/src/views/FuelCodeBulletins/FuelCodeBulletins.tsx
@@ -1,4 +1,4 @@
-import { nonGovRoles } from '@/constants/roles'
+import { govRoles, nonGovRoles } from '@/constants/roles'
 import ROUTES from '@/routes/routes'
 import withRole from '@/utils/withRole'
 import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
@@ -12,7 +12,7 @@ export const FuelCodeBulletinsBase = () => {
   const isArchived = searchParams.get('type') === 'archived'
 
   return (
-    <Stack spacing={2} sx={{ width: '100%' }}>
+    <Stack sx={{ width: '100%' }}>
       <FuelCodesTabs />
       {isArchived ? <ArchivedFuelCodes /> : <CurrentFuelCodes />}
     </Stack>
@@ -21,7 +21,7 @@ export const FuelCodeBulletinsBase = () => {
 
 export const FuelCodeBulletins = withRole(
   FuelCodeBulletinsBase,
-  nonGovRoles,
+  [...govRoles, ...nonGovRoles],
   ROUTES.DASHBOARD
 )
 FuelCodeBulletins.displayName = 'FuelCodeBulletins'

--- a/frontend/src/views/FuelCodeBulletins/__tests__/FuelCodeBulletins.test.tsx
+++ b/frontend/src/views/FuelCodeBulletins/__tests__/FuelCodeBulletins.test.tsx
@@ -15,6 +15,14 @@ vi.mock('@/utils/withRole', () => ({
   default: (Component: any) => Component
 }))
 
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    hasAnyRole: () => false,
+    data: null,
+    isLoading: false
+  })
+}))
+
 vi.mock('react-router-dom', async () => {
   const actual: any = await vi.importActual('react-router-dom')
   return {

--- a/frontend/src/views/FuelCodeBulletins/components/ArchivedFuelCodes.tsx
+++ b/frontend/src/views/FuelCodeBulletins/components/ArchivedFuelCodes.tsx
@@ -4,6 +4,8 @@ import { DownloadButton } from '@/components/DownloadButton'
 import { Stack } from '@mui/material'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { govRoles } from '@/constants/roles'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { buildColumnDefs, normalizeRows } from '../_schema'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer'
 import {
@@ -21,6 +23,8 @@ const initialPaginationOptions = {
 
 export const ArchivedFuelCodes = () => {
   const { t } = useTranslation(['bulletins'])
+  const { hasAnyRole } = useCurrentUser()
+  const isIdirView = hasAnyRole(...govRoles)
   const gridRef = useRef<any>(null)
   const [isDownloading, setIsDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState('')
@@ -79,15 +83,19 @@ export const ArchivedFuelCodes = () => {
         </BCAlert>
       )}
       <BCTypography variant="h5" color="primary">
-        {t('archived.title')}
+        {isIdirView ? t('archived.idirTitle') : t('archived.title')}
       </BCTypography>
 
-      <BCTypography variant="body2" color="text">
-        {t('archived.description')}
-      </BCTypography>
-      <BCTypography variant="body2" color="text">
-        {t('common.fuelCodePrefix')}
-      </BCTypography>
+      {!isIdirView && (
+        <>
+          <BCTypography variant="body2" color="text">
+            {t('archived.description')}
+          </BCTypography>
+          <BCTypography variant="body2" color="text">
+            {t('common.fuelCodePrefix')}
+          </BCTypography>
+        </>
+      )}
 
       <Stack direction="row">
         <DownloadButton

--- a/frontend/src/views/FuelCodeBulletins/components/CurrentFuelCodes.tsx
+++ b/frontend/src/views/FuelCodeBulletins/components/CurrentFuelCodes.tsx
@@ -4,6 +4,8 @@ import { DownloadButton } from '@/components/DownloadButton'
 import { Stack } from '@mui/material'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { govRoles } from '@/constants/roles'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { buildColumnDefs, formatDate, normalizeRows } from '../_schema'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer'
 import {
@@ -21,6 +23,8 @@ const initialPaginationOptions = {
 
 export const CurrentFuelCodes = () => {
   const { t } = useTranslation(['bulletins'])
+  const { hasAnyRole } = useCurrentUser()
+  const isIdirView = hasAnyRole(...govRoles)
   const gridRef = useRef<any>(null)
   const [isDownloading, setIsDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState('')
@@ -83,15 +87,19 @@ export const CurrentFuelCodes = () => {
       )}
 
       <BCTypography variant="h5" color="primary">
-        {t('current.title')}
+        {isIdirView ? t('current.idirTitle') : t('current.title')}
       </BCTypography>
 
-      <BCTypography variant="body2" color="text">
-        {t('current.description', { cutoffLabel })}
-      </BCTypography>
-      <BCTypography variant="body2" color="text">
-        {t('common.fuelCodePrefix')}
-      </BCTypography>
+      {!isIdirView && (
+        <>
+          <BCTypography variant="body2" color="text">
+            {t('current.description', { cutoffLabel })}
+          </BCTypography>
+          <BCTypography variant="body2" color="text">
+            {t('common.fuelCodePrefix')}
+          </BCTypography>
+        </>
+      )}
 
       <Stack direction="row">
         <DownloadButton

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -16,9 +16,11 @@ import { Stack } from '@mui/material'
 import Grid2 from '@mui/material/Grid2'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { fuelCodeColDefs, defaultSortModel } from './_schema'
 import { defaultInitialPagination } from '@/constants/schedules'
+import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
+import { ArchivedFuelCodes } from '@/views/FuelCodeBulletins/components/ArchivedFuelCodes'
 
 const convertToBackendFilters = (model = {}) =>
   Object.entries(model).map(([field, cfg]) => ({
@@ -53,11 +55,16 @@ const FuelCodesBase = () => {
   const { t } = useTranslation(['common', 'fuelCodes'])
   const navigate = useNavigate()
   const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const isArchived = searchParams.get('type') === 'archived'
 
-  const queryData = useGetFuelCodes(paginationOptions, {
-    cacheTime: 0,
-    staleTime: 0
-  })
+  const queryData = useGetFuelCodes(
+    { ...paginationOptions, excludeArchived: true },
+    {
+      cacheTime: 0,
+      staleTime: 0
+    }
+  )
   const { mutateAsync: downloadFuelCodes } = useDownloadFuelCodes()
 
   useEffect(() => {
@@ -101,7 +108,11 @@ const FuelCodesBase = () => {
     setIsDownloading(true)
     setAlertMessage('')
     try {
-      await downloadFuelCodes({ format: 'xlsx', body: buildExportPayload() })
+      await downloadFuelCodes({
+        format: 'xlsx',
+        body: buildExportPayload(),
+        excludeArchived: true
+      })
       setIsDownloading(false)
     } catch (error) {
       console.error('Error downloading fuel code information:', error)
@@ -122,68 +133,76 @@ const FuelCodesBase = () => {
 
   return (
     <Grid2 className="fuel-code-container" mx={-1}>
-      <div>
-        {alertMessage && (
-          <BCAlert data-test="alert-box" severity={alertSeverity}>
-            {alertMessage}
-          </BCAlert>
-        )}
-      </div>
-      <BCTypography variant="h5" color="primary" data-test="title">
-        {t('FuelCodes')}
-      </BCTypography>
-      <Stack
-        direction={{ md: 'column', lg: 'row' }}
-        spacing={{ xs: 2, sm: 2, md: 3 }}
-        useFlexGap
-        flexWrap="wrap"
-        mt={1}
-        mb={2}
-      >
-        <Role roles={[roles.analyst]}>
-          <BCButton
-            variant="contained"
-            size="small"
-            color="primary"
-            startIcon={
-              <FontAwesomeIcon icon={faCirclePlus} className="small-icon" />
-            }
-            data-test="new-fuel-code-btn"
-            onClick={() => navigate(ROUTES.FUEL_CODES.ADD)}
+      <FuelCodesTabs variant="internal" />
+
+      {isArchived ? (
+        <ArchivedFuelCodes />
+      ) : (
+        <>
+          <div>
+            {alertMessage && (
+              <BCAlert data-test="alert-box" severity={alertSeverity}>
+                {alertMessage}
+              </BCAlert>
+            )}
+          </div>
+          <BCTypography variant="h5" color="primary" data-test="title">
+            {t('fuelCode:currentFuelCodes')}
+          </BCTypography>
+          <Stack
+            direction={{ md: 'column', lg: 'row' }}
+            spacing={{ xs: 2, sm: 2, md: 3 }}
+            useFlexGap
+            flexWrap="wrap"
+            mt={1}
+            mb={2}
           >
-            <BCTypography variant="subtitle2">
-              {t('fuelCode:newFuelCodeBtn')}
-            </BCTypography>
-          </BCButton>
-        </Role>
-        <DownloadButton
-          ref={downloadButtonRef}
-          onDownload={handleDownload}
-          isDownloading={isDownloading}
-          label={t('fuelCode:fuelCodeDownloadBtn')}
-          downloadLabel={`${t('fuelCode:fuelCodeDownloadingMsg')}...`}
-          dataTest="fuel-code-download-btn"
-        />
-      </Stack>
-      <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
-        <BCGridViewer
-          gridRef={gridRef}
-          gridKey="fuel-codes-grid"
-          columnDefs={fuelCodeColDefs(t)}
-          getRowId={getRowId}
-          overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
-          defaultColDef={defaultColDef}
-          queryData={queryData}
-          dataKey="fuelCodes"
-          paginationOptions={paginationOptions}
-          onPaginationChange={(newPagination) =>
-            setPaginationOptions((prev) => ({
-              ...prev,
-              ...newPagination
-            }))
-          }
-        />
-      </BCBox>
+            <Role roles={[roles.analyst]}>
+              <BCButton
+                variant="contained"
+                size="small"
+                color="primary"
+                startIcon={
+                  <FontAwesomeIcon icon={faCirclePlus} className="small-icon" />
+                }
+                data-test="new-fuel-code-btn"
+                onClick={() => navigate(ROUTES.FUEL_CODES.ADD)}
+              >
+                <BCTypography variant="subtitle2">
+                  {t('fuelCode:newFuelCodeBtn')}
+                </BCTypography>
+              </BCButton>
+            </Role>
+            <DownloadButton
+              ref={downloadButtonRef}
+              onDownload={handleDownload}
+              isDownloading={isDownloading}
+              label={t('fuelCode:fuelCodeDownloadBtn')}
+              downloadLabel={`${t('fuelCode:fuelCodeDownloadingMsg')}...`}
+              dataTest="fuel-code-download-btn"
+            />
+          </Stack>
+          <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
+            <BCGridViewer
+              gridRef={gridRef}
+              gridKey="fuel-codes-grid"
+              columnDefs={fuelCodeColDefs(t)}
+              getRowId={getRowId}
+              overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
+              defaultColDef={defaultColDef}
+              queryData={queryData}
+              dataKey="fuelCodes"
+              paginationOptions={paginationOptions}
+              onPaginationChange={(newPagination) =>
+                setPaginationOptions((prev) => ({
+                  ...prev,
+                  ...newPagination
+                }))
+              }
+            />
+          </BCBox>
+        </>
+      )}
     </Grid2>
   )
 }

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -16,10 +16,11 @@ import { Stack } from '@mui/material'
 import Grid2 from '@mui/material/Grid2'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { fuelCodeColDefs, defaultSortModel } from './_schema'
 import { defaultInitialPagination } from '@/constants/schedules'
 import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
+import { ArchivedFuelCodes } from '@/views/FuelCodeBulletins/components/ArchivedFuelCodes'
 
 const convertToBackendFilters = (model = {}) =>
   Object.entries(model).map(([field, cfg]) => ({
@@ -54,11 +55,18 @@ const FuelCodesBase = () => {
   const { t } = useTranslation(['common', 'fuelCodes'])
   const navigate = useNavigate()
   const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const tabType = searchParams.get('type')
+  const isArchived = tabType === 'archived'
+  const isCurrent = tabType === 'current'
 
-  const queryData = useGetFuelCodes(paginationOptions, {
-    cacheTime: 0,
-    staleTime: 0
-  })
+  const queryData = useGetFuelCodes(
+    { ...paginationOptions, excludeArchived: isCurrent },
+    {
+      cacheTime: 0,
+      staleTime: 0
+    }
+  )
   const { mutateAsync: downloadFuelCodes } = useDownloadFuelCodes()
 
   useEffect(() => {
@@ -102,7 +110,11 @@ const FuelCodesBase = () => {
     setIsDownloading(true)
     setAlertMessage('')
     try {
-      await downloadFuelCodes({ format: 'xlsx', body: buildExportPayload() })
+      await downloadFuelCodes({
+        format: 'xlsx',
+        body: buildExportPayload(),
+        excludeArchived: isCurrent
+      })
       setIsDownloading(false)
     } catch (error) {
       console.error('Error downloading fuel code information:', error)
@@ -123,69 +135,78 @@ const FuelCodesBase = () => {
 
   return (
     <Grid2 className="fuel-code-container" mx={-1}>
-      <FuelCodesTabs />
-      <div>
-        {alertMessage && (
-          <BCAlert data-test="alert-box" severity={alertSeverity}>
-            {alertMessage}
-          </BCAlert>
-        )}
-      </div>
-      <BCTypography variant="h5" color="primary" data-test="title">
-        {t('FuelCodes')}
-      </BCTypography>
-      <Stack
-        direction={{ md: 'column', lg: 'row' }}
-        spacing={{ xs: 2, sm: 2, md: 3 }}
-        useFlexGap
-        flexWrap="wrap"
-        mt={1}
-        mb={2}
-      >
-        <Role roles={[roles.analyst]}>
-          <BCButton
-            variant="contained"
-            size="small"
-            color="primary"
-            startIcon={
-              <FontAwesomeIcon icon={faCirclePlus} className="small-icon" />
-            }
-            data-test="new-fuel-code-btn"
-            onClick={() => navigate(ROUTES.FUEL_CODES.ADD)}
+      <FuelCodesTabs variant="internal" />
+
+      {isArchived ? (
+        <ArchivedFuelCodes />
+      ) : (
+        <>
+          <div>
+            {alertMessage && (
+              <BCAlert data-test="alert-box" severity={alertSeverity}>
+                {alertMessage}
+              </BCAlert>
+            )}
+          </div>
+          <BCTypography variant="h5" color="primary" data-test="title">
+            {isCurrent
+              ? t('fuelCode:currentFuelCodes')
+              : t('fuelCode:fuelCodes')}
+          </BCTypography>
+          <Stack
+            direction={{ md: 'column', lg: 'row' }}
+            spacing={{ xs: 2, sm: 2, md: 3 }}
+            useFlexGap
+            flexWrap="wrap"
+            mt={1}
+            mb={2}
           >
-            <BCTypography variant="subtitle2">
-              {t('fuelCode:newFuelCodeBtn')}
-            </BCTypography>
-          </BCButton>
-        </Role>
-        <DownloadButton
-          ref={downloadButtonRef}
-          onDownload={handleDownload}
-          isDownloading={isDownloading}
-          label={t('fuelCode:fuelCodeDownloadBtn')}
-          downloadLabel={`${t('fuelCode:fuelCodeDownloadingMsg')}...`}
-          dataTest="fuel-code-download-btn"
-        />
-      </Stack>
-      <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
-        <BCGridViewer
-          gridRef={gridRef}
-          gridKey="fuel-codes-grid"
-          columnDefs={fuelCodeColDefs(t)}
-          getRowId={getRowId}
-          overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
-          defaultColDef={defaultColDef}
-          queryData={queryData}
-          dataKey="fuelCodes"
-          paginationOptions={paginationOptions}
-          onPaginationChange={(newPagination) =>
-            setPaginationOptions((prev) => ({
-              ...prev,
-              ...newPagination
-            }))
-          }
-        />
-      </BCBox>
+            <Role roles={[roles.analyst]}>
+              <BCButton
+                variant="contained"
+                size="small"
+                color="primary"
+                startIcon={
+                  <FontAwesomeIcon icon={faCirclePlus} className="small-icon" />
+                }
+                data-test="new-fuel-code-btn"
+                onClick={() => navigate(ROUTES.FUEL_CODES.ADD)}
+              >
+                <BCTypography variant="subtitle2">
+                  {t('fuelCode:newFuelCodeBtn')}
+                </BCTypography>
+              </BCButton>
+            </Role>
+            <DownloadButton
+              ref={downloadButtonRef}
+              onDownload={handleDownload}
+              isDownloading={isDownloading}
+              label={t('fuelCode:fuelCodeDownloadBtn')}
+              downloadLabel={`${t('fuelCode:fuelCodeDownloadingMsg')}...`}
+              dataTest="fuel-code-download-btn"
+            />
+          </Stack>
+          <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
+            <BCGridViewer
+              gridRef={gridRef}
+              gridKey="fuel-codes-grid"
+              columnDefs={fuelCodeColDefs(t)}
+              getRowId={getRowId}
+              overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
+              defaultColDef={defaultColDef}
+              queryData={queryData}
+              dataKey="fuelCodes"
+              paginationOptions={paginationOptions}
+              onPaginationChange={(newPagination) =>
+                setPaginationOptions((prev) => ({
+                  ...prev,
+                  ...newPagination
+                }))
+              }
+            />
+          </BCBox>
+        </>
+      )}
     </Grid2>
   )
 }

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -52,7 +52,7 @@ const FuelCodesBase = () => {
     initialPaginationOptions
   )
 
-  const { t } = useTranslation(['common', 'fuelCodes'])
+  const { t } = useTranslation(['common', 'fuelCode'])
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()

--- a/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
+++ b/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
@@ -13,12 +13,12 @@ import { roles } from '@/constants/roles'
 import { wrapper } from '@/tests/utils/wrapper'
 import { ROUTES } from '@/routes/routes'
 
-// Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key, options) => {
       const translations = {
         FuelCodes: 'Fuel codes',
+        'fuelCode:currentFuelCodes': 'Current fuel codes',
         'fuelCode:newFuelCodeBtn': 'New fuel code',
         'fuelCode:fuelCodeDownloadBtn': 'Download fuel codes information',
         'fuelCode:fuelCodeDownloadingMsg': 'Downloading fuel codes information',
@@ -31,7 +31,6 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
-// Mock Keycloak
 vi.mock('@react-keycloak/web', () => ({
   useKeycloak: () => ({
     keycloak: {
@@ -42,16 +41,17 @@ vi.mock('@react-keycloak/web', () => ({
   })
 }))
 
-// Mock Current User
+const mockUserRoleNames = [roles.government, roles.analyst]
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
     data: {
-      roles: [{ name: roles.government }, { name: roles.analyst }]
-    }
+      roles: mockUserRoleNames.map((name) => ({ name }))
+    },
+    hasAnyRole: (...names) => names.some((n) => mockUserRoleNames.includes(n)),
+    hasRoles: (...names) => names.some((n) => mockUserRoleNames.includes(n))
   })
 }))
 
-// Mock BCGridViewer
 vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
   BCGridViewer: ({ gridRef, columnDefs, queryData, dataKey, className }) => (
     <div
@@ -64,7 +64,6 @@ vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
   )
 }))
 
-// Mock React Router
 const mockNavigate = vi.fn()
 const mockLocationState = { state: null }
 vi.mock('react-router-dom', () => ({
@@ -73,7 +72,6 @@ vi.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams(), vi.fn()]
 }))
 
-// Mock useFuelCode hooks
 let mockDownloadMutate = vi.fn()
 let mockGetFuelCodesData = {
   data: {
@@ -113,15 +111,12 @@ vi.mock('@/hooks/useFuelCode', () => ({
   }))
 }))
 
-// Mock BCBox to prevent jsx prop warnings
 vi.mock('@/components/BCBox', () => ({
   default: ({ children, jsx, ...props }) => <div {...props}>{children}</div>
 }))
 
-// Import the component internals for direct testing
 import { FuelCodes as FuelCodesComponent } from '@/views/FuelCodes/FuelCodes.jsx'
 
-// Create mock grid ref with AG Grid API methods
 const createMockGridRef = (filterModel = {}, columnState = []) => ({
   current: {
     api: {
@@ -249,7 +244,12 @@ describe('FuelCodes Component Tests', () => {
       render(<FuelCodes />, { wrapper })
       const title = screen.getByTestId('title')
       expect(title).toBeInTheDocument()
-      expect(title.textContent).toBe('Fuel codes')
+      expect(title.textContent).toBe('Current fuel codes')
+    })
+
+    it('should render the Current fuel codes tab strip', () => {
+      render(<FuelCodes />, { wrapper })
+      expect(screen.getByRole('tablist')).toBeInTheDocument()
     })
 
     it('should render grid viewer with correct props', () => {
@@ -345,6 +345,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: true,
           body: {
             page: 1,
             size: 10000,
@@ -437,6 +438,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: true,
           body: expect.objectContaining({
             page: 1,
             size: 10000,
@@ -456,6 +458,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: true,
           body: {
             page: 1,
             size: 10000,
@@ -468,6 +471,20 @@ describe('FuelCodes Component Tests', () => {
             ]
           }
         })
+      })
+    })
+
+    it('should pass excludeArchived: true on every download call', async () => {
+      mockDownloadMutate = vi.fn().mockResolvedValue(undefined)
+      render(<FuelCodes />, { wrapper })
+      const downloadButton = screen.getByTestId('fuel-code-download-btn')
+
+      fireEvent.click(downloadButton)
+
+      await waitFor(() => {
+        expect(mockDownloadMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ excludeArchived: true })
+        )
       })
     })
   })
@@ -495,7 +512,6 @@ describe('FuelCodes Component Tests', () => {
       }
 
       render(<FuelCodes />, { wrapper })
-      // The grid container should still be rendered - error handling is done by BCGridViewer
       const gridContainer = screen.getByTestId('bc-grid-container')
       expect(gridContainer).toBeInTheDocument()
     })
@@ -520,8 +536,6 @@ describe('FuelCodes Component Tests', () => {
   describe('Component State Management', () => {
     it('should initialize with correct default state', () => {
       render(<FuelCodes />, { wrapper })
-      
-      // Verify initial rendering without errors
       expect(screen.getByTestId('title')).toBeInTheDocument()
       expect(screen.queryByTestId('alert-box')).not.toBeInTheDocument()
     })
@@ -649,8 +663,8 @@ describe('FuelCodes Component Tests', () => {
   describe('Translation Integration', () => {
     it('should use translation keys for all text content', () => {
       render(<FuelCodes />, { wrapper })
-      
-      expect(screen.getByText('Fuel codes')).toBeInTheDocument()
+
+      expect(screen.getByText('Current fuel codes')).toBeInTheDocument()
       expect(screen.getByText('New fuel code')).toBeInTheDocument()
       expect(screen.getByText('Download fuel codes information')).toBeInTheDocument()
     })

--- a/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
+++ b/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
@@ -13,12 +13,13 @@ import { roles } from '@/constants/roles'
 import { wrapper } from '@/tests/utils/wrapper'
 import { ROUTES } from '@/routes/routes'
 
-// Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key, options) => {
       const translations = {
         FuelCodes: 'Fuel codes',
+        'fuelCode:fuelCodes': 'Fuel codes',
+        'fuelCode:currentFuelCodes': 'Current fuel codes',
         'fuelCode:newFuelCodeBtn': 'New fuel code',
         'fuelCode:fuelCodeDownloadBtn': 'Download fuel codes information',
         'fuelCode:fuelCodeDownloadingMsg': 'Downloading fuel codes information',
@@ -31,7 +32,6 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
-// Mock Keycloak
 vi.mock('@react-keycloak/web', () => ({
   useKeycloak: () => ({
     keycloak: {
@@ -42,21 +42,17 @@ vi.mock('@react-keycloak/web', () => ({
   })
 }))
 
-// Mock Current User
+const mockUserRoleNames = [roles.government, roles.analyst]
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => {
-    const userRoles = [{ name: roles.government }, { name: roles.analyst }]
-    return {
-      data: { roles: userRoles },
-      hasAnyRole: (...names) =>
-        names.some((n) => userRoles.some((r) => r.name === n)),
-      hasRoles: (...names) =>
-        names.every((n) => userRoles.some((r) => r.name === n))
-    }
-  }
+  useCurrentUser: () => ({
+    data: {
+      roles: mockUserRoleNames.map((name) => ({ name }))
+    },
+    hasAnyRole: (...names) => names.some((n) => mockUserRoleNames.includes(n)),
+    hasRoles: (...names) => names.every((n) => mockUserRoleNames.includes(n))
+  })
 }))
 
-// Mock BCGridViewer
 vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
   BCGridViewer: ({ gridRef, columnDefs, queryData, dataKey, className }) => (
     <div
@@ -69,7 +65,6 @@ vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
   )
 }))
 
-// Mock React Router
 const mockNavigate = vi.fn()
 const mockLocationState = {
   state: null,
@@ -82,7 +77,6 @@ vi.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams(), vi.fn()]
 }))
 
-// Mock useFuelCode hooks
 let mockDownloadMutate = vi.fn()
 let mockGetFuelCodesData = {
   data: {
@@ -122,15 +116,12 @@ vi.mock('@/hooks/useFuelCode', () => ({
   }))
 }))
 
-// Mock BCBox to prevent jsx prop warnings
 vi.mock('@/components/BCBox', () => ({
   default: ({ children, jsx, ...props }) => <div {...props}>{children}</div>
 }))
 
-// Import the component internals for direct testing
 import { FuelCodes as FuelCodesComponent } from '@/views/FuelCodes/FuelCodes.jsx'
 
-// Create mock grid ref with AG Grid API methods
 const createMockGridRef = (filterModel = {}, columnState = []) => ({
   current: {
     api: {
@@ -261,6 +252,11 @@ describe('FuelCodes Component Tests', () => {
       expect(title.textContent).toBe('Fuel codes')
     })
 
+    it('should render the Current fuel codes tab strip', () => {
+      render(<FuelCodes />, { wrapper })
+      expect(screen.getByRole('tablist')).toBeInTheDocument()
+    })
+
     it('should render grid viewer with correct props', () => {
       render(<FuelCodes />, { wrapper })
       const gridContainer = screen.getByTestId('bc-grid-container')
@@ -354,6 +350,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: false,
           body: {
             page: 1,
             size: 10000,
@@ -446,6 +443,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: false,
           body: expect.objectContaining({
             page: 1,
             size: 10000,
@@ -465,6 +463,7 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
+          excludeArchived: false,
           body: {
             page: 1,
             size: 10000,
@@ -477,6 +476,20 @@ describe('FuelCodes Component Tests', () => {
             ]
           }
         })
+      })
+    })
+
+    it('should pass excludeArchived: false on the default (Fuel codes) tab', async () => {
+      mockDownloadMutate = vi.fn().mockResolvedValue(undefined)
+      render(<FuelCodes />, { wrapper })
+      const downloadButton = screen.getByTestId('fuel-code-download-btn')
+
+      fireEvent.click(downloadButton)
+
+      await waitFor(() => {
+        expect(mockDownloadMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ excludeArchived: false })
+        )
       })
     })
   })
@@ -504,7 +517,6 @@ describe('FuelCodes Component Tests', () => {
       }
 
       render(<FuelCodes />, { wrapper })
-      // The grid container should still be rendered - error handling is done by BCGridViewer
       const gridContainer = screen.getByTestId('bc-grid-container')
       expect(gridContainer).toBeInTheDocument()
     })
@@ -529,8 +541,6 @@ describe('FuelCodes Component Tests', () => {
   describe('Component State Management', () => {
     it('should initialize with correct default state', () => {
       render(<FuelCodes />, { wrapper })
-      
-      // Verify initial rendering without errors
       expect(screen.getByTestId('title')).toBeInTheDocument()
       expect(screen.queryByTestId('alert-box')).not.toBeInTheDocument()
     })
@@ -658,7 +668,7 @@ describe('FuelCodes Component Tests', () => {
   describe('Translation Integration', () => {
     it('should use translation keys for all text content', () => {
       render(<FuelCodes />, { wrapper })
-      
+
       expect(screen.getByText('Fuel codes')).toBeInTheDocument()
       expect(screen.getByText('New fuel code')).toBeInTheDocument()
       expect(screen.getByText('Download fuel codes information')).toBeInTheDocument()


### PR DESCRIPTION
This PR aligns internal Fuel Code navigation with the public Approved CI experience by reusing shared tab components.

Closes #4380