### PR TITLE
fix: exclude Renewable naphtha from pre-2022 legacy reports (#4349)

### DIFF
--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -266,13 +266,20 @@ class FuelSupplyRepository:
             # - Exclude Jet fuel category (didn't exist before 2024)
             # - Exclude Fossil-derived fuel types (new in 2024, is_legacy=False but fossil_derived=True)
             # - Only show legacy provisions (Section 6 references, not Section 19)
-            query = query.where(
-                and_(
-                    FuelCategory.category != "Jet fuel",
-                    ~and_(FuelType.is_legacy == False, FuelType.fossil_derived == True),
-                    ProvisionOfTheAct.is_legacy == True,
+            # - Renewable naphtha (fuel_type_id=15) was first reportable in the
+            #   2022 compliance year; exclude it from 2019-2021 legacy reports.
+            renewable_naphtha_fuel_type_id = 15
+            renewable_naphtha_min_year = 2022
+            extra_filters = [
+                FuelCategory.category != "Jet fuel",
+                ~and_(FuelType.is_legacy == False, FuelType.fossil_derived == True),
+                ProvisionOfTheAct.is_legacy == True,
+            ]
+            if current_year < renewable_naphtha_min_year:
+                extra_filters.append(
+                    FuelType.fuel_type_id != renewable_naphtha_fuel_type_id
                 )
-            )
+            query = query.where(and_(*extra_filters))
 
         fuel_type_results = (await self.db.execute(query)).all()
 


### PR DESCRIPTION
## Summary
- Renewable naphtha (`fuel_type_id=15`) was first reportable in the 2022 compliance year. The pre-2024 branch of `FuelSupplyRepository.get_fuel_supply_table_options` was returning it for 2019–2021 legacy reports, so it was incorrectly selectable in the Fuels Supply schedule for those years.
- Add a guard to that branch: when `current_year < 2022`, exclude `fuel_type_id=15`. 2022, 2023, and 2024+ behaviour is unchanged.
- Natural gas-based gasoline already comes back from the existing `is_legacy=True` branch — verified against the local Docker DB; no code change needed for it.

Follow-up to #4357 / addresses the remaining comment on #4349.

## Test plan
- [ ] On a fresh local DB, open a 2019/2020/2021 legacy compliance report → Fuels Supply schedule → "Fuel type" dropdown does **not** list "Renewable naphtha".
- [ ] Open a 2022 and 2023 report → "Renewable naphtha" is listed and the Determining Carbon Intensity options are the legacy Section 6 (5)(c)/(d)(i)/(d)(ii) provisions (no Section 19 / Prescribed).
- [ ] Open a 2024+ report → "Renewable naphtha" still listed with the modern Section 19 provisions.
- [ ] Confirm "Natural gas-based gasoline" appears in 2019–2023 with the Section 6 Prescribed (a)/(b) options only.
- [ ] No regression to other fuel types in the legacy or modern dropdowns.