### PR TITLE
fix: serialise compliance report submissions + harden modal double-click guards

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -174,6 +174,10 @@ async def test_handle_submitted_status_blocks_duplicate_when_reserved_exists(
     report.transaction_id = 100  # left behind by the first submit
     report.compliance_report_group_uuid = "test-uuid"
 
+    # The lock returns the persisted transaction_id — what the row-level
+    # lock acquires and what the idempotency guard then reads against.
+    mock_repo.lock_compliance_report_row.return_value = 100
+
     existing_reserve = MagicMock()
     existing_reserve.transaction_id = 100
     mock_trxn_repo.get_reserved_transaction_by_id.return_value = existing_reserve
@@ -194,6 +198,56 @@ async def test_handle_submitted_status_blocks_duplicate_when_reserved_exists(
     mock_trxn_repo.get_reserved_transaction_by_id.assert_called_once_with(
         100
     )
+
+
+@pytest.mark.anyio
+async def test_handle_submitted_status_lock_resyncs_transaction_id(
+    compliance_report_update_service,
+    mock_user_has_roles,
+    mock_repo,
+    mock_trxn_repo,
+):
+    """Concurrent-race regression for incident 4368.
+
+    Two in-flight submit requests both read the report with
+    transaction_id=NULL. The first commits, the second blocks on the row
+    lock. When the second wakes up its in-memory `report.transaction_id`
+    is still NULL — but the lock returns the freshly-persisted value, and
+    the handler must trust *that* (not the stale ORM attribute) for the
+    idempotency check. Without this resync the second writer would mint
+    a duplicate Reserved row and leave the first one orphaned.
+    """
+    mock_user_has_roles.return_value = True
+
+    report_id = 1
+    report = MagicMock(spec=ComplianceReport)
+    report.compliance_report_id = report_id
+    report.organization_id = 1
+    report.transaction_id = None  # stale — loaded before the lock
+    report.compliance_report_group_uuid = "test-uuid"
+
+    # First writer already committed transaction 200; our lock acquisition
+    # returns that fresh value.
+    mock_repo.lock_compliance_report_row.return_value = 200
+
+    existing_reserve = MagicMock()
+    existing_reserve.transaction_id = 200
+    mock_trxn_repo.get_reserved_transaction_by_id.return_value = existing_reserve
+
+    user = MagicMock(spec=UserProfile)
+    user.keycloak_username = "test-user"
+
+    with pytest.raises(HTTPException) as exc:
+        await compliance_report_update_service.handle_submitted_status(
+            report, user
+        )
+
+    assert exc.value.status_code == 409
+    # The idempotency check must use the lock-returned id (200), not the
+    # stale in-memory None.
+    mock_trxn_repo.get_reserved_transaction_by_id.assert_called_once_with(200)
+    mock_trxn_repo.create_transaction.assert_not_called()
+    mock_repo.update_compliance_report.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -653,6 +653,24 @@ class ComplianceReportRepository:
         return compliance_report
 
     @repo_handler
+    async def lock_compliance_report_row(self, report_id: int) -> Optional[int]:
+        """Take a row-level lock on the compliance_report row and return its
+        current persisted transaction_id.
+
+        Serialises concurrent handlers that mint a Reserved transaction for
+        the same report (incident 4368). Returns the freshly-read
+        transaction_id so the caller can detect a sibling writer that
+        already committed a Reserved row — using the in-memory ORM value
+        would defeat the lock, since it was loaded before we blocked.
+        """
+        result = await self.db.execute(
+            select(ComplianceReport.transaction_id)
+            .where(ComplianceReport.compliance_report_id == report_id)
+            .with_for_update()
+        )
+        return result.scalar_one_or_none()
+
+    @repo_handler
     async def get_compliance_report_schema_by_id(
         self, report_id: int
     ) -> ComplianceReportBaseSchema | None:

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -301,12 +301,23 @@ class ComplianceReportUpdateService:
         if not has_supplier_roles:
             raise HTTPException(status_code=403, detail="Forbidden.")
 
+        # Serialise concurrent submissions of the same report. Without this
+        # lock the idempotency check below is a TOCTOU race: two in-flight
+        # requests both read transaction_id=NULL, both create a Reserved
+        # transaction, and the second UPDATE leaves the first row orphaned
+        # (incident 4368 follow-up — the original hotfix only closed the
+        # sequential repeat-click window). The lock returns the freshly
+        # persisted transaction_id; we sync it back onto the report so the
+        # rest of the handler can't act on a stale in-memory value.
+        persisted_transaction_id = await self.repo.lock_compliance_report_row(
+            report.compliance_report_id
+        )
+        report.transaction_id = persisted_transaction_id
+
         # Idempotency guard. If a Reserved transaction already exists for
         # this report, a prior submission already ran — re-running here
         # would mint a duplicate Reserved row, re-send notifications, and
-        # corrupt the org's available_balance. Incident 4368: a report
-        # ended up with 7 duplicate Reserved rows because repeat clicks on
-        # Sign-and-Submit each got a fresh handler run.
+        # corrupt the org's available_balance.
         existing_reserve = await self._fetch_reserved_transaction_for_report(
             report
         )
@@ -421,6 +432,17 @@ class ComplianceReportUpdateService:
         ):
             credit_change = report.summary.line_20_surplus_deficit_units
             if credit_change != 0:
+                # Same TOCTOU race as supplier submission — two analysts
+                # (or one analyst clicking twice) both reading
+                # transaction_id=NULL would each mint a Reserved row.
+                # Serialise via the same row lock and resync the
+                # in-memory transaction_id from the persisted value.
+                persisted_transaction_id = (
+                    await self.repo.lock_compliance_report_row(
+                        report.compliance_report_id
+                    )
+                )
+                report.transaction_id = persisted_transaction_id
                 await self._create_or_update_reserve_transaction(
                     credit_change, report
                 )

--- a/frontend/src/components/BCModal.jsx
+++ b/frontend/src/components/BCModal.jsx
@@ -45,13 +45,32 @@ const BCModal = ({ open, onClose, data = null }) => {
     await primaryButtonAction()
   }
 
+  // Belt-and-suspenders close guard. The X / Cancel buttons already carry
+  // `disabled={isLoading}`, but the disabled attribute only suppresses the
+  // click after React commits the state update — and the action button
+  // dispatches a react-query `mutate()` (fire-and-forget) so the modal
+  // doesn't actually wait on the network call. A keyboard activation or
+  // a queued click landing in that pre-commit window could still close
+  // the modal and let the user fire a duplicate submit. JS-level guard
+  // closes that gap regardless of the disabled prop's render timing.
+  const handleClose = () => {
+    if (isLoading) return
+    onClose()
+  }
+
+  const handleSecondaryButtonClick = () => {
+    if (isLoading) return
+    if (secondaryButtonAction) {
+      secondaryButtonAction()
+    } else {
+      onClose()
+    }
+  }
+
   return (
     <Dialog
       open={open}
-      onClose={() => {
-        if (isLoading) return
-        onClose()
-      }}
+      onClose={handleClose}
       maxWidth="md"
       fullWidth
       data-test="modal"
@@ -59,7 +78,7 @@ const BCModal = ({ open, onClose, data = null }) => {
       <DialogTitle>{title}</DialogTitle>
       <IconButton
         aria-label="close"
-        onClick={onClose}
+        onClick={handleClose}
         disabled={isLoading}
         sx={{
           position: 'absolute',
@@ -99,7 +118,7 @@ const BCModal = ({ open, onClose, data = null }) => {
               secondaryButtonText.toLowerCase().replaceAll(' ', '-')
             }
             color={secondaryButtonColor ?? 'dark'}
-            onClick={secondaryButtonAction ?? onClose}
+            onClick={handleSecondaryButtonClick}
             disabled={isLoading}
             data-test="modal-btn-secondary"
           >

--- a/frontend/src/components/BCModal.jsx
+++ b/frontend/src/components/BCModal.jsx
@@ -137,7 +137,17 @@ const BCModal = ({ open, onClose, data = null }) => {
             autoFocus
             onClick={handlePrimaryButtonClick}
             isLoading={isLoading}
-            disabled={primaryButtonDisabled}
+            // `isLoading` swaps the children for a spinner but does NOT
+            // disable the underlying button. The JS guard in
+            // handlePrimaryButtonClick catches a repeat click *if* its
+            // closure has already seen isLoading=true, but a click queued
+            // before React commits, or an Enter keypress while focus is
+            // still on the action button, can land a second
+            // primaryButtonAction — onSuccess of the first then navigates
+            // the user to the list view, hiding the duplicate submission.
+            // DOM-level disabled is the only thing that suppresses those
+            // pre-commit and keyboard activations.
+            disabled={isLoading || primaryButtonDisabled}
             data-test="modal-btn-primary"
           >
             {primaryButtonText}

--- a/frontend/src/components/__tests__/BCModal.test.jsx
+++ b/frontend/src/components/__tests__/BCModal.test.jsx
@@ -107,6 +107,54 @@ describe('Not Found Component', () => {
     expect(secondaryButtonAction).toHaveBeenCalled()
   })
 
+  it('blocks cancel / X / backdrop close while the primary action is in flight', async () => {
+    // Regression for the submission-duplicate flow (incident 4368):
+    // primaryButtonAction here mimics react-query's fire-and-forget
+    // `mutate()` — the modal doesn't await the real network call, so
+    // between setIsLoading(true) and the API completing, the secondary
+    // and close controls must refuse to dispatch onClose. Otherwise a
+    // user who clicks Submit then Cancel can close the modal and re-fire
+    // submit, minting a duplicate Reserved transaction.
+    const onClose = vi.fn()
+    const secondaryButtonAction = vi.fn()
+    let resolvePrimary
+    const primaryButtonAction = vi.fn(
+      () => new Promise((resolve) => { resolvePrimary = resolve })
+    )
+
+    render(
+      <BCModal
+        open={true}
+        onClose={onClose}
+        data={{
+          ...baseData,
+          primaryButtonText: 'Confirm',
+          primaryButtonAction,
+          secondaryButtonText: 'Cancel',
+          secondaryButtonAction
+        }}
+      />
+    )
+
+    // Kick off the in-flight primary action.
+    fireEvent.click(screen.getByTestId('modal-btn-primary'))
+    await Promise.resolve()
+    expect(primaryButtonAction).toHaveBeenCalledTimes(1)
+
+    // While the action hangs, the X and Cancel must not close the modal
+    // or run the secondary action — both are belt-and-suspenders against
+    // the same duplicate-submission gap.
+    fireEvent.click(screen.getByTestId('modal-btn-close'))
+    fireEvent.click(screen.getByTestId('modal-btn-secondary'))
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(secondaryButtonAction).not.toHaveBeenCalled()
+
+    // Settle the primary so the test doesn't leak the pending promise.
+    resolvePrimary()
+    await Promise.resolve()
+  })
+
   it('should render warningText when warningText is true', async () => {
     const warningText = 'This is a warning!'
     const data = {

--- a/frontend/src/components/__tests__/BCModal.test.jsx
+++ b/frontend/src/components/__tests__/BCModal.test.jsx
@@ -137,7 +137,8 @@ describe('Not Found Component', () => {
     )
 
     // Kick off the in-flight primary action.
-    fireEvent.click(screen.getByTestId('modal-btn-primary'))
+    const primaryBtn = screen.getByTestId('modal-btn-primary')
+    fireEvent.click(primaryBtn)
     await Promise.resolve()
     expect(primaryButtonAction).toHaveBeenCalledTimes(1)
 
@@ -149,6 +150,15 @@ describe('Not Found Component', () => {
 
     expect(onClose).not.toHaveBeenCalled()
     expect(secondaryButtonAction).not.toHaveBeenCalled()
+
+    // The primary button itself must also refuse a second activation
+    // while the first action is in flight. Without DOM-level disabled,
+    // a repeat click or Enter keypress would queue a second
+    // primaryButtonAction; on success of the first the navigation away
+    // to the list view would hide the duplicate from the user.
+    expect(primaryBtn).toBeDisabled()
+    fireEvent.click(primaryBtn)
+    expect(primaryButtonAction).toHaveBeenCalledTimes(1)
 
     // Settle the primary so the test doesn't leak the pending promise.
     resolvePrimary()


### PR DESCRIPTION
## Summary

Hotfix into `main` covering the full submission-race fix set. Equivalent to what landed on `release` via #4394, #4412, and #4422 — collected into a single clean branch off `main` without any develop merge contamination. Three commits:

1. **`fix: lock compliance_report row to prevent concurrent submission duplicates`** — backend row-level lock.
2. **`fix: js-level guard on BCModal close controls during in-flight action`** — Cancel / X / backdrop guards.
3. **`fix: disable BCModal primary button while action is in flight`** — DOM-level disable on the action button.

## Background

Original idempotency hotfix (#4368) closed the sequential repeat-click window but left two gaps that have continued producing duplicate Reserved transactions in prod, visible in the transactions UI as "Legacy Transaction" rows (the display label for `StandaloneTransaction` in `mv_transaction_aggregate` — i.e. orphaned `transaction` rows with no `compliance_report.transaction_id` pointing at them).

### Gap 1: concurrent server-side race

```
T0  Req A: SELECT compliance_report   -> transaction_id = NULL
T0  Req B: SELECT compliance_report   -> transaction_id = NULL   (A uncommitted)
T1  Req A: idempotency check          -> None
T1  Req B: idempotency check          -> None
T2  Req A: org_service.adjust_balance -> Transaction N   (Reserved)
T2  Req B: org_service.adjust_balance -> Transaction N+1 (Reserved)
T3  Req A: UPDATE compliance_report SET transaction_id = N   commit
T3  Req B: UPDATE compliance_report SET transaction_id = N+1 commit  (last writer wins)
           -> Transaction N is now an orphan
```

New `ComplianceReportRepository.lock_compliance_report_row` issues `SELECT compliance_report.transaction_id … FOR UPDATE` and returns the persisted `transaction_id`. `handle_submitted_status` and `handle_recommended_by_analyst_status` (government reassessment path) take the lock **before** the idempotency check and resync `report.transaction_id` from the lock's return value. Trusting the in-memory ORM attribute would defeat the lock — it was loaded before we blocked on the other writer.

### Gap 2: pre-commit click race in the modal

The submit button shows a spinner via `isLoading={isLoading}` but the underlying button wasn't actually disabled (`disabled` was only wired to `primaryButtonDisabled`). The JS guard `if (isLoading) return` in the click handler only catches a repeat click *after* React commits `setIsLoading(true)` — a click queued before commit, or an Enter keypress while focus stays on the button, lands a second `primaryButtonAction`. On the first call's `onSuccess` the user navigates to the list view, hiding the duplicate from them.

Same window exists on Cancel / X: `disabled={isLoading}` was already on the props, but the disabled attribute only suppresses clicks after the commit. JS-level guards in the onClick handlers close the gap regardless of disabled-prop render timing.

## Changes

**Backend** ([`backend/lcfs/web/api/compliance_report/repo.py`](backend/lcfs/web/api/compliance_report/repo.py), [`update_service.py`](backend/lcfs/web/api/compliance_report/update_service.py))
- `lock_compliance_report_row(report_id)` — bare row lock + returns persisted `transaction_id`.
- `handle_submitted_status` and `handle_recommended_by_analyst_status` lock and resync before the idempotency check.

**Frontend** ([`frontend/src/components/BCModal.jsx`](frontend/src/components/BCModal.jsx))
- `handleClose` wired to X and Dialog backdrop/escape; drops the call when `isLoading`.
- `handleSecondaryButtonClick`; drops the call when `isLoading`, otherwise dispatches `secondaryButtonAction ?? onClose`.
- Primary button: `disabled={isLoading || primaryButtonDisabled}`. Spinner stays as the visual signal.

**Tests** ([`backend/lcfs/tests/compliance_report/test_update_service.py`](backend/lcfs/tests/compliance_report/test_update_service.py), [`frontend/src/components/__tests__/BCModal.test.jsx`](frontend/src/components/__tests__/BCModal.test.jsx))
- Updated `test_handle_submitted_status_blocks_duplicate_when_reserved_exists` to mock the lock return value.
- New `test_handle_submitted_status_lock_resyncs_transaction_id` covers the concurrent-race path.
- New Vitest regression holds a Promise open for the primary action and asserts Cancel / X / secondaryButtonAction don't fire while in flight, primary button is `toBeDisabled()`, and repeat clicks don't re-invoke `primaryButtonAction`.

## Test plan

- [x] Backend regression tests cover the lock + idempotency + race path.
- [x] Frontend regression test covers the in-flight modal guards.
- [ ] Manual: in a staging deploy, open two browser tabs to the same draft report and hit Sign-and-Submit rapidly from both — verify only one Reserved transaction is created and the second request returns 409.
- [ ] Manual: in the submit modal, click Submit and then press Enter / re-click — verify only one submission fires, no list-view navigation triggers from a duplicate.
- [ ] Post-merge: run the orphan-cleanup SQL script against prod to remove the existing duplicates surfaced in the transactions UI.