### PR TITLE
fix: speed up compliance report submission (#4431)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
@@ -16,7 +16,7 @@ All statements use ``IF NOT EXISTS`` so the migration is safe to
 re-run, and any ad-hoc indexes added out-of-band won't collide.
 
 Revision ID: a7b3c9d5e1f2
-Revises: c2a4f6b8d9e1
+Revises: e60c34503169
 Create Date: 2026-05-28 14:00:00.000000
 
 """
@@ -25,7 +25,7 @@ from alembic import op
 
 
 revision = "a7b3c9d5e1f2"
-down_revision = "c2a4f6b8d9e1"
+down_revision = "e60c34503169"
 branch_labels = None
 depends_on = None
 

--- a/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
@@ -1,0 +1,84 @@
+"""Add submission hot-path indexes on schedule tables.
+
+Compliance report submission re-fetches every versioned schedule
+(fuel_supply, fuel_export, other_uses, notional_transfer,
+allocation_agreement) by ``compliance_report_id`` and walks the
+group history via ``group_uuid``. Postgres does not auto-index FKs,
+and only ``allocation_agreement.group_uuid`` was indexed prior to
+this migration, so each lookup was a sequential scan over the
+table.
+
+We also index ``compliance_report.compliance_report_group_uuid`` —
+that column is the join key used to assemble a report's version
+chain on every submit, status change, and report fetch.
+
+All statements use ``IF NOT EXISTS`` so the migration is safe to
+re-run, and any ad-hoc indexes added out-of-band won't collide.
+
+Revision ID: a7b3c9d5e1f2
+Revises: c2a4f6b8d9e1
+Create Date: 2026-05-28 14:00:00.000000
+
+"""
+
+from alembic import op
+
+
+revision = "a7b3c9d5e1f2"
+down_revision = "c2a4f6b8d9e1"
+branch_labels = None
+depends_on = None
+
+
+# (index_name, table_name, column_name)
+INDEXES = [
+    # Schedule tables — compliance_report_id is the per-version FK
+    ("ix_fuel_supply_compliance_report_id", "fuel_supply", "compliance_report_id"),
+    ("ix_fuel_export_compliance_report_id", "fuel_export", "compliance_report_id"),
+    ("ix_other_uses_compliance_report_id", "other_uses", "compliance_report_id"),
+    (
+        "ix_notional_transfer_compliance_report_id",
+        "notional_transfer",
+        "compliance_report_id",
+    ),
+    (
+        "ix_allocation_agreement_compliance_report_id",
+        "allocation_agreement",
+        "compliance_report_id",
+    ),
+    # Schedule tables — group_uuid is used to walk the version chain
+    # (allocation_agreement.group_uuid was already indexed in 173179aeed95)
+    ("ix_fuel_supply_group_uuid", "fuel_supply", "group_uuid"),
+    ("ix_fuel_export_group_uuid", "fuel_export", "group_uuid"),
+    ("ix_other_uses_group_uuid", "other_uses", "group_uuid"),
+    ("ix_notional_transfer_group_uuid", "notional_transfer", "group_uuid"),
+    # Compliance report itself + its 1:1 / 1:N children keyed on report id
+    (
+        "ix_compliance_report_compliance_report_group_uuid",
+        "compliance_report",
+        "compliance_report_group_uuid",
+    ),
+    (
+        "ix_compliance_report_history_compliance_report_id",
+        "compliance_report_history",
+        "compliance_report_id",
+    ),
+    (
+        "ix_compliance_report_summary_compliance_report_id",
+        "compliance_report_summary",
+        "compliance_report_id",
+    ),
+]
+
+
+def upgrade() -> None:
+    for index_name, table_name, column_name in INDEXES:
+        op.execute(
+            f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+            f'ON "{table_name}" ("{column_name}")'
+        )
+
+
+def downgrade() -> None:
+    for index_name, _table_name, _column_name in reversed(INDEXES):
+        op.execute(f'DROP INDEX IF EXISTS "{index_name}"')

--- a/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-28-14-00_a7b3c9d5e1f2.py
@@ -15,6 +15,11 @@ chain on every submit, status change, and report fetch.
 All statements use ``IF NOT EXISTS`` so the migration is safe to
 re-run, and any ad-hoc indexes added out-of-band won't collide.
 
+Note: ``down_revision`` was rebased onto the current chain head
+(``e60c34503169``) after merging ``develop``, which had branched off
+the same parent and introduced a competing Alembic head. Keeping a
+single head lets ``alembic upgrade head`` resolve unambiguously in CI.
+
 Revision ID: a7b3c9d5e1f2
 Revises: e60c34503169
 Create Date: 2026-05-28 14:00:00.000000

--- a/frontend/src/hooks/useComplianceReports.ts
+++ b/frontend/src/hooks/useComplianceReports.ts
@@ -267,6 +267,14 @@ export const useUpdateComplianceReport = (reportID: number | string | undefined 
   } = options
 
   return useMutation({
+    // Compliance report updates (including submission) are NOT idempotent
+    // from the client's perspective: the backend serialises concurrent
+    // submits with a row lock and rejects the second attempt with a 409
+    // ("This report has already been submitted"). If react-query silently
+    // retries a slow-but-successful PUT, the retry races the first
+    // request's tail and surfaces that 409 as a "network error" toast even
+    // though the submit succeeded. See ticket #4431.
+    retry: 0,
     mutationFn: async (data: any) => {
       if (!reportID) {
         throw new Error('Report ID is required')

--- a/frontend/src/services/__tests__/useApiService.test.js
+++ b/frontend/src/services/__tests__/useApiService.test.js
@@ -136,11 +136,14 @@ describe('useApiService', () => {
 
       expect(axios.create).toHaveBeenCalledWith({
         baseURL: 'http://localhost:8000/api',
+        timeout: 90000,
       })
       expect(result).toBe(mockAxiosInstance)
     })
 
     it('should create axios instance with custom options', () => {
+      // Caller-supplied opts override defaults — e.g. a longer timeout
+      // for an export endpoint.
       const customOpts = { timeout: 5000 }
       const result = useApiService(customOpts)
 
@@ -639,6 +642,7 @@ describe('useApiService', () => {
 
       expect(axios.create).toHaveBeenCalledWith({
         baseURL: 'http://localhost:8000/api',
+        timeout: 90000,
       })
 
     })
@@ -650,6 +654,7 @@ describe('useApiService', () => {
 
       expect(axios.create).toHaveBeenCalledWith({
         baseURL: 'http://localhost:8000/api',
+        timeout: 90000,
       })
 
     })

--- a/frontend/src/services/useApiService.ts
+++ b/frontend/src/services/useApiService.ts
@@ -21,6 +21,14 @@ export interface ApiServiceInstance extends AxiosInstance {
   download: (options: DownloadOptions) => Promise<void>
 }
 
+// Default request timeout. Axios's own default is 0 (wait forever), which
+// means a slow request hangs until OpenShift/nginx returns a 504 — long
+// after the user has assumed the action failed. 90s comfortably covers
+// the slowest compliance-report submission summary recalculation we see
+// in test (ticket #4431) while still giving the client a clean local
+// error well before any infra-layer timeout.
+const DEFAULT_TIMEOUT_MS = 90_000
+
 type ErrorResponse = {
   response?: { status: number; data?: unknown; headers?: Record<string, string> }
   message?: string
@@ -47,6 +55,7 @@ export const useApiService = (opts: AxiosRequestConfig = {}): ApiServiceInstance
   const apiService = useMemo(() => {
     const instance = axios.create({
       baseURL: CONFIG.API_BASE,
+      timeout: DEFAULT_TIMEOUT_MS,
       ...opts
     }) as ApiServiceInstance
 


### PR DESCRIPTION
## Summary

Investigated the lag + intermittent "network error" reports on compliance report submission ([#4431](https://github.com/bcgov/lcfs/issues/4431)) and shipped the two highest-leverage, lowest-risk fixes.

### 1. Missing indexes on the submission hot path (backend)

Submission's summary recalc fans out across every versioned schedule (`fuel_supply`, `fuel_export`, `other_uses`, `notional_transfer`, `allocation_agreement`) plus a couple of children of `compliance_report` itself, filtering by `compliance_report_id` and walking version chains via `group_uuid`. Postgres doesn't auto-index FKs, and only `allocation_agreement.group_uuid` was indexed before this PR — so each lookup was a sequential scan.

New alembic revision `a7b3c9d5e1f2` adds 12 indexes:

| Table | Column(s) |
| --- | --- |
| `fuel_supply` | `compliance_report_id`, `group_uuid` |
| `fuel_export` | `compliance_report_id`, `group_uuid` |
| `other_uses` | `compliance_report_id`, `group_uuid` |
| `notional_transfer` | `compliance_report_id`, `group_uuid` |
| `allocation_agreement` | `compliance_report_id` (group_uuid done in `173179aeed95`) |
| `compliance_report` | `compliance_report_group_uuid` |
| `compliance_report_history` | `compliance_report_id` |
| `compliance_report_summary` | `compliance_report_id` |

All statements use `CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS`, so the migration is safe to re-run and won't collide with any ad-hoc indexes added out-of-band.

### 2. Disable retry on the submit mutation + add a 90s client timeout (frontend)

`useUpdateComplianceReport` was inheriting the default react-query config (3 retries, 1s/2s/4s exponential backoff). The backend `handle_submitted_status` path serialises concurrent submits with a row lock and rejects the second attempt with a 409 ("This report has already been submitted") — by design, see #4368. When a PUT was slow but eventually succeeded, the silent retry raced its tail and got that 409, which the UI surfaced as a network error toast even though the submit had succeeded. This is the exact "appears not to submit initially but eventually processes" symptom from the ticket.

- `retry: 0` on the submit mutation (read queries are unaffected).
- 90s default axios `timeout` (was `0` = wait forever) — slow requests now fail with a clean client-side error before the infra-layer 504 hits. Caller-supplied opts still override.

### Out of scope (deferred follow-ups)

Two larger wins from the same investigation, intentionally split out:

- **Move synchronous email dispatch off the submit request path** ([notification/services.py:389](https://github.com/bcgov/lcfs/blob/develop/backend/lcfs/web/api/notification/services.py#L389)). Biggest single perceived-latency win; needs its own PR because it touches the notification service contract.
- **Push fossil/renewable filters into SQL inside `calculate_compliance_report_summary`** ([summary_service.py:779-808](https://github.com/bcgov/lcfs/blob/develop/backend/lcfs/web/api/compliance_report/summary_service.py#L779)). Eliminates the in-memory filter loop over the whole effective schedule set. Higher risk — better done after the indexes above are live so query plans are sane to begin with.

## Test plan

- [x] `alembic heads` → `a7b3c9d5e1f2 (head)`, chain intact
- [x] Migration syntax + idempotency (re-run safe via IF NOT EXISTS)
- [x] Frontend vitest: `useApiService.test.js` 28/28, `useComplianceReports.test.js` 12/12, `useComplianceReports.analyst.test.jsx` 13/13
- [ ] Apply migration in dev: `alembic upgrade head`, confirm all 12 indexes appear in `pg_indexes`
- [ ] Reproduce ticket flow in test: create + submit compliance report, confirm no "network error" toast on slow response, no duplicate Reserved transaction
- [ ] Sanity check `EXPLAIN` on `get_effective_fuel_supplies` and `get_compliance_report_chain` queries — should now use index scans, not seq scans