### PR TITLE
fix: disable BCModal primary button while action is in flight

### DIFF
--- a/frontend/src/components/BCModal.jsx
+++ b/frontend/src/components/BCModal.jsx
@@ -137,7 +137,17 @@ const BCModal = ({ open, onClose, data = null }) => {
             autoFocus
             onClick={handlePrimaryButtonClick}
             isLoading={isLoading}
-            disabled={primaryButtonDisabled}
+            // `isLoading` swaps the children for a spinner but does NOT
+            // disable the underlying button. The JS guard in
+            // handlePrimaryButtonClick catches a repeat click *if* its
+            // closure has already seen isLoading=true, but a click queued
+            // before React commits, or an Enter keypress while focus is
+            // still on the action button, can land a second
+            // primaryButtonAction — onSuccess of the first then navigates
+            // the user to the list view, hiding the duplicate submission.
+            // DOM-level disabled is the only thing that suppresses those
+            // pre-commit and keyboard activations.
+            disabled={isLoading || primaryButtonDisabled}
             data-test="modal-btn-primary"
           >
             {primaryButtonText}

--- a/frontend/src/components/__tests__/BCModal.test.jsx
+++ b/frontend/src/components/__tests__/BCModal.test.jsx
@@ -137,7 +137,8 @@ describe('Not Found Component', () => {
     )
 
     // Kick off the in-flight primary action.
-    fireEvent.click(screen.getByTestId('modal-btn-primary'))
+    const primaryBtn = screen.getByTestId('modal-btn-primary')
+    fireEvent.click(primaryBtn)
     await Promise.resolve()
     expect(primaryButtonAction).toHaveBeenCalledTimes(1)
 
@@ -149,6 +150,15 @@ describe('Not Found Component', () => {
 
     expect(onClose).not.toHaveBeenCalled()
     expect(secondaryButtonAction).not.toHaveBeenCalled()
+
+    // The primary button itself must also refuse a second activation
+    // while the first action is in flight. Without DOM-level disabled,
+    // a repeat click or Enter keypress would queue a second
+    // primaryButtonAction; on success of the first the navigation away
+    // to the list view would hide the duplicate from the user.
+    expect(primaryBtn).toBeDisabled()
+    fireEvent.click(primaryBtn)
+    expect(primaryButtonAction).toHaveBeenCalledTimes(1)
 
     // Settle the primary so the test doesn't leak the pending promise.
     resolvePrimary()


### PR DESCRIPTION
The primary action button carried `isLoading={isLoading}` (which only swaps the children for a spinner) but `disabled` was wired only to `primaryButtonDisabled`, not to `isLoading`. The JS guard in handlePrimaryButtonClick (`if (isLoading) return`) catches a repeat click iff its closure has already observed isLoading=true — but a click queued before React commits, or an Enter keypress while focus is still on the action button, can land a second primaryButtonAction. The first call's onSuccess then navigates the user to the list view, hiding the duplicate submission from them.

DOM-level disabled is the only mechanism that suppresses pre-commit and keyboard-driven activations. Set `disabled={isLoading || primaryButtonDisabled}` so the button is truly inert while the action is in flight; the spinner remains as the visual signal.

Extends the existing in-flight regression test to assert the primary button is disabled and a second click does not run primaryButtonAction again.