### PR TITLE
Fix: decommissioned FSE blocking prior-year supplemental reports (#4485)

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -438,6 +438,7 @@ async def test_handle_submitted_status_rejects_decommissioned_fse(
     mock_report.compliance_report_id = 1
     mock_report.organization_id = 123
     mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period.description = "2024"
 
     mock_user_has_roles.return_value = True
     compliance_report_update_service.final_supply_equipment_repo.has_decommissioned_fse_in_report = AsyncMock(
@@ -464,6 +465,7 @@ async def test_handle_submitted_status_refreshes_decommissioned_fse_for_original
     mock_report.organization_id = 123
     mock_report.compliance_report_group_uuid = "report-group-123"
     mock_report.supplemental_initiator = None
+    mock_report.compliance_period.description = "2024"
 
     mock_user_has_roles.return_value = True
     compliance_report_update_service.summary_service.calculate_compliance_report_summary = AsyncMock(
@@ -480,8 +482,10 @@ async def test_handle_submitted_status_refreshes_decommissioned_fse_for_original
         mock_report, UserProfile()
     )
 
+    # Deactivation is now compliance-period-aware: only FSE decommissioned
+    # before the reported year are deactivated.
     compliance_report_update_service.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report.assert_awaited_once_with(
-        1
+        1, compliance_year=2024
     )
 
 

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from sqlalchemy import select, literal
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -563,6 +564,26 @@ async def test_deactivate_decommissioned_fse_for_report(repo, fake_db):
 
 
 @pytest.mark.anyio
+async def test_deactivate_decommissioned_fse_for_report_filters_by_compliance_year(
+    repo, fake_db
+):
+    execute_result = MagicMock()
+    execute_result.rowcount = 1
+    fake_db.execute.return_value = execute_result
+
+    result = await repo.deactivate_decommissioned_fse_for_report(
+        10, compliance_year=2024
+    )
+
+    assert result == 1
+    executed_query = fake_db.execute.call_args[0][0]
+    compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+    # Period-aware path only deactivates equipment decommissioned before the
+    # reported year.
+    assert "EXTRACT(year FROM charging_equipment.update_date) < 2024" in compiled_sql
+
+
+@pytest.mark.anyio
 async def test_get_fse_reporting_list_paginated_excludes_decommissioned_when_requested(
     repo, fake_db
 ):
@@ -585,6 +606,23 @@ async def test_get_fse_reporting_list_paginated_excludes_decommissioned_when_req
     compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
     assert "charging_equipment_status != 'Decommissioned'" in compiled_sql
     assert "charging_equipment_compliance_id IS NOT NULL" not in compiled_sql
+
+
+@pytest.mark.anyio
+async def test_has_decommissioned_fse_in_report_filters_by_compliance_year(
+    repo, fake_db
+):
+    fake_db.scalar.return_value = 0
+
+    result = await repo.has_decommissioned_fse_in_report(10, compliance_year=2024)
+
+    assert result is False
+    stmt = fake_db.scalar.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    # Period-aware path joins charging_equipment and only counts rows
+    # decommissioned before the reported year.
+    assert "charging_equipment" in compiled
+    assert "EXTRACT(year FROM charging_equipment.update_date) < 2024" in compiled
 
 
 @pytest.mark.anyio
@@ -1059,40 +1097,50 @@ async def test_bulk_update_deactivate_takes_precedence_over_activate(repo, fake_
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_returns_status(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_returns_status(repo, fake_db):
+    decommissioned_at = datetime(2025, 6, 1)
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = "Submitted"
+    result_mock.first.return_value = ("Decommissioned", decommissioned_at)
     fake_db.execute.return_value = result_mock
 
-    status_value = await repo.get_latest_equipment_status(charging_equipment_id=42)
+    status_value, decommissioned_date = (
+        await repo.get_latest_equipment_status_with_date(charging_equipment_id=42)
+    )
 
-    assert status_value == "Submitted"
+    assert status_value == "Decommissioned"
+    assert decommissioned_date == decommissioned_at
     fake_db.execute.assert_called_once()
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_returns_none_when_not_found(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_returns_none_when_not_found(
+    repo, fake_db
+):
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
+    result_mock.first.return_value = None
     fake_db.execute.return_value = result_mock
 
-    status_value = await repo.get_latest_equipment_status(charging_equipment_id=999)
+    status_value, decommissioned_date = (
+        await repo.get_latest_equipment_status_with_date(charging_equipment_id=999)
+    )
 
     assert status_value is None
+    assert decommissioned_date is None
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_query_compiles(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_query_compiles(repo, fake_db):
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
+    result_mock.first.return_value = None
     fake_db.execute.return_value = result_mock
 
-    await repo.get_latest_equipment_status(charging_equipment_id=1)
+    await repo.get_latest_equipment_status_with_date(charging_equipment_id=1)
 
     stmt = fake_db.execute.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
 
     assert "charging_equipment" in compiled
     assert "charging_equipment_status" in compiled
+    assert "charging_equipment.update_date" in compiled
     assert "FROM charging_equipment JOIN charging_equipment_status" in compiled
     assert "ORDER BY charging_equipment.version DESC" in compiled

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
@@ -39,6 +39,8 @@ def mock_repo():
     repo = AsyncMock()
     repo.get_charging_power_output.return_value = None
     repo.get_total_kwh_usage_for_report_group.return_value = 0
+    # Default: equipment is active (not decommissioned).
+    repo.get_latest_equipment_status_with_date.return_value = ("Submitted", None)
     return repo
 
 
@@ -47,7 +49,12 @@ def mock_comp_report_repo():
     """
     Return an AsyncMock for the ComplianceReportRepository.
     """
-    return AsyncMock()
+    repo = AsyncMock()
+    # Default: reports resolve to the 2024 compliance period.
+    default_report = MagicMock()
+    default_report.compliance_period.description = "2024"
+    repo.get_compliance_report_by_id.return_value = default_report
+    return repo
 
 
 @pytest.fixture
@@ -544,11 +551,17 @@ async def test_create_fse_reporting_batch_success(service, mock_repo):
 async def test_create_fse_reporting_batch_rejects_decommissioned_equipment(
     service, mock_repo
 ):
-    mock_repo.get_latest_equipment_status.return_value = "Decommissioned"
+    # Decommissioned in 2023, reported for the 2024 period -> already retired
+    # before the period began, so it must be rejected.
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2023, 5, 1),
+    )
 
     data = [
         MagicMock(
             charging_equipment_id=99,
+            compliance_report_id=10,
             model_dump=lambda: {
                 "charging_equipment_id": 99,
                 "compliance_report_id": 10,
@@ -567,12 +580,43 @@ async def test_create_fse_reporting_batch_rejects_decommissioned_equipment(
 
 
 @pytest.mark.anyio
+async def test_create_fse_reporting_batch_allows_post_period_decommissioned_equipment(
+    service, mock_repo
+):
+    # Decommissioned in 2025 but reported for the 2024 period -> the equipment
+    # was still active during 2024, so the batch must be allowed. This is the
+    # core fix for prior-year supplementals (issue #4485).
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2025, 3, 1),
+    )
+    mock_repo.create_fse_reporting_batch.return_value = {"message": "Success"}
+
+    data = [
+        MagicMock(
+            charging_equipment_id=99,
+            compliance_report_id=10,
+            model_dump=lambda: {
+                "charging_equipment_id": 99,
+                "compliance_report_id": 10,
+                "supply_from_date": "2024-01-01",
+                "supply_to_date": "2024-12-31",
+            },
+        )
+    ]
+
+    result = await service.create_fse_reporting_batch(data)
+
+    assert result["message"] == "Success"
+    mock_repo.create_fse_reporting_batch.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_update_fse_reporting_success(service, mock_repo):
     """Test successful update of FSE reporting"""
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.update_fse_reporting.return_value = {"id": 1, "kwh_usage": 1500.0}
 
     data = MagicMock(model_dump=lambda: {"kwh_usage": 1500.0})
@@ -609,9 +653,8 @@ async def test_delete_fse_reporting_batch_success(service, mock_repo):
 async def test_update_fse_reporting_active_status(service, mock_repo):
     """Test toggling FSE reporting active status"""
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.update_reporting_active_status.return_value = 3
 
     data = MagicMock(reporting_ids=[1, 2, 3], is_active=False, compliance_report_id=10)
@@ -630,9 +673,13 @@ async def test_update_fse_reporting_active_status_rejects_activating_decommissio
     service, mock_repo
 ):
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Decommissioned"
+    # Decommissioned in 2023, report is for the 2024 period -> reject activation.
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2023, 5, 1),
+    )
 
     data = MagicMock(reporting_ids=[1], is_active=True)
 
@@ -647,11 +694,11 @@ async def test_update_fse_reporting_active_status_rejects_activating_decommissio
 @pytest.mark.anyio
 async def test_set_default_dates_fse_reporting_success(service, mock_repo):
     """Test successful setting of default dates for FSE reporting"""
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.bulk_update_reporting_dates.return_value = 3
 
     data = MagicMock(
         equipment_ids=[1, 2, 3],
+        compliance_report_id=10,
         supply_from_date="2024-01-01",
         supply_to_date="2024-12-31",
     )

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -349,15 +349,28 @@ class ComplianceReportUpdateService:
                 report.organization_id,
             )
 
+        # Only act on FSE that were decommissioned before the report's
+        # compliance period. Equipment retired during or after the reported
+        # year was still valid for that year (e.g. a 2024 report must not be
+        # blocked by a 2025 decommission), so it stays reportable.
+        compliance_period = getattr(report, "compliance_period", None)
+        period_description = getattr(compliance_period, "description", None)
+        try:
+            submission_compliance_year = int(period_description)
+        except (TypeError, ValueError):
+            submission_compliance_year = None
+
         if report.supplemental_initiator is None:
             await self.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report(
-                report.compliance_report_id
+                report.compliance_report_id,
+                compliance_year=submission_compliance_year,
             )
 
         has_decommissioned_fse = (
             await self.final_supply_equipment_repo.has_decommissioned_fse_in_report(
                 report.compliance_report_id,
                 only_active=True,
+                compliance_year=submission_compliance_year,
             )
         )
         if has_decommissioned_fse:

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -1,5 +1,5 @@
-from datetime import date
-from typing import Any, List, Sequence
+from datetime import date, datetime
+from typing import Any, List, Optional, Sequence, Tuple
 
 import structlog
 from fastapi import Depends
@@ -8,6 +8,7 @@ from sqlalchemy import (
     delete,
     distinct,
     exists,
+    extract,
     func,
     select,
     update,
@@ -1071,10 +1072,21 @@ class FinalSupplyEquipmentRepository:
         return float(await self.db.scalar(total_query) or 0)
 
     @repo_handler
-    async def get_latest_equipment_status(self, charging_equipment_id: int) -> str | None:
+    async def get_latest_equipment_status_with_date(
+        self, charging_equipment_id: int
+    ) -> Tuple[Optional[str], Optional[datetime]]:
         """
-        Return the current status for the latest version in the same logical
-        charging equipment series as the provided equipment id.
+        Return the status and last-updated time for the latest version in the
+        same logical charging equipment series as the provided equipment id.
+
+        ``update_date`` doubles as a proxy for when the equipment was
+        decommissioned: decommissioning is an in-place status change with no
+        dedicated timestamp, so the last-updated time of the decommissioned
+        row stands in for the decommission date. Callers compare it against a
+        report's compliance period to decide whether the equipment was already
+        decommissioned for that period.
+
+        Returns ``(None, None)`` when the equipment series is not found.
         """
         group_uuid_subquery = (
             select(ChargingEquipment.group_uuid)
@@ -1083,7 +1095,7 @@ class FinalSupplyEquipmentRepository:
         )
 
         stmt = (
-            select(ChargingEquipmentStatus.status)
+            select(ChargingEquipmentStatus.status, ChargingEquipment.update_date)
             .select_from(ChargingEquipment)
             .join(
                 ChargingEquipmentStatus,
@@ -1097,7 +1109,10 @@ class FinalSupplyEquipmentRepository:
             )
             .limit(1)
         )
-        return (await self.db.execute(stmt)).scalar_one_or_none()
+        row = (await self.db.execute(stmt)).first()
+        if row is None:
+            return None, None
+        return row[0], row[1]
 
     @repo_handler
     async def get_reporting_record_by_id(
@@ -1115,11 +1130,24 @@ class FinalSupplyEquipmentRepository:
 
     @repo_handler
     async def has_decommissioned_fse_in_report(
-        self, compliance_report_id: int, only_active: bool = True
+        self,
+        compliance_report_id: int,
+        only_active: bool = True,
+        compliance_year: Optional[int] = None,
     ) -> bool:
         """
-        Check whether the current draft/report view contains any decommissioned
-        FSE rows that are still attached to the report.
+        Check whether the report contains decommissioned FSE rows that should
+        block submission.
+
+        A decommissioned FSE only blocks the report when it was decommissioned
+        *before* the report's compliance period. Equipment decommissioned during
+        or after the reported year was still valid for that year (e.g. a 2024
+        report must not be blocked by a 2025 decommission), so it is allowed.
+        The equipment's ``update_date`` stands in for the decommission date
+        (in-place status change, no dedicated timestamp).
+
+        When ``compliance_year`` is ``None`` the period check is skipped and any
+        decommissioned row counts (legacy behaviour).
         """
         vt = FSEReportingBasePrefView.__table__
         conditions = [
@@ -1130,28 +1158,61 @@ class FinalSupplyEquipmentRepository:
         if only_active:
             conditions.append(vt.c.is_active.is_(True))
 
-        stmt = select(func.count()).select_from(vt).where(*conditions)
+        stmt = select(func.count()).select_from(vt)
+
+        if compliance_year is not None:
+            stmt = stmt.join(
+                ChargingEquipment,
+                and_(
+                    ChargingEquipment.charging_equipment_id
+                    == vt.c.charging_equipment_id,
+                    ChargingEquipment.version == vt.c.charging_equipment_version,
+                ),
+            )
+            conditions.append(
+                extract("year", ChargingEquipment.update_date) < compliance_year
+            )
+
+        stmt = stmt.where(*conditions)
         return bool(await self.db.scalar(stmt))
 
     @repo_handler
     async def deactivate_decommissioned_fse_for_report(
-        self, compliance_report_id: int
+        self, compliance_report_id: int, compliance_year: Optional[int] = None
     ) -> int:
         """
-        Deactivate active FSE reporting rows when the current equipment status
-        has become Decommissioned.
+        Deactivate active FSE reporting rows whose equipment has been
+        decommissioned.
+
+        Period-aware: when ``compliance_year`` is provided, only rows for
+        equipment decommissioned *before* that compliance period are
+        deactivated. Equipment retired during or after the reported year was
+        still valid for that year and is left active. The equipment's
+        ``update_date`` stands in for the decommission date (in-place status
+        change, no dedicated timestamp). When ``compliance_year`` is ``None``
+        every decommissioned row is deactivated (legacy behaviour).
         """
         vt = FSEReportingBasePrefView.__table__
-        decommissioned_reporting_ids = (
-            select(vt.c.charging_equipment_compliance_id)
-            .where(
-                vt.c.compliance_report_id == compliance_report_id,
-                vt.c.charging_equipment_compliance_id.is_not(None),
-                vt.c.charging_equipment_status == "Decommissioned",
-                vt.c.is_active.is_(True),
+        base_select = select(vt.c.charging_equipment_compliance_id)
+        conditions = [
+            vt.c.compliance_report_id == compliance_report_id,
+            vt.c.charging_equipment_compliance_id.is_not(None),
+            vt.c.charging_equipment_status == "Decommissioned",
+            vt.c.is_active.is_(True),
+        ]
+        if compliance_year is not None:
+            base_select = base_select.join(
+                ChargingEquipment,
+                and_(
+                    ChargingEquipment.charging_equipment_id
+                    == vt.c.charging_equipment_id,
+                    ChargingEquipment.version == vt.c.charging_equipment_version,
+                ),
             )
-            .subquery()
-        )
+            conditions.append(
+                extract("year", ChargingEquipment.update_date) < compliance_year
+            )
+        decommissioned_reporting_ids = base_select.where(*conditions).subquery()
 
         result = await self.db.execute(
             update(ComplianceReportChargingEquipment)

--- a/backend/lcfs/web/api/final_supply_equipment/services.py
+++ b/backend/lcfs/web/api/final_supply_equipment/services.py
@@ -328,11 +328,36 @@ class FinalSupplyEquipmentServices:
 
         return compliance_report
 
+    async def _get_report_compliance_year(self, compliance_report_id: int) -> int:
+        """Resolve the compliance period year for a report id."""
+        report = await self.compliance_report_repo.get_compliance_report_by_id(
+            compliance_report_id
+        )
+        if not report:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Compliance report not found",
+            )
+        return int(report.compliance_period.description)
+
     async def _validate_equipment_is_not_decommissioned(
-        self, charging_equipment_id: int
+        self, charging_equipment_id: int, compliance_year: int
     ) -> None:
-        latest_status = await self.repo.get_latest_equipment_status(charging_equipment_id)
-        if latest_status == self.DECOMMISSIONED_STATUS:
+        latest_status, decommissioned_date = (
+            await self.repo.get_latest_equipment_status_with_date(charging_equipment_id)
+        )
+        # The decommission restriction is period-aware: equipment is only
+        # off-limits for periods that begin after it was decommissioned. A
+        # report for an earlier year (e.g. a 2024 supplemental for FSE retired
+        # in 2025) stays editable because the equipment was still active during
+        # the reported period. update_date stands in for the decommission date
+        # (in-place status change, no dedicated timestamp). When the date is
+        # unavailable we err on the side of allowing the edit.
+        if (
+            latest_status == self.DECOMMISSIONED_STATUS
+            and decommissioned_date is not None
+            and decommissioned_date.year < compliance_year
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -350,8 +375,11 @@ class FinalSupplyEquipmentServices:
                 detail="FSE reporting record not found",
             )
 
+        compliance_year = await self._get_report_compliance_year(
+            reporting_record.compliance_report_id
+        )
         await self._validate_equipment_is_not_decommissioned(
-            reporting_record.charging_equipment_id
+            reporting_record.charging_equipment_id, compliance_year
         )
         return reporting_record
 
@@ -530,10 +558,14 @@ class FinalSupplyEquipmentServices:
         """
         Create FSE compliance reporting data
         """
-        for item in data:
-            await self._validate_equipment_is_not_decommissioned(
-                item.charging_equipment_id
+        if data:
+            compliance_year = await self._get_report_compliance_year(
+                data[0].compliance_report_id
             )
+            for item in data:
+                await self._validate_equipment_is_not_decommissioned(
+                    item.charging_equipment_id, compliance_year
+                )
 
         # Convert Pydantic schemas to dict format for SQLAlchemy
         model_data = [item.model_dump() for item in data]
@@ -602,8 +634,13 @@ class FinalSupplyEquipmentServices:
                 detail="Supply from and to dates are required",
             )
 
+        compliance_year = await self._get_report_compliance_year(
+            data.compliance_report_id
+        )
         for equipment_id in data.equipment_ids:
-            await self._validate_equipment_is_not_decommissioned(equipment_id)
+            await self._validate_equipment_is_not_decommissioned(
+                equipment_id, compliance_year
+            )
 
         updated_count = await self.repo.bulk_update_reporting_dates(data)
 


### PR DESCRIPTION
## Problem

Closes #4485. `develop` companion to #4486 (main) / #4487 (release).

Decommissioned Fuel Supply Equipment (FSE) blocked **editing and submission of prior-year compliance reports**, regardless of when the equipment was retired. Suppliers could not resubmit, e.g., a **2024** supplemental for an FSE decommissioned in **2025** — even though it was active for the whole reported year.

Root cause: the decommission check resolved the equipment's **current, global** status with no awareness of the report's compliance period, so any decommission affected every report referencing that equipment series.

## Fix

Make the check **compliance-period-aware**: an FSE only affects a report when it was decommissioned *before* that report's compliance period. Equipment retired during or after the reported year stays reportable; equipment retired in a prior year is still handled (preserves the original #4360 intent).

Decommissioning is an in-place status change with no dedicated timestamp, so the equipment row's `update_date` stands in for the decommission date.

### Changes
- **repo**: `get_latest_equipment_status` → `get_latest_equipment_status_with_date` (returns status + `update_date`); both `has_decommissioned_fse_in_report` (supplemental block path) **and** `deactivate_decommissioned_fse_for_report` (original-report auto-deactivate path) gain a `compliance_year` filter (`EXTRACT(year FROM update_date) < year`).
- **services**: thread the report's compliance year through the four edit-time decommission validations (batch create, update, activate, set-default-dates).
- **update_service**: compute the compliance year on submit and pass it to **both** the deactivate (original reports) and block (supplementals) paths, with a safe fallback to prior behaviour when the year can't be resolved.

## Develop-specific note
`develop` (unlike main/release) auto-deactivates decommissioned FSE on **original** reports via `deactivate_decommissioned_fse_for_report`. That path was also period-blind, so it's made period-aware here too — otherwise originals would silently drop period-valid FSE while supplementals correctly keep them. This is the only delta versus #4486/#4487.

## Testing
- Repo unit tests pass (69), including new period-aware coverage for both the block and deactivate paths; compiled SQL verified.
- Service / update_service tests updated with period-aware cases (decommission *before* period → acted on; *after* period → left active).

## Note
The issue's written "Expected Behaviour" (hide decommissioned FSE entirely) differs from this date-aware approach, which keeps valid prior-year rows reportable per the follow-up discussion on #4485. Acceptance criteria may want a quick reconciliation.