### PR TITLE
Feat: add internalCommentSearch feature flag (#4460)

### DIFF
--- a/frontend/public/config/config.js
+++ b/frontend/public/config/config.js
@@ -21,7 +21,8 @@ export const config = {
     reporting2025Enabled: false,
     manageChargingSites: true,
     manageFse: true,
-    legacySupplementalLock: false
+    legacySupplementalLock: false,
+    internalCommentSearch: true
   }
 }
 

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -10,6 +10,7 @@ export interface FeatureFlagsConfig {
   manageFse?: boolean
   legacySupplementalLock?: boolean
   ciApplications?: boolean
+  internalCommentSearch?: boolean
 }
 
 export interface KeycloakConfig {
@@ -76,7 +77,8 @@ export const FEATURE_FLAGS = {
   MANAGE_CHARGING_SITES: 'manageChargingSites',
   MANAGE_FSE: 'manageFse',
   LEGACY_SUPPLEMENTAL_LOCK: 'legacySupplementalLock',
-  CI_APPLICATIONS: 'ciApplications'
+  CI_APPLICATIONS: 'ciApplications',
+  INTERNAL_COMMENT_SEARCH: 'internalCommentSearch'
 } as const
 
 export type FeatureFlagValue =
@@ -135,6 +137,8 @@ export const CONFIG: AppConfig = {
     // flips it on for production.
     ciApplications:
       window.lcfs_config.feature_flags.ciApplications ??
-      !isProductionEnvironment
+      !isProductionEnvironment,
+    internalCommentSearch:
+      window.lcfs_config.feature_flags.internalCommentSearch ?? false
   }
 }


### PR DESCRIPTION
## Summary

Closes #4460. Stubs the feature flag that will gate the enhanced internal comment search / new internal commenting view. **Flag only — no consumer yet**; a follow-up ticket wires it into the UI.

## Changes
- `frontend/src/constants/config.ts` — register `internalCommentSearch` in the `FeatureFlagsConfig` interface, the `FEATURE_FLAGS` map (`INTERNAL_COMMENT_SEARCH`), and the `CONFIG` defaults, using the **same form as the standard flags** (`window.lcfs_config.feature_flags.internalCommentSearch ?? false`).
- `frontend/public/config/config.js` — enable it for local development.

## Behaviour / defaults
- Local default is `?? false` (same as `supplementalReporting`, `fseImportExport`, etc.) — **no `!isProductionEnvironment` check**.
- Per-environment values (dev/test/prod) are set in the tenant/ops config repo and injected at runtime via `window.lcfs_config.feature_flags`, so the flag can be toggled per environment without a redeploy where that injection is supported.
- Since there is no consumer yet, existing search and commenting behaviour is unchanged in every environment.

## How it'll be used (follow-up)
```jsx
import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
// or: withFeatureFlag(Component, FEATURE_FLAGS.INTERNAL_COMMENT_SEARCH)
{isFeatureEnabled(FEATURE_FLAGS.INTERNAL_COMMENT_SEARCH) && <NewInternalCommentView />}
```

## Acceptance criteria
- [x] Feature flag implemented to enable/disable enhanced internal search
- [x] OFF → existing search/commenting unchanged (no consumer yet, so true in all envs)
- [x] Configurable per environment (dev/test/prod) via injected runtime config
- [x] No redeploy needed where runtime config injection is supported
- [x] No regression to commenting (no behavioural code touched)

## Verification
- `tsc --noEmit` passes (the `Record<FeatureFlagValue, boolean>` constraint enforces the key is registered in both the map and the defaults).

## Note on naming
Flag key: `internalCommentSearch`. Chosen to be unambiguous about scope (internal commenting view). Easy to rename before the follow-up ticket if a different convention is preferred.