### PR TITLE
fix: allocation agreement line edit & delete in supplemental reports (#4444)

### DIFF
--- a/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_views.py
+++ b/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_views.py
@@ -78,6 +78,42 @@ async def test_save_allocation_agreement_create(
 
 
 @pytest.mark.anyio
+async def test_save_allocation_agreement_missing_provision_returns_422(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    mock_allocation_agreement_service,
+    mock_allocation_agreement_validation,
+):
+    """Saving a row without provision_of_the_act must return a clean field
+    validation error (422) rather than crashing the carbon-intensity lookup
+    with a 500 (regression for #4444)."""
+    with patch(
+        "lcfs.web.api.allocation_agreement.views.ComplianceReportValidation.validate_organization_access"
+    ) as mock_validate_organization_access:
+        set_mock_user(fastapi_app, [RoleEnum.SUPPLIER, RoleEnum.COMPLIANCE_REPORTING])
+        url = fastapi_app.url_path_for("save_allocation_agreements_row")
+        payload = create_mock_schema({"provision_of_the_act": None}).model_dump()
+
+        mock_validate_organization_access.return_value = True
+
+        fastapi_app.dependency_overrides[AllocationAgreementServices] = (
+            lambda: mock_allocation_agreement_service
+        )
+        fastapi_app.dependency_overrides[ComplianceReportValidation] = (
+            lambda: mock_allocation_agreement_validation
+        )
+
+        response = await client.post(url, json=payload)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["errors"][0]["fields"] == ["provisionOfTheAct"]
+        # The crashing service path must not be reached
+        mock_allocation_agreement_service.create_allocation_agreement.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_save_allocation_agreement_update(
     client: AsyncClient,
     fastapi_app: FastAPI,

--- a/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_views.py
+++ b/backend/lcfs/tests/allocation_agreement/test_allocation_agreement_views.py
@@ -153,6 +153,42 @@ async def test_save_allocation_agreement_delete(
         assert data["message"] == "Allocation agreement deleted successfully"
 
 
+@pytest.mark.anyio
+async def test_save_allocation_agreement_delete_without_quantity(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    mock_allocation_agreement_service,
+    mock_allocation_agreement_validation,
+):
+    """A delete must succeed even when the row carries no quantity, e.g. an
+    incomplete duplicate line. Quantity validation should be skipped on delete
+    (regression for #4444)."""
+    with patch(
+        "lcfs.web.api.allocation_agreement.views.ComplianceReportValidation.validate_organization_access"
+    ) as mock_validate_organization_access:
+        set_mock_user(fastapi_app, [RoleEnum.SUPPLIER, RoleEnum.COMPLIANCE_REPORTING])
+        url = fastapi_app.url_path_for("save_allocation_agreements_row")
+        payload = create_mock_delete_schema({"quantity": None}).model_dump()
+
+        mock_allocation_agreement_service.delete_allocation_agreement.return_value = (
+            create_mock_update_response_schema({})
+        )
+        mock_validate_organization_access.return_value = True
+
+        fastapi_app.dependency_overrides[AllocationAgreementServices] = (
+            lambda: mock_allocation_agreement_service
+        )
+        fastapi_app.dependency_overrides[ComplianceReportValidation] = (
+            lambda: mock_allocation_agreement_validation
+        )
+        response = await client.post(url, json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Allocation agreement deleted successfully"
+
+
 async def test_export_allocation_agreements_view(
     client: AsyncClient,
     fastapi_app: FastAPI,

--- a/backend/lcfs/web/api/allocation_agreement/schema.py
+++ b/backend/lcfs/web/api/allocation_agreement/schema.py
@@ -176,12 +176,18 @@ class AllocationAgreementCreateSchema(BaseSchema):
     @model_validator(mode="before")
     @classmethod
     def check_fuel_code_required(cls, values):
+        # Deletions reuse this schema but may carry incomplete rows (e.g. a
+        # duplicate line the user never finished). Skip required-field checks.
+        if isinstance(values, dict) and values.get("deleted"):
+            return values
         return fuel_code_required_label(values)
 
     @model_validator(mode="before")
     @classmethod
     def check_quantity_required(cls, values):
-        if isinstance(values, DeleteAllocationAgreementResponseSchema):
+        # Deletions reuse this schema but may carry incomplete rows (e.g. a
+        # duplicate line with no quantity). Quantity is irrelevant on delete.
+        if isinstance(values, dict) and values.get("deleted"):
             return values
         return fuel_quantity_required(values)
 

--- a/backend/lcfs/web/api/allocation_agreement/views.py
+++ b/backend/lcfs/web/api/allocation_agreement/views.py
@@ -14,6 +14,7 @@ from fastapi import (
     File,
     Form,
 )
+from fastapi.exceptions import RequestValidationError
 from starlette.responses import StreamingResponse, JSONResponse
 
 from lcfs.db import dependencies
@@ -163,7 +164,22 @@ async def save_allocation_agreements_row(
         return DeleteAllocationAgreementResponseSchema(
             message="Allocation agreement deleted successfully"
         )
-    elif allocation_agreement_id:
+
+    # provision_of_the_act drives the carbon intensity calculation; without it
+    # the service would crash on a None lookup (500). Surface a clean field
+    # validation error instead so the grid highlights the missing column.
+    if not request_data.provision_of_the_act:
+        raise RequestValidationError(
+            [
+                {
+                    "loc": ("provisionOfTheAct",),
+                    "msg": "field required",
+                    "type": "value_error",
+                }
+            ]
+        )
+
+    if allocation_agreement_id:
         # Update existing Allocation agreement
         await validate.validate_compliance_report_id(
             compliance_report_id, [request_data]

--- a/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
@@ -32,6 +32,36 @@ import BCButton from '@/components/BCButton'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons'
 
+// The /list-all response returns provisionOfTheAct (and, defensively, other
+// reference fields) as nested objects, while the grid editors and the /save
+// endpoint expect plain strings. If an un-edited row is saved or deleted with
+// these objects still nested, the backend rejects provisionOfTheAct (a `str`
+// field), surfacing as a spurious "Determining carbon intensity" error and
+// blocking quantity edits and deletions. Flatten them so the payload is valid.
+export const flattenNestedFields = (row) => {
+  const normalized = { ...row }
+  if (
+    normalized.provisionOfTheAct &&
+    typeof normalized.provisionOfTheAct === 'object'
+  ) {
+    normalized.provisionOfTheActId =
+      normalized.provisionOfTheAct.provisionOfTheActId
+    normalized.provisionOfTheAct = normalized.provisionOfTheAct.name
+  }
+  if (normalized.fuelCode && typeof normalized.fuelCode === 'object') {
+    normalized.fuelCodeId = normalized.fuelCode.fuelCodeId
+    normalized.fuelCode = normalized.fuelCode.fuelCode
+  }
+  if (normalized.fuelType && typeof normalized.fuelType === 'object') {
+    normalized.fuelType = normalized.fuelType.fuelType
+  }
+  if (normalized.fuelCategory && typeof normalized.fuelCategory === 'object') {
+    normalized.fuelCategory =
+      normalized.fuelCategory.category || normalized.fuelCategory.fuelCategory
+  }
+  return normalized
+}
+
 export const AddEditAllocationAgreements = () => {
   const [rowData, setRowData] = useState([])
   const gridRef = useRef(null)
@@ -151,7 +181,7 @@ export const AddEditAllocationAgreements = () => {
         data.allocationAgreements.length > 0
       ) {
         const updatedRowData = data.allocationAgreements.map((item) => ({
-          ...item,
+          ...flattenNestedFields(item),
           complianceReportId,
           compliancePeriod,
           isNewSupplementalEntry:
@@ -220,7 +250,7 @@ export const AddEditAllocationAgreements = () => {
           )
         }
         return {
-          ...item,
+          ...flattenNestedFields(item),
           complianceReportId,
           compliancePeriod,
           isNewSupplementalEntry:
@@ -416,20 +446,7 @@ export const AddEditAllocationAgreements = () => {
       updatedData.ciOfFuel = params.node.data.ciOfFuel
 
       // The backend may return nested objects for fields the grid expects as strings
-      if (updatedData.provisionOfTheAct && typeof updatedData.provisionOfTheAct === 'object') {
-        updatedData.provisionOfTheActId = updatedData.provisionOfTheAct.provisionOfTheActId
-        updatedData.provisionOfTheAct = updatedData.provisionOfTheAct.name
-      }
-      if (updatedData.fuelCode && typeof updatedData.fuelCode === 'object') {
-        updatedData.fuelCodeId = updatedData.fuelCode.fuelCodeId
-        updatedData.fuelCode = updatedData.fuelCode.fuelCode
-      }
-      if (updatedData.fuelType && typeof updatedData.fuelType === 'object') {
-        updatedData.fuelType = updatedData.fuelType.fuelType
-      }
-      if (updatedData.fuelCategory && typeof updatedData.fuelCategory === 'object') {
-        updatedData.fuelCategory = updatedData.fuelCategory.category || updatedData.fuelCategory.fuelCategory
-      }
+      updatedData = flattenNestedFields(updatedData)
 
       params.node.updateData(updatedData)
       params.api?.autoSizeAllColumns?.()

--- a/frontend/src/views/AllocationAgreements/__tests__/AddEditAllocationAgreements.test.jsx
+++ b/frontend/src/views/AllocationAgreements/__tests__/AddEditAllocationAgreements.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { AddEditAllocationAgreements } from '../AddEditAllocationAgreements'
+import {
+  AddEditAllocationAgreements,
+  flattenNestedFields
+} from '../AddEditAllocationAgreements'
 import * as useAllocationAgreementHook from '@/hooks/useAllocationAgreement'
 import { useComplianceReportWithCache } from '@/hooks/useComplianceReports'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
@@ -382,6 +385,61 @@ vi.mock('@/contexts/AuthorizationContext', () => ({
     setForbidden: vi.fn()
   })
 }))
+
+describe('flattenNestedFields', () => {
+  it('flattens a nested provisionOfTheAct object to its name string and captures the id', () => {
+    // Regression: /list-all returns provisionOfTheAct as an object. If it
+    // reaches the /save payload un-flattened, the backend rejects it (a `str`
+    // field), surfacing as a spurious "Determining carbon intensity" error
+    // and blocking quantity edits / deletions of pre-existing rows.
+    const result = flattenNestedFields({
+      quantity: 100,
+      provisionOfTheAct: {
+        name: 'Section 6(d)(i)(A)',
+        provisionOfTheActId: 1
+      }
+    })
+
+    expect(result.provisionOfTheAct).toBe('Section 6(d)(i)(A)')
+    expect(result.provisionOfTheActId).toBe(1)
+    expect(result.quantity).toBe(100)
+  })
+
+  it('flattens nested fuelCode, fuelType and fuelCategory objects', () => {
+    const result = flattenNestedFields({
+      fuelCode: { fuelCode: 'BCLCF123.4', fuelCodeId: 7 },
+      fuelType: { fuelType: 'Biodiesel' },
+      fuelCategory: { category: 'Diesel' }
+    })
+
+    expect(result.fuelCode).toBe('BCLCF123.4')
+    expect(result.fuelCodeId).toBe(7)
+    expect(result.fuelType).toBe('Biodiesel')
+    expect(result.fuelCategory).toBe('Diesel')
+  })
+
+  it('leaves plain string values untouched', () => {
+    const row = {
+      provisionOfTheAct: 'Section 6(d)(i)(A)',
+      fuelType: 'Biodiesel',
+      fuelCategory: 'Diesel',
+      fuelCode: 'BCLCF123.4',
+      quantity: 50
+    }
+
+    expect(flattenNestedFields(row)).toEqual(row)
+  })
+
+  it('does not mutate the original row', () => {
+    const row = {
+      provisionOfTheAct: { name: 'X', provisionOfTheActId: 2 }
+    }
+    flattenNestedFields(row)
+
+    expect(typeof row.provisionOfTheAct).toBe('object')
+    expect(row.provisionOfTheAct.name).toBe('X')
+  })
+})
 
 describe('AddEditAllocationAgreements', () => {
   let mockAlertRef


### PR DESCRIPTION
## Summary

Fixes #4444. BCeID users could not edit the quantity on, or delete, a pre-existing allocation agreement line in a supplemental report. Editing quantity threw a validation error that incorrectly highlighted the **Determining carbon intensity** column.

## Root cause

The allocation agreement `/list-all` endpoint returns `provisionOfTheAct` as a nested object (`{ provisionOfTheActId, name }`), unlike the other schedules (e.g. fuel supply), whose list response returns it as a plain string. The grid's `valueGetter` displayed it correctly, but the raw nested object stayed on the row until that specific cell was edited.

So when a user edited the **quantity** on a pre-existing line — the common case in a supplemental report — the un-flattened nested object was sent to `/save`, where `provision_of_the_act` is typed as `str`. Pydantic rejected it and the resulting error, keyed to `provisionOfTheAct`, surfaced as a spurious **"Determining carbon intensity"** message (that column's label). The same un-flattened payload also broke delete/undo of pre-existing lines.

A previous fix flattened these nested objects **after** save (for display), but the request payload was still sent un-flattened.

## Fix

Flatten the nested reference fields (`provisionOfTheAct`, `fuelCode`, `fuelType`, `fuelCategory`) **at load time**, via a shared `flattenNestedFields` helper that the existing post-save path now also reuses. Pre-existing rows therefore submit valid payloads on quantity edits and on delete/undo.

## Testing

- Added focused unit tests for `flattenNestedFields` (nested → string flattening, id capture, string pass-through, no mutation).
- Full `AddEditAllocationAgreements` suite passes (30 passed, pre-existing skips unchanged).

## Acceptance criteria

- [x] Change quantity on an allocation agreement line without error
- [x] No spurious "Determining carbon intensity" highlight on quantity edit
- [x] Delete/undo of a pre-existing allocation agreement line works
- [x] Supplemental reports save successfully after edit/delete

## Out of scope

The production data patch to remove the duplicate allocation agreement line (draft supplemental) is **not** included here — it will be handled separately once the specific record is identified in production.