### PR TITLE
fix: allocation agreement line edit & delete in supplemental reports (#4444) [release]

### DIFF
--- a/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
@@ -32,6 +32,36 @@ import BCButton from '@/components/BCButton'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons'
 
+// The /list-all response returns provisionOfTheAct (and, defensively, other
+// reference fields) as nested objects, while the grid editors and the /save
+// endpoint expect plain strings. If an un-edited row is saved or deleted with
+// these objects still nested, the backend rejects provisionOfTheAct (a `str`
+// field), surfacing as a spurious "Determining carbon intensity" error and
+// blocking quantity edits and deletions. Flatten them so the payload is valid.
+export const flattenNestedFields = (row) => {
+  const normalized = { ...row }
+  if (
+    normalized.provisionOfTheAct &&
+    typeof normalized.provisionOfTheAct === 'object'
+  ) {
+    normalized.provisionOfTheActId =
+      normalized.provisionOfTheAct.provisionOfTheActId
+    normalized.provisionOfTheAct = normalized.provisionOfTheAct.name
+  }
+  if (normalized.fuelCode && typeof normalized.fuelCode === 'object') {
+    normalized.fuelCodeId = normalized.fuelCode.fuelCodeId
+    normalized.fuelCode = normalized.fuelCode.fuelCode
+  }
+  if (normalized.fuelType && typeof normalized.fuelType === 'object') {
+    normalized.fuelType = normalized.fuelType.fuelType
+  }
+  if (normalized.fuelCategory && typeof normalized.fuelCategory === 'object') {
+    normalized.fuelCategory =
+      normalized.fuelCategory.category || normalized.fuelCategory.fuelCategory
+  }
+  return normalized
+}
+
 export const AddEditAllocationAgreements = () => {
   const [rowData, setRowData] = useState([])
   const gridRef = useRef(null)
@@ -151,7 +181,7 @@ export const AddEditAllocationAgreements = () => {
         data.allocationAgreements.length > 0
       ) {
         const updatedRowData = data.allocationAgreements.map((item) => ({
-          ...item,
+          ...flattenNestedFields(item),
           complianceReportId,
           compliancePeriod,
           isNewSupplementalEntry:
@@ -220,7 +250,7 @@ export const AddEditAllocationAgreements = () => {
           )
         }
         return {
-          ...item,
+          ...flattenNestedFields(item),
           complianceReportId,
           compliancePeriod,
           isNewSupplementalEntry:
@@ -416,20 +446,7 @@ export const AddEditAllocationAgreements = () => {
       updatedData.ciOfFuel = params.node.data.ciOfFuel
 
       // The backend may return nested objects for fields the grid expects as strings
-      if (updatedData.provisionOfTheAct && typeof updatedData.provisionOfTheAct === 'object') {
-        updatedData.provisionOfTheActId = updatedData.provisionOfTheAct.provisionOfTheActId
-        updatedData.provisionOfTheAct = updatedData.provisionOfTheAct.name
-      }
-      if (updatedData.fuelCode && typeof updatedData.fuelCode === 'object') {
-        updatedData.fuelCodeId = updatedData.fuelCode.fuelCodeId
-        updatedData.fuelCode = updatedData.fuelCode.fuelCode
-      }
-      if (updatedData.fuelType && typeof updatedData.fuelType === 'object') {
-        updatedData.fuelType = updatedData.fuelType.fuelType
-      }
-      if (updatedData.fuelCategory && typeof updatedData.fuelCategory === 'object') {
-        updatedData.fuelCategory = updatedData.fuelCategory.category || updatedData.fuelCategory.fuelCategory
-      }
+      updatedData = flattenNestedFields(updatedData)
 
       params.node.updateData(updatedData)
       params.api?.autoSizeAllColumns?.()

--- a/frontend/src/views/AllocationAgreements/__tests__/AddEditAllocationAgreements.test.jsx
+++ b/frontend/src/views/AllocationAgreements/__tests__/AddEditAllocationAgreements.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { AddEditAllocationAgreements } from '../AddEditAllocationAgreements'
+import {
+  AddEditAllocationAgreements,
+  flattenNestedFields
+} from '../AddEditAllocationAgreements'
 import * as useAllocationAgreementHook from '@/hooks/useAllocationAgreement'
 import { useComplianceReportWithCache } from '@/hooks/useComplianceReports'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
@@ -382,6 +385,61 @@ vi.mock('@/contexts/AuthorizationContext', () => ({
     setForbidden: vi.fn()
   })
 }))
+
+describe('flattenNestedFields', () => {
+  it('flattens a nested provisionOfTheAct object to its name string and captures the id', () => {
+    // Regression: /list-all returns provisionOfTheAct as an object. If it
+    // reaches the /save payload un-flattened, the backend rejects it (a `str`
+    // field), surfacing as a spurious "Determining carbon intensity" error
+    // and blocking quantity edits / deletions of pre-existing rows.
+    const result = flattenNestedFields({
+      quantity: 100,
+      provisionOfTheAct: {
+        name: 'Section 6(d)(i)(A)',
+        provisionOfTheActId: 1
+      }
+    })
+
+    expect(result.provisionOfTheAct).toBe('Section 6(d)(i)(A)')
+    expect(result.provisionOfTheActId).toBe(1)
+    expect(result.quantity).toBe(100)
+  })
+
+  it('flattens nested fuelCode, fuelType and fuelCategory objects', () => {
+    const result = flattenNestedFields({
+      fuelCode: { fuelCode: 'BCLCF123.4', fuelCodeId: 7 },
+      fuelType: { fuelType: 'Biodiesel' },
+      fuelCategory: { category: 'Diesel' }
+    })
+
+    expect(result.fuelCode).toBe('BCLCF123.4')
+    expect(result.fuelCodeId).toBe(7)
+    expect(result.fuelType).toBe('Biodiesel')
+    expect(result.fuelCategory).toBe('Diesel')
+  })
+
+  it('leaves plain string values untouched', () => {
+    const row = {
+      provisionOfTheAct: 'Section 6(d)(i)(A)',
+      fuelType: 'Biodiesel',
+      fuelCategory: 'Diesel',
+      fuelCode: 'BCLCF123.4',
+      quantity: 50
+    }
+
+    expect(flattenNestedFields(row)).toEqual(row)
+  })
+
+  it('does not mutate the original row', () => {
+    const row = {
+      provisionOfTheAct: { name: 'X', provisionOfTheActId: 2 }
+    }
+    flattenNestedFields(row)
+
+    expect(typeof row.provisionOfTheAct).toBe('object')
+    expect(row.provisionOfTheAct.name).toBe('X')
+  })
+})
 
 describe('AddEditAllocationAgreements', () => {
   let mockAlertRef


### PR DESCRIPTION
Release-targeted cherry-pick of the fix for #4444. Same change as #4467 (into `main`), applied cleanly onto `release`.

## Summary

BCeID users could not edit the quantity on, or delete, a pre-existing allocation agreement line in a supplemental report. Editing quantity threw a validation error that incorrectly highlighted the **Determining carbon intensity** column.

## Root cause

The allocation agreement `/list-all` endpoint returns `provisionOfTheAct` as a nested object (`{ provisionOfTheActId, name }`), unlike the other schedules whose list response returns a plain string. The grid displayed it correctly, but the raw object stayed on the row until that specific cell was edited. So editing **quantity** on a pre-existing line sent the nested object to `/save`, where `provision_of_the_act` is typed as `str`; Pydantic rejected it and the error, keyed to `provisionOfTheAct`, surfaced as a spurious **"Determining carbon intensity"** message. The same un-flattened payload also broke delete/undo (a separate `onAction → handleScheduleDelete` path).

## Fix

Flatten the nested reference fields at **load time** via a shared `flattenNestedFields` helper (the existing post-save flatten now reuses it), so pre-existing rows submit valid payloads on quantity edits and on delete/undo.

## Testing

- Added focused unit tests for `flattenNestedFields`.
- Full `AddEditAllocationAgreements` suite passes (30 passed, pre-existing skips unchanged).

## Out of scope

The production data patch for the duplicate line (draft supplemental) is handled separately.