### PR TITLE
Refactor: Add and Backfill Internal Comment Metadata - 4449, 4450

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-05-29-10-00_d3b5a1c9e2f7.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-29-10-00_d3b5a1c9e2f7.py
@@ -1,0 +1,225 @@
+"""Add comment_category lookup table and denormalized metadata for Comment Log.
+
+Introduces:
+- ``comment_category`` lookup (seeded)
+- Denormalized columns on ``internal_comment`` for fast org-scoped queries.
+- ``compliance_report_group_uuid`` on ``compliance_report_internal_comment``.
+- Composite + GIN + date indexes backing Comment Log queries.
+
+Backfill in follow-up migration; nullable here to unblock concurrent deploys.
+
+Revision ID: d3b5a1c9e2f7
+Revises: c2a4f6b8d9e1
+Create Date: 2026-05-29 10:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "d3b5a1c9e2f7"
+down_revision = "c2a4f6b8d9e1"
+branch_labels = None
+depends_on = None
+
+
+CATEGORY_SEED = (
+    ("Compliance notes", 10),
+    ("Transfer notes", 20),
+    ("IA notes", 30),
+    ("Penalty notes", 40),
+    ("CI application notes", 50),
+)
+
+COMPOSITE_INDEX_NAME = "idx_internal_comment_org_year_cat_vis"
+GIN_INDEX_NAME = "idx_internal_comment_search_vector"
+CREATE_DATE_INDEX_NAME = "idx_internal_comment_create_date"
+GROUP_UUID_INDEX_NAME = "idx_cr_internal_comment_group_uuid"
+
+
+def upgrade() -> None:
+    # --- comment_category lookup table ---------------------------------
+    op.create_table(
+        "comment_category",
+        sa.Column(
+            "comment_category_id",
+            sa.Integer(),
+            primary_key=True,
+            autoincrement=True,
+            comment="Primary key.",
+        ),
+        sa.Column(
+            "display_name",
+            sa.String(length=100),
+            nullable=False,
+            comment="Display label for Comment Log UI.",
+        ),
+        sa.Column(
+            "display_order",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+            comment="Display sort order.",
+        ),
+        sa.Column(
+            "create_date",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "update_date",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("display_name", name="uq_comment_category_display_name"),
+        comment="Lookup table for Comment Log categories.",
+    )
+
+    # Seed categories (idempotent per unique display_name constraint).
+    op.bulk_insert(
+        sa.table(
+            "comment_category",
+            sa.column("display_name", sa.String),
+            sa.column("display_order", sa.Integer),
+        ),
+        [
+            {"display_name": name, "display_order": order}
+            for name, order in CATEGORY_SEED
+        ],
+    )
+
+    # --- internal_comment new columns ----------------------------------
+    op.add_column(
+        "internal_comment",
+        sa.Column(
+            "organization_id",
+            sa.Integer(),
+            nullable=True,
+            comment="Denormalized org for fast org-scoped queries.",
+        ),
+    )
+    op.create_foreign_key(
+        "fk_internal_comment_organization_id",
+        source_table="internal_comment",
+        referent_table="organization",
+        local_cols=["organization_id"],
+        remote_cols=["organization_id"],
+    )
+
+    op.add_column(
+        "internal_comment",
+        sa.Column(
+            "compliance_year",
+            sa.Integer(),
+            nullable=True,
+            comment="Denormalized compliance year from source entity.",
+        ),
+    )
+
+    op.add_column(
+        "internal_comment",
+        sa.Column(
+            "comment_category_id",
+            sa.Integer(),
+            nullable=True,
+            comment="FK to comment_category.",
+        ),
+    )
+    op.create_foreign_key(
+        "fk_internal_comment_comment_category_id",
+        source_table="internal_comment",
+        referent_table="comment_category",
+        local_cols=["comment_category_id"],
+        remote_cols=["comment_category_id"],
+    )
+
+    op.add_column(
+        "internal_comment",
+        sa.Column(
+            "comment_search_text",
+            sa.Text(),
+            nullable=True,
+            comment="Sanitized plain text for full-text search.",
+        ),
+    )
+
+    op.add_column(
+        "internal_comment",
+        sa.Column(
+            "comment_search_vector",
+            postgresql.TSVECTOR(),
+            nullable=True,
+            comment="tsvector for PostgreSQL full-text search.",
+        ),
+    )
+
+    # --- compliance_report_internal_comment new column -----------------
+    op.add_column(
+        "compliance_report_internal_comment",
+        sa.Column(
+            "compliance_report_group_uuid",
+            sa.String(length=36),
+            nullable=True,
+            comment="Denormalized for grouping comments across report versions.",
+        ),
+    )
+    op.create_index(
+        GROUP_UUID_INDEX_NAME,
+        "compliance_report_internal_comment",
+        ["compliance_report_group_uuid"],
+    )
+
+    # --- Supporting indexes for the Comment Log read view --------------
+    # Composite index with DESC create_date serves filter + ordering.
+    op.create_index(
+        COMPOSITE_INDEX_NAME,
+        "internal_comment",
+        [
+            "organization_id",
+            "compliance_year",
+            "comment_category_id",
+            "visibility",
+            sa.text("create_date DESC"),
+        ],
+    )
+    op.create_index(
+        GIN_INDEX_NAME,
+        "internal_comment",
+        ["comment_search_vector"],
+        postgresql_using="gin",
+    )
+    op.create_index(
+        CREATE_DATE_INDEX_NAME,
+        "internal_comment",
+        ["create_date"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(CREATE_DATE_INDEX_NAME, table_name="internal_comment")
+    op.drop_index(GIN_INDEX_NAME, table_name="internal_comment")
+    op.drop_index(COMPOSITE_INDEX_NAME, table_name="internal_comment")
+
+    op.drop_index(
+        GROUP_UUID_INDEX_NAME,
+        table_name="compliance_report_internal_comment",
+    )
+    op.drop_column("compliance_report_internal_comment", "compliance_report_group_uuid")
+
+    op.drop_constraint(
+        "fk_internal_comment_comment_category_id",
+        "internal_comment",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_internal_comment_organization_id",
+        "internal_comment",
+        type_="foreignkey",
+    )
+    op.drop_column("internal_comment", "comment_search_vector")
+    op.drop_column("internal_comment", "comment_search_text")
+    op.drop_column("internal_comment", "comment_category_id")
+    op.drop_column("internal_comment", "compliance_year")
+    op.drop_column("internal_comment", "organization_id")
+
+    op.drop_table("comment_category")

--- a/backend/lcfs/db/migrations/versions/2026-05-29-10-30_e4c6b2d0f3a8.py
+++ b/backend/lcfs/db/migrations/versions/2026-05-29-10-30_e4c6b2d0f3a8.py
@@ -1,0 +1,250 @@
+"""Backfill comment metadata and group UUIDs.
+
+Derivation rules:
+- Compliance reports: org_id, year from report; category=COMPLIANCE_NOTES; group_uuid
+- Transfers: org_id from buyer; category=TRANSFER_NOTES
+- IA: org_id from initiator; category=IA_NOTES
+- Admin adjustment: org_id from assessed org; category=PENALTY_NOTES
+- comment_search_text: HTML-stripped plain text
+- comment_search_vector: to_tsvector('english', search_text)
+
+Revision ID: e4c6b2d0f3a8
+Revises: d3b5a1c9e2f7
+Create Date: 2026-05-29 10:30:00.000000
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e4c6b2d0f3a8"
+down_revision = "d3b5a1c9e2f7"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+# HTML tag stripping + whitespace collapse (conservative for SQL backfill).
+SANITIZED_COMMENT_SQL = (
+    "btrim(regexp_replace("
+    "regexp_replace(coalesce(ic.comment, ''), E'<[^>]*>', ' ', 'g'), "
+    "E'\\s+', ' ', 'g'))"
+)
+
+
+def _exec(sql: str, label: str, **params) -> int:
+    """Execute statement, log row count, abort on failure with context."""
+    bind = op.get_bind()
+    try:
+        result = bind.execute(sa.text(sql), params)
+        count = result.rowcount if result.rowcount is not None else -1
+        logger.info("comment-log backfill: %s updated %s rows", label, count)
+        return max(count, 0)
+    except Exception as exc:  # pragma: no cover - logged + re-raised
+        logger.exception("comment-log backfill: %s FAILED: %s", label, exc)
+        raise
+
+
+def _category_ids(bind: sa.engine.Connection) -> dict[str, int]:
+    """Return ``{display_name: comment_category_id}`` for the agreed categories."""
+    rows = bind.execute(
+        sa.text("SELECT display_name, comment_category_id FROM comment_category")
+    ).fetchall()
+    mapping = {name: cid for name, cid in rows}
+    required = {
+        "Compliance notes",
+        "Transfer notes",
+        "IA notes",
+        "Penalty notes",
+        "CI application notes",
+    }
+    missing = required - mapping.keys()
+    if missing:
+        raise RuntimeError(
+            "comment-log backfill: missing seed rows in comment_category: "
+            f"{sorted(missing)}"
+        )
+    return mapping
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    categories = _category_ids(bind)
+    total = 0
+
+    # 1. Compliance report comments -------------------------------------
+    total += _exec(
+        """
+        UPDATE internal_comment AS ic
+        SET organization_id = cr.organization_id,
+            compliance_year = cp.description::int,
+            comment_category_id = :cat_id
+        FROM compliance_report_internal_comment AS cric
+        JOIN compliance_report AS cr
+          ON cr.compliance_report_id = cric.compliance_report_id
+        JOIN compliance_period AS cp
+          ON cp.compliance_period_id = cr.compliance_period_id
+        WHERE cric.internal_comment_id = ic.internal_comment_id
+          AND cp.description ~ '^[0-9]+$'
+          AND (
+            ic.organization_id IS DISTINCT FROM cr.organization_id
+            OR ic.compliance_year IS DISTINCT FROM cp.description::int
+            OR ic.comment_category_id IS DISTINCT FROM :cat_id
+          )
+        """,
+        "compliance_report comments",
+        cat_id=categories["Compliance notes"],
+    )
+
+    # 2. Transfer comments (buyer = to_organization_id) -----------------
+    total += _exec(
+        """
+        UPDATE internal_comment AS ic
+        SET organization_id = t.to_organization_id,
+            comment_category_id = :cat_id
+        FROM transfer_internal_comment AS tic
+        JOIN transfer AS t ON t.transfer_id = tic.transfer_id
+        WHERE tic.internal_comment_id = ic.internal_comment_id
+          AND (
+            ic.organization_id IS DISTINCT FROM t.to_organization_id
+            OR ic.comment_category_id IS DISTINCT FROM :cat_id
+          )
+        """,
+        "transfer comments",
+        cat_id=categories["Transfer notes"],
+    )
+
+    # 3. Initiative agreement comments (initiator = to_organization_id) --
+    total += _exec(
+        """
+        UPDATE internal_comment AS ic
+        SET organization_id = ia.to_organization_id,
+            comment_category_id = :cat_id
+        FROM initiative_agreement_internal_comment AS iaic
+        JOIN initiative_agreement AS ia
+          ON ia.initiative_agreement_id = iaic.initiative_agreement_id
+        WHERE iaic.internal_comment_id = ic.internal_comment_id
+          AND (
+            ic.organization_id IS DISTINCT FROM ia.to_organization_id
+            OR ic.comment_category_id IS DISTINCT FROM :cat_id
+          )
+        """,
+        "initiative_agreement comments",
+        cat_id=categories["IA notes"],
+    )
+
+    # 4. Admin adjustment comments (assessed = to_organization_id) ------
+    total += _exec(
+        """
+        UPDATE internal_comment AS ic
+        SET organization_id = aa.to_organization_id,
+            comment_category_id = :cat_id
+        FROM admin_adjustment_internal_comment AS aaic
+        JOIN admin_adjustment AS aa
+          ON aa.admin_adjustment_id = aaic.admin_adjustment_id
+        WHERE aaic.internal_comment_id = ic.internal_comment_id
+          AND (
+            ic.organization_id IS DISTINCT FROM aa.to_organization_id
+            OR ic.comment_category_id IS DISTINCT FROM :cat_id
+          )
+        """,
+        "admin_adjustment comments",
+        cat_id=categories["Penalty notes"],
+    )
+
+    # 5. CI application comments ------------------------------------
+    total += _exec(
+        """
+        UPDATE internal_comment AS ic
+        SET organization_id = cia.organization_id,
+            comment_category_id = :cat_id
+        FROM ci_application_internal_comment AS ciaic
+        JOIN ci_application AS cia
+          ON cia.ci_application_id = ciaic.ci_application_id
+        WHERE ciaic.internal_comment_id = ic.internal_comment_id
+          AND (
+            ic.organization_id IS DISTINCT FROM cia.organization_id
+            OR ic.comment_category_id IS DISTINCT FROM :cat_id
+          )
+        """,
+        "ci_application comments",
+        cat_id=categories["CI application notes"],
+    )
+
+    # 6. Sanitize comment text and rebuild search vector ----------------
+    total += _exec(
+        f"""
+        UPDATE internal_comment AS ic
+        SET comment_search_text = {SANITIZED_COMMENT_SQL},
+            comment_search_vector = to_tsvector(
+                'english', {SANITIZED_COMMENT_SQL}
+            )
+        WHERE ic.comment IS NOT NULL
+          AND (
+            ic.comment_search_text IS DISTINCT FROM {SANITIZED_COMMENT_SQL}
+            OR ic.comment_search_vector IS NULL
+          )
+        """,
+        "search text/vector",
+    )
+
+    # 6. Backfill compliance_report_group_uuid on the association table --
+    total += _exec(
+        """
+        UPDATE compliance_report_internal_comment AS cric
+        SET compliance_report_group_uuid = cr.compliance_report_group_uuid
+        FROM compliance_report AS cr
+        WHERE cr.compliance_report_id = cric.compliance_report_id
+          AND cric.compliance_report_group_uuid
+              IS DISTINCT FROM cr.compliance_report_group_uuid
+        """,
+        "compliance_report_group_uuid on association",
+    )
+
+    # 7. Summary --------------------------------------------------------
+    missing_org = bind.execute(
+        sa.text("SELECT count(*) FROM internal_comment WHERE organization_id IS NULL")
+    ).scalar()
+    missing_cat = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM internal_comment WHERE comment_category_id IS NULL"
+        )
+    ).scalar()
+    missing_vec = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM internal_comment "
+            "WHERE comment_search_vector IS NULL AND comment IS NOT NULL"
+        )
+    ).scalar()
+    logger.info(
+        "comment-log backfill: total writes=%s, "
+        "remaining NULL organization_id=%s, comment_category_id=%s, "
+        "comment_search_vector=%s",
+        total,
+        missing_org,
+        missing_cat,
+        missing_vec,
+    )
+
+
+def downgrade() -> None:
+    # Best-effort revert: clear the columns populated by this backfill.
+    op.execute(
+        sa.text(
+            "UPDATE internal_comment SET "
+            "organization_id = NULL, "
+            "compliance_year = NULL, "
+            "comment_category_id = NULL, "
+            "comment_search_text = NULL, "
+            "comment_search_vector = NULL"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE compliance_report_internal_comment SET "
+            "compliance_report_group_uuid = NULL"
+        )
+    )

--- a/backend/lcfs/db/models/comment/CommentCategory.py
+++ b/backend/lcfs/db/models/comment/CommentCategory.py
@@ -1,0 +1,39 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from lcfs.db.base import BaseModel
+
+
+class CommentCategory(BaseModel):
+    """
+    Lookup table for Comment Log categories.
+    """
+
+    __tablename__ = "comment_category"
+    __table_args__ = {"comment": "Lookup table for Comment Log categories."}
+
+    comment_category_id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment="Primary key.",
+    )
+    display_name = Column(
+        String(length=100),
+        nullable=False,
+        unique=True,
+        comment="Display label for Comment Log UI.",
+    )
+    display_order = Column(
+        Integer,
+        nullable=False,
+        server_default="0",
+        comment="Display sort order.",
+    )
+
+    internal_comments = relationship(
+        "InternalComment", back_populates="comment_category"
+    )
+
+    def __repr__(self) -> str:
+        return f"<CommentCategory(id={self.comment_category_id}, name={self.display_name})>"

--- a/backend/lcfs/db/models/comment/ComplianceReportInternalComment.py
+++ b/backend/lcfs/db/models/comment/ComplianceReportInternalComment.py
@@ -1,11 +1,17 @@
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Index, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
 from lcfs.db.base import BaseModel
 
 
 class ComplianceReportInternalComment(BaseModel):
     __tablename__ = "compliance_report_internal_comment"
-    __table_args__ = {"comment": "Associates internal comments with compliance report."}
+    __table_args__ = (
+        Index(
+            "idx_cr_internal_comment_group_uuid",
+            "compliance_report_group_uuid",
+        ),
+        {"comment": "Associates internal comments with compliance report."},
+    )
 
     # Columns
     compliance_report_id = Column(
@@ -19,6 +25,14 @@ class ComplianceReportInternalComment(BaseModel):
         ForeignKey("internal_comment.internal_comment_id"),
         primary_key=True,
         comment="Foreign key to internal_comment, part of the composite primary key.",
+    )
+    compliance_report_group_uuid = Column(
+        String(length=36),
+        nullable=True,
+        comment=(
+            "Denormalized compliance_report.compliance_report_group_uuid so "
+            "comments stay grouped across supplemental/versioned reports."
+        ),
     )
 
     # Relationships

--- a/backend/lcfs/db/models/comment/InternalComment.py
+++ b/backend/lcfs/db/models/comment/InternalComment.py
@@ -1,5 +1,11 @@
-from sqlalchemy import Column, Integer, Text
-from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import ENUM, TSVECTOR
 from sqlalchemy.orm import relationship
 
 from lcfs.db.base import BaseModel, Auditable
@@ -25,6 +31,21 @@ comment_visibility_enum = ENUM(
 class InternalComment(BaseModel, Auditable):
     __tablename__ = "internal_comment"
     __table_args__ = (
+        Index(
+            "idx_internal_comment_org_year_cat_vis",
+            "organization_id",
+            "compliance_year",
+            "comment_category_id",
+            "visibility",
+            "create_date",
+            postgresql_ops={"create_date": "DESC"},
+        ),
+        Index(
+            "idx_internal_comment_search_vector",
+            "comment_search_vector",
+            postgresql_using="gin",
+        ),
+        Index("idx_internal_comment_create_date", "create_date"),
         {"comment": "Stores internal comments with scope and related metadata."},
     )
 
@@ -48,7 +69,39 @@ class InternalComment(BaseModel, Auditable):
         comment="Visibility scope: Internal (gov-only) or Public (visible to org users)",
     )
 
+    # --- Comment Log denormalized metadata -------------------------------
+    organization_id = Column(
+        Integer,
+        ForeignKey("organization.organization_id"),
+        nullable=True,
+        comment="Denormalized org for fast org-scoped queries.",
+    )
+    compliance_year = Column(
+        Integer,
+        nullable=True,
+        comment="Denormalized compliance year from source entity.",
+    )
+    comment_category_id = Column(
+        Integer,
+        ForeignKey("comment_category.comment_category_id"),
+        nullable=True,
+        comment="FK to comment_category.",
+    )
+    comment_search_text = Column(
+        Text,
+        nullable=True,
+        comment="Sanitized plain text for full-text search.",
+    )
+    comment_search_vector = Column(
+        TSVECTOR,
+        nullable=True,
+        comment="tsvector for PostgreSQL full-text search.",
+    )
+
     # Relationships
+    comment_category = relationship(
+        "CommentCategory", back_populates="internal_comments"
+    )
     transfer_internal_comments = relationship(
         "TransferInternalComment", back_populates="internal_comment"
     )

--- a/backend/lcfs/db/models/comment/__init__.py
+++ b/backend/lcfs/db/models/comment/__init__.py
@@ -1,5 +1,6 @@
 from .AdminAdjustmentInternalComment import AdminAdjustmentInternalComment
 from .CIApplicationInternalComment import CIApplicationInternalComment
+from .CommentCategory import CommentCategory
 from .InitiativeAgreementInternalComment import InitiativeAgreementInternalComment
 from .InternalComment import InternalComment
 from .ComplianceReportInternalComment import ComplianceReportInternalComment
@@ -7,6 +8,7 @@ from .ComplianceReportInternalComment import ComplianceReportInternalComment
 __all__ = [
     "AdminAdjustmentInternalComment",
     "CIApplicationInternalComment",
+    "CommentCategory",
     "InitiativeAgreementInternalComment",
     "InternalComment",
     "ComplianceReportInternalComment",


### PR DESCRIPTION
This PR adds internal comment metadata columns, backfills existing comment records, and populates compliance report group UUIDs to support organization-wide Comment Log reporting.

- Add internal comment metadata columns
- Add compliance report group UUID
- Backfill existing comment metadata
- Populate report group UUID values
- Preserve existing comment history

Closes #4449
Closes #4450