### PR TITLE
Feat: Add comment metadata population and organization comments endpoint - 4451, 4452, 4454

### DIFF
--- a/backend/lcfs/tests/internal_comment/test_internal_comment.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import asyncio
 
 from lcfs.db.models import UserProfile
+from lcfs.db.models.organization.Organization import Organization
 from lcfs.db.models.transfer.Transfer import Transfer, TransferRecommendationEnum
 from lcfs.db.models.initiative_agreement.InitiativeAgreement import InitiativeAgreement
 from lcfs.db.models.admin_adjustment.AdminAdjustment import AdminAdjustment
@@ -345,7 +346,7 @@ async def test_get_internal_comments_multiple_comments(
 
     comments = []
     base_time = datetime.now()
-    
+
     for i in range(3):
         # Create comments with different update times to ensure ordering
         internal_comment = InternalComment(
@@ -353,7 +354,8 @@ async def test_get_internal_comments_multiple_comments(
             comment=f"Comment {i}",
             audience_scope=AudienceScopeEnum.ANALYST.value,
             create_user="IDIRUSER",
-            create_date=base_time - timedelta(seconds=i)  # Each comment has a later update_date
+            create_date=base_time
+            - timedelta(seconds=i),  # Each comment has a later update_date
         )
         await add_models([internal_comment])
         association = TransferInternalComment(
@@ -362,7 +364,7 @@ async def test_get_internal_comments_multiple_comments(
         )
         await add_models([association])
         comments.append(internal_comment)
-        
+
         # Small delay to ensure different timestamps
         await asyncio.sleep(0.001)
 
@@ -493,3 +495,268 @@ async def test_update_internal_comment_nonexistent(
     response = await client.put(url, json=update_payload)
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ======================================================================
+# Organization Comment Log endpoint
+# GET /organizations/{organization_id}/comments
+# ======================================================================
+def _make_transfer(transfer_id: int, to_org_id: int) -> Transfer:
+    """Minimal Transfer fixture so the live org derivation can find it."""
+    return Transfer(
+        transfer_id=transfer_id,
+        from_organization_id=1,
+        to_organization_id=to_org_id,
+        agreement_date=datetime.now(),
+        transaction_effective_date=datetime.now(),
+        price_per_unit=1.0,
+        quantity=100,
+        transfer_category_id=1,
+        current_status_id=1,
+        recommendation=TransferRecommendationEnum.Record,
+        effective_status=True,
+    )
+
+
+async def _seed_org_comment(
+    add_models,
+    *,
+    transfer_id: int,
+    to_org_id: int,
+    visibility: str,
+    create_user: str,
+    audience_scope: str | None = None,
+    comment: str = "<p>x</p>",
+) -> InternalComment:
+    """Seed Transfer + InternalComment + association so the live-derive
+    read path can find the comment by ``to_org_id``."""
+    transfer = _make_transfer(transfer_id, to_org_id)
+    await add_models([transfer])
+    ic = InternalComment(
+        comment=comment,
+        comment_search_text=comment,
+        visibility=visibility,
+        audience_scope=audience_scope,
+        create_user=create_user,
+    )
+    await add_models([ic])
+    await add_models(
+        [
+            TransferInternalComment(
+                transfer_id=transfer.transfer_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+    return ic
+
+
+@pytest.mark.anyio
+async def test_org_comments_idir_sees_internal_and_public(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """AC: IDIR sees Internal + Public comments for the organization."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.GOVERNMENT],
+        user_details={"keycloak_username": "IDIRUSER"},
+    )
+    await add_models(
+        [UserProfile(keycloak_username="IDIRUSER", first_name="Test", last_name="User")]
+    )
+
+    await _seed_org_comment(
+        add_models,
+        transfer_id=1001,
+        to_org_id=1,
+        visibility="Internal",
+        audience_scope=AudienceScopeEnum.ANALYST.value,
+        create_user="IDIRUSER",
+        comment="internal",
+    )
+    await _seed_org_comment(
+        add_models,
+        transfer_id=1002,
+        to_org_id=1,
+        visibility="Public",
+        create_user="IDIRUSER",
+        comment="public",
+    )
+    await _seed_org_comment(
+        add_models,
+        transfer_id=1003,
+        to_org_id=2,
+        visibility="Internal",
+        audience_scope=AudienceScopeEnum.ANALYST.value,
+        create_user="IDIRUSER",
+        comment="other",
+    )
+
+    url = fastapi_app.url_path_for("get_organization_comments", organization_id=1)
+    response = await client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["pagination"]["total"] == 2
+    visibilities = sorted(c["visibility"] for c in data["comments"])
+    assert visibilities == ["Internal", "Public"]
+
+
+@pytest.mark.anyio
+async def test_org_comments_bcid_own_org_public_only(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """AC: BCeID for own org sees only Public comments."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.SUPPLIER],
+        user_details={"keycloak_username": "BCEIDUSER", "organization_id": 1},
+    )
+    await add_models(
+        [
+            UserProfile(
+                keycloak_username="BCEIDUSER",
+                first_name="BC",
+                last_name="User",
+                organization_id=1,
+            )
+        ]
+    )
+
+    await _seed_org_comment(
+        add_models,
+        transfer_id=2001,
+        to_org_id=1,
+        visibility="Internal",
+        audience_scope=AudienceScopeEnum.ANALYST.value,
+        create_user="IDIRUSER",
+    )
+    await _seed_org_comment(
+        add_models,
+        transfer_id=2002,
+        to_org_id=1,
+        visibility="Public",
+        create_user="BCEIDUSER",
+    )
+
+    url = fastapi_app.url_path_for("get_organization_comments", organization_id=1)
+    response = await client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["pagination"]["total"] == 1
+    assert data["comments"][0]["visibility"] == "Public"
+    # canEdit true for own comment
+    assert data["comments"][0]["canEdit"] is True
+
+
+@pytest.mark.anyio
+async def test_org_comments_bcid_other_org_forbidden(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+):
+    """AC: BCeID requesting another org's log gets 403."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.SUPPLIER],
+        user_details={"keycloak_username": "BCEIDUSER", "organization_id": 1},
+    )
+    url = fastapi_app.url_path_for("get_organization_comments", organization_id=99)
+    response = await client.get(url)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_org_comments_pagination_metadata(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """AC: page=2&size=25 returns correct pagination block."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.GOVERNMENT],
+        user_details={"keycloak_username": "IDIRUSER"},
+    )
+    await add_models(
+        [UserProfile(keycloak_username="IDIRUSER", first_name="T", last_name="U")]
+    )
+
+    for i in range(30):
+        await _seed_org_comment(
+            add_models,
+            transfer_id=3000 + i,
+            to_org_id=1,
+            visibility="Internal",
+            audience_scope=AudienceScopeEnum.ANALYST.value,
+            create_user="IDIRUSER",
+            comment=f"c{i}",
+        )
+
+    url = fastapi_app.url_path_for("get_organization_comments", organization_id=1)
+    response = await client.get(url, params={"page": 2, "size": 25})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["pagination"]["page"] == 2
+    assert data["pagination"]["size"] == 25
+    assert data["pagination"]["total"] == 30
+    assert data["pagination"]["totalPages"] == 2
+    assert len(data["comments"]) == 5
+
+
+@pytest.mark.anyio
+async def test_org_comments_reflect_parent_update(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+    dbsession,
+):
+    """Live derivation: changing the parent's to_organization_id moves
+    the comment to the new org's Comment Log without any sync code."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.GOVERNMENT],
+        user_details={"keycloak_username": "IDIRUSER"},
+    )
+    await add_models(
+        [
+            UserProfile(keycloak_username="IDIRUSER", first_name="T", last_name="U"),
+            Organization(organization_id=7, name="Org Seven"),
+        ]
+    )
+
+    ic = await _seed_org_comment(
+        add_models,
+        transfer_id=4001,
+        to_org_id=1,
+        visibility="Internal",
+        audience_scope=AudienceScopeEnum.ANALYST.value,
+        create_user="IDIRUSER",
+        comment="moved",
+    )
+
+    url1 = fastapi_app.url_path_for("get_organization_comments", organization_id=1)
+    assert (await client.get(url1)).json()["pagination"]["total"] == 1
+
+    # Reassign the parent transfer to org 7 — no sync code involved.
+    from sqlalchemy import update as sa_update
+
+    await dbsession.execute(
+        sa_update(Transfer)
+        .where(Transfer.transfer_id == 4001)
+        .values(to_organization_id=7)
+    )
+    await dbsession.flush()
+
+    assert (await client.get(url1)).json()["pagination"]["total"] == 0
+    url7 = fastapi_app.url_path_for("get_organization_comments", organization_id=7)
+    body = (await client.get(url7)).json()
+    assert body["pagination"]["total"] == 1
+    assert body["comments"][0]["internalCommentId"] == ic.internal_comment_id

--- a/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
@@ -226,6 +226,11 @@ def _build_service_with_user_roles(role_names):
     service.repo.get_internal_comments = AsyncMock()
     service.repo.get_internal_comment_by_id = AsyncMock()
     service.repo.update_internal_comment = AsyncMock()
+    # Metadata helpers used by ``_populate_comment_metadata``. Tests that
+    # care about specific values can override these on the returned service.
+    service.repo.get_category_id_by_name = AsyncMock(return_value=99)
+    service.repo.get_entity_org_and_year = AsyncMock(return_value=(7, 2025))
+    service.repo.get_comments_for_organization = AsyncMock()
     return service
 
 
@@ -417,12 +422,12 @@ async def test_update_internal_comment_public_sets_audience_scope_to_none():
 
     await service.update_internal_comment(8, payload)
 
-    service.repo.update_internal_comment.assert_awaited_once_with(
-        internal_comment_id=8,
-        new_comment_text="updated",
-        visibility="Public",
-        audience_scope=None,
-    )
+    service.repo.update_internal_comment.assert_awaited_once()
+    call_kwargs = service.repo.update_internal_comment.await_args.kwargs
+    assert call_kwargs["internal_comment_id"] == 8
+    assert call_kwargs["new_comment_text"] == "updated"
+    assert call_kwargs["visibility"] == "Public"
+    assert call_kwargs["audience_scope"] is None
 
 
 @pytest.mark.anyio
@@ -451,9 +456,261 @@ async def test_update_internal_comment_internal_without_scope_defaults_to_analys
 
     await service.update_internal_comment(9, payload)
 
-    service.repo.update_internal_comment.assert_awaited_once_with(
-        internal_comment_id=9,
-        new_comment_text="updated",
-        visibility="Internal",
-        audience_scope="Analyst",
+    service.repo.update_internal_comment.assert_awaited_once()
+    call_kwargs = service.repo.update_internal_comment.await_args.kwargs
+    assert call_kwargs["internal_comment_id"] == 9
+    assert call_kwargs["new_comment_text"] == "updated"
+    assert call_kwargs["visibility"] == "Internal"
+    assert call_kwargs["audience_scope"] == "Analyst"
+
+
+# ======================================================================
+# Comment Log metadata helper (`_populate_comment_metadata`)
+# ======================================================================
+from lcfs.web.api.internal_comment.services import (
+    DEFAULT_CATEGORY_BY_ENTITY,
+    sanitize_comment_text,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
+
+
+def test_sanitize_comment_text_strips_html_and_collapses_whitespace():
+    assert sanitize_comment_text(None) == ""
+    assert sanitize_comment_text("") == ""
+    assert sanitize_comment_text("<p>Hello <b>world</b></p>") == "Hello world"
+    assert sanitize_comment_text("<p>a</p>\n<p>b   c</p>") == "a b c"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "entity_type,expected_category",
+    [
+        (EntityTypeEnum.COMPLIANCE_REPORT, "Compliance notes"),
+        (EntityTypeEnum.TRANSFER, "Transfer notes"),
+        (EntityTypeEnum.INITIATIVE_AGREEMENT, "IA notes"),
+        (EntityTypeEnum.ADMIN_ADJUSTMENT, "Penalty notes"),
+        (EntityTypeEnum.CI_APPLICATION, "CI application notes"),
+    ],
+)
+async def test_populate_comment_metadata_default_category_per_entity_type(
+    entity_type, expected_category
+):
+    """
+    The helper must apply the agreed default category for every supported
+    entity type when the caller does not pass an explicit override.
+    """
+    assert DEFAULT_CATEGORY_BY_ENTITY[entity_type] == expected_category
+
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_entity_org_and_year.return_value = (42, 2025)
+    service.repo.get_category_id_by_name.return_value = 11
+
+    comment = InternalComment(comment="<p>hello</p>")
+    await service._populate_comment_metadata(
+        comment,
+        entity_type=entity_type,
+        entity_id=123,
+        category_display_name=None,
     )
+
+    service.repo.get_category_id_by_name.assert_awaited_once_with(expected_category)
+    service.repo.get_entity_org_and_year.assert_awaited_once_with(entity_type, 123)
+    assert comment.organization_id == 42
+    # compliance_year is only meaningful for compliance reports; the fake
+    # returns 2025 for all but the assertion is on the helper wiring.
+    assert comment.compliance_year == 2025
+    assert comment.comment_category_id == 11
+    assert comment.comment_search_text == "hello"
+    assert comment.comment_search_vector is not None  # SQL expression
+
+
+@pytest.mark.anyio
+async def test_populate_comment_metadata_explicit_category_wins():
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_category_id_by_name.return_value = 77
+
+    comment = InternalComment(comment="<p>x</p>")
+    await service._populate_comment_metadata(
+        comment,
+        entity_type=EntityTypeEnum.TRANSFER,
+        entity_id=1,
+        category_display_name="Organization details",
+    )
+
+    service.repo.get_category_id_by_name.assert_awaited_once_with(
+        "Organization details"
+    )
+    assert comment.comment_category_id == 77
+
+
+@pytest.mark.anyio
+async def test_create_internal_comment_populates_all_metadata():
+    """AC: All five metadata columns are populated on create."""
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_entity_org_and_year.return_value = (3, 2024)
+    service.repo.get_category_id_by_name.return_value = 5
+    service.repo.create_internal_comment.return_value = SimpleNamespace(
+        internal_comment_id=1,
+        comment="<p>hi</p>",
+        audience_scope="Analyst",
+        visibility="Internal",
+        create_user="mockuser",
+        create_date=None,
+        update_date=None,
+        full_name="Mock User",
+    )
+
+    payload = InternalCommentCreateSchema(
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT,
+        entity_id=10,
+        comment="<p>hi</p>",
+        visibility=CommentVisibilityEnum.INTERNAL,
+    )
+    await service.create_internal_comment(payload)
+
+    created = service.repo.create_internal_comment.await_args.args[0]
+    assert created.organization_id == 3
+    assert created.compliance_year == 2024
+    assert created.comment_category_id == 5
+    assert created.comment_search_text == "hi"
+    assert created.comment_search_vector is not None
+
+
+@pytest.mark.anyio
+async def test_update_internal_comment_refreshes_search_text_and_vector():
+    """AC: search_text and search_vector are refreshed on edit."""
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_internal_comment_by_id.return_value = SimpleNamespace(
+        internal_comment_id=5,
+        comment="<p>old</p>",
+        audience_scope="Analyst",
+        visibility="Internal",
+    )
+    service.repo.update_internal_comment.return_value = SimpleNamespace(
+        internal_comment_id=5,
+        comment="<p>new</p>",
+        audience_scope="Analyst",
+        visibility="Internal",
+        create_user="mockuser",
+        create_date=None,
+        update_date=None,
+        full_name="Mock User",
+    )
+
+    await service.update_internal_comment(
+        5,
+        InternalCommentUpdateSchema(comment="<p>new <b>edited</b></p>"),
+    )
+
+    call_kwargs = service.repo.update_internal_comment.await_args.kwargs
+    assert call_kwargs["comment_search_text"] == "new edited"
+    assert call_kwargs["comment_search_vector"] is not None
+
+
+# ======================================================================
+# Organization Comment Log read view
+# ======================================================================
+@pytest.mark.anyio
+async def test_get_organization_comments_bcid_other_org_forbidden():
+    """AC: BCeID requesting another org's log gets 403."""
+    service = _build_service_with_user_roles([RoleEnum.SUPPLIER])
+    service.request.user = SimpleNamespace(
+        role_names=[RoleEnum.SUPPLIER],
+        keycloak_username="bceid-user",
+        organization=SimpleNamespace(organization_id=10),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.get_organization_comments(organization_id=99)
+    assert exc.value.status_code == 403
+    service.repo.get_comments_for_organization.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_organization_comments_bcid_own_org_public_only():
+    """AC: BCeID for own org only sees Public comments."""
+    service = _build_service_with_user_roles([RoleEnum.SUPPLIER])
+    service.request.user = SimpleNamespace(
+        role_names=[RoleEnum.SUPPLIER],
+        keycloak_username="bceid-user",
+        organization=SimpleNamespace(organization_id=10),
+    )
+    service.repo.get_comments_for_organization.return_value = ([], 0)
+
+    await service.get_organization_comments(organization_id=10)
+
+    service.repo.get_comments_for_organization.assert_awaited_once_with(
+        organization_id=10, page=1, size=25, visibility_filter="Public"
+    )
+
+
+@pytest.mark.anyio
+async def test_get_organization_comments_idir_sees_internal_and_public():
+    """AC: IDIR sees Internal + Public (no visibility filter)."""
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_comments_for_organization.return_value = ([], 0)
+
+    await service.get_organization_comments(organization_id=10, page=2, size=25)
+
+    service.repo.get_comments_for_organization.assert_awaited_once_with(
+        organization_id=10, page=2, size=25, visibility_filter=None
+    )
+
+
+@pytest.mark.anyio
+async def test_get_organization_comments_pagination_metadata():
+    """AC: page/size/total/totalPages reflect the request and result count."""
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    sample_row = {
+        "internal_comment_id": 1,
+        "comment": "<p>x</p>",
+        "plain_text_comment": "x",
+        "organization_id": 5,
+        "organization_name": "Org",
+        "compliance_year": 2025,
+        "visibility": "Internal",
+        "audience_scope": "Analyst",
+        "create_user": "mockuser",
+        "create_date": None,
+        "update_date": None,
+        "category": "Compliance notes",
+        "full_name": "Mock User",
+        "entity_type": "complianceReport",
+        "entity_id": 42,
+    }
+    service.repo.get_comments_for_organization.return_value = ([sample_row], 51)
+
+    result = await service.get_organization_comments(organization_id=5, page=2, size=25)
+    assert result.pagination.page == 2
+    assert result.pagination.size == 25
+    assert result.pagination.total == 51
+    assert result.pagination.total_pages == 3
+    assert len(result.comments) == 1
+    # canEdit true when the requesting user created the comment.
+    assert result.comments[0].can_edit is True
+
+
+@pytest.mark.anyio
+async def test_get_organization_comments_can_edit_false_for_other_user():
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    row = {
+        "internal_comment_id": 2,
+        "comment": "x",
+        "plain_text_comment": "x",
+        "organization_id": 5,
+        "organization_name": "Org",
+        "compliance_year": 2025,
+        "visibility": "Internal",
+        "audience_scope": "Analyst",
+        "create_user": "someone-else",
+        "create_date": None,
+        "update_date": None,
+        "category": "Compliance notes",
+        "full_name": "Other User",
+        "entity_type": "complianceReport",
+        "entity_id": 1,
+    }
+    service.repo.get_comments_for_organization.return_value = ([row], 1)
+
+    result = await service.get_organization_comments(organization_id=5)
+    assert result.comments[0].can_edit is False

--- a/backend/lcfs/web/api/internal_comment/__init__.py
+++ b/backend/lcfs/web/api/internal_comment/__init__.py
@@ -1,5 +1,5 @@
 """API for internal comments."""
 
-from lcfs.web.api.internal_comment.views import router
+from lcfs.web.api.internal_comment.views import router, org_comments_router
 
-__all__ = ["router"]
+__all__ = ["router", "org_comments_router"]

--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -1,10 +1,11 @@
 from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
 import structlog
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import asc, select, desc
+import sqlalchemy as sa
+from sqlalchemy import asc, case, desc, func, select
 
 from lcfs.web.exception.exceptions import DataNotFoundException
 from lcfs.db.dependencies import get_async_db_session
@@ -13,6 +14,16 @@ from lcfs.web.core.decorators import repo_handler
 from lcfs.web.api.user.repo import UserRepository
 from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.comment.CommentCategory import CommentCategory
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.compliance.ComplianceReport import ComplianceReport
+from lcfs.db.models.compliance.CompliancePeriod import CompliancePeriod
+from lcfs.db.models.transfer.Transfer import Transfer
+from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
+    InitiativeAgreement,
+)
+from lcfs.db.models.admin_adjustment.AdminAdjustment import AdminAdjustment
+from lcfs.db.models.ci_application.CIApplication import CIApplication
 from lcfs.web.api.internal_comment.schema import EntityTypeEnum
 from lcfs.db.models.comment.TransferInternalComment import TransferInternalComment
 from lcfs.db.models.comment.InitiativeAgreementInternalComment import (
@@ -27,7 +38,6 @@ from lcfs.db.models.comment.ComplianceReportInternalComment import (
 from lcfs.db.models.comment.CIApplicationInternalComment import (
     CIApplicationInternalComment,
 )
-
 
 logger = structlog.get_logger(__name__)
 
@@ -116,7 +126,10 @@ class InternalCommentRepository:
 
     @repo_handler
     async def get_internal_comments(
-        self, entity_type: EntityTypeEnum, entity_id: int, visibility_filter: Optional[str] = None
+        self,
+        entity_type: EntityTypeEnum,
+        entity_id: int,
+        visibility_filter: Optional[str] = None,
     ) -> List[dict]:
         """
         Retrieves a list of internal comments associated with a specific entity,
@@ -256,6 +269,9 @@ class InternalCommentRepository:
         new_comment_text: Optional[str] = None,
         visibility: Optional[str] = None,
         audience_scope: Optional[str] = None,
+        comment_category_id: Optional[int] = None,
+        comment_search_text: Optional[str] = None,
+        comment_search_vector=None,
     ) -> InternalComment:
         """
         Updates the text of an existing internal comment.
@@ -265,6 +281,9 @@ class InternalCommentRepository:
             new_comment_text (str, optional): The new text for the comment.
             visibility (str, optional): The visibility for the comment.
             audience_scope (str, optional): The audience scope for the comment.
+            comment_category_id (int, optional): New category FK if changed.
+            comment_search_text (str, optional): Refreshed sanitized text.
+            comment_search_vector: SQL expression / value for the tsvector.
 
         Returns:
             InternalComment: The updated internal comment object.
@@ -291,6 +310,12 @@ class InternalCommentRepository:
             internal_comment.audience_scope = audience_scope
         elif visibility is not None and str(visibility) == "Public":
             internal_comment.audience_scope = None
+        if comment_category_id is not None:
+            internal_comment.comment_category_id = comment_category_id
+        if comment_search_text is not None:
+            internal_comment.comment_search_text = comment_search_text
+        if comment_search_vector is not None:
+            internal_comment.comment_search_vector = comment_search_vector
         await self.db.flush()
         await self.db.refresh(internal_comment)
 
@@ -344,3 +369,272 @@ class InternalCommentRepository:
         )
         result = await self.db.execute(query)
         return [row[0] for row in result.all()]
+
+    @repo_handler
+    async def get_category_id_by_name(self, display_name: str) -> Optional[int]:
+        """Look up a ``comment_category`` row id by display name."""
+        if not display_name:
+            return None
+        result = await self.db.execute(
+            select(CommentCategory.comment_category_id).where(
+                CommentCategory.display_name == display_name
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @repo_handler
+    async def get_entity_org_and_year(
+        self, entity_type: EntityTypeEnum, entity_id: int
+    ) -> Tuple[Optional[int], Optional[int]]:
+        """
+        Derive (organization_id, compliance_year) for a source entity.
+        """
+        if entity_type == EntityTypeEnum.COMPLIANCE_REPORT:
+            stmt = (
+                select(ComplianceReport.organization_id, CompliancePeriod.description)
+                .join(
+                    CompliancePeriod,
+                    CompliancePeriod.compliance_period_id
+                    == ComplianceReport.compliance_period_id,
+                )
+                .where(ComplianceReport.compliance_report_id == entity_id)
+            )
+            row = (await self.db.execute(stmt)).first()
+            if row is None:
+                return (None, None)
+            org_id, period_desc = row
+            try:
+                year = int(period_desc) if period_desc else None
+            except (TypeError, ValueError):
+                year = None
+            return (org_id, year)
+
+        if entity_type == EntityTypeEnum.TRANSFER:
+            stmt = select(Transfer.to_organization_id).where(
+                Transfer.transfer_id == entity_id
+            )
+        elif entity_type == EntityTypeEnum.INITIATIVE_AGREEMENT:
+            stmt = select(InitiativeAgreement.to_organization_id).where(
+                InitiativeAgreement.initiative_agreement_id == entity_id
+            )
+        elif entity_type == EntityTypeEnum.ADMIN_ADJUSTMENT:
+            stmt = select(AdminAdjustment.to_organization_id).where(
+                AdminAdjustment.admin_adjustment_id == entity_id
+            )
+        elif entity_type == EntityTypeEnum.CI_APPLICATION:
+            stmt = select(CIApplication.organization_id).where(
+                CIApplication.ci_application_id == entity_id
+            )
+        else:
+            return (None, None)
+
+        org_id = (await self.db.execute(stmt)).scalar_one_or_none()
+        return (org_id, None)
+
+    def _entity_meta_subquery(self):
+        """
+        Per ``internal_comment_id``, choose one (entity_type, entity_id,
+        live_org_id, live_year) tuple via ``DISTINCT ON``.
+        """
+        # CompliancePeriod.description is a varchar; safely cast numeric
+        # values to integer, NULL otherwise.
+        cp_year = case(
+            (
+                CompliancePeriod.description.op("~")("^[0-9]+$"),
+                func.cast(CompliancePeriod.description, sa.Integer),
+            ),
+            else_=None,
+        )
+        return (
+            select(
+                InternalComment.internal_comment_id.label("ic_id"),
+                case(
+                    (
+                        TransferInternalComment.transfer_id.isnot(None),
+                        EntityTypeEnum.TRANSFER.value,
+                    ),
+                    (
+                        InitiativeAgreementInternalComment.initiative_agreement_id.isnot(
+                            None
+                        ),
+                        EntityTypeEnum.INITIATIVE_AGREEMENT.value,
+                    ),
+                    (
+                        AdminAdjustmentInternalComment.admin_adjustment_id.isnot(None),
+                        EntityTypeEnum.ADMIN_ADJUSTMENT.value,
+                    ),
+                    (
+                        ComplianceReportInternalComment.compliance_report_id.isnot(
+                            None
+                        ),
+                        EntityTypeEnum.COMPLIANCE_REPORT.value,
+                    ),
+                    (
+                        CIApplicationInternalComment.ci_application_id.isnot(None),
+                        EntityTypeEnum.CI_APPLICATION.value,
+                    ),
+                    else_=None,
+                ).label("entity_type"),
+                func.coalesce(
+                    TransferInternalComment.transfer_id,
+                    InitiativeAgreementInternalComment.initiative_agreement_id,
+                    AdminAdjustmentInternalComment.admin_adjustment_id,
+                    ComplianceReportInternalComment.compliance_report_id,
+                    CIApplicationInternalComment.ci_application_id,
+                ).label("entity_id"),
+                func.coalesce(
+                    Transfer.to_organization_id,
+                    InitiativeAgreement.to_organization_id,
+                    AdminAdjustment.to_organization_id,
+                    ComplianceReport.organization_id,
+                    CIApplication.organization_id,
+                ).label("live_org_id"),
+                cp_year.label("live_year"),
+            )
+            .outerjoin(
+                TransferInternalComment,
+                TransferInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                Transfer,
+                Transfer.transfer_id == TransferInternalComment.transfer_id,
+            )
+            .outerjoin(
+                InitiativeAgreementInternalComment,
+                InitiativeAgreementInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                InitiativeAgreement,
+                InitiativeAgreement.initiative_agreement_id
+                == InitiativeAgreementInternalComment.initiative_agreement_id,
+            )
+            .outerjoin(
+                AdminAdjustmentInternalComment,
+                AdminAdjustmentInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                AdminAdjustment,
+                AdminAdjustment.admin_adjustment_id
+                == AdminAdjustmentInternalComment.admin_adjustment_id,
+            )
+            .outerjoin(
+                ComplianceReportInternalComment,
+                ComplianceReportInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                ComplianceReport,
+                ComplianceReport.compliance_report_id
+                == ComplianceReportInternalComment.compliance_report_id,
+            )
+            .outerjoin(
+                CompliancePeriod,
+                CompliancePeriod.compliance_period_id
+                == ComplianceReport.compliance_period_id,
+            )
+            .outerjoin(
+                CIApplicationInternalComment,
+                CIApplicationInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                CIApplication,
+                CIApplication.ci_application_id
+                == CIApplicationInternalComment.ci_application_id,
+            )
+            .distinct(InternalComment.internal_comment_id)
+            .order_by(InternalComment.internal_comment_id)
+            .subquery()
+        )
+
+    @repo_handler
+    async def get_comments_for_organization(
+        self,
+        organization_id: int,
+        page: int,
+        size: int,
+        visibility_filter: Optional[str] = None,
+    ) -> Tuple[List[dict], int]:
+        """
+        Paginated list of comments scoped to ``organization_id``, with the
+        organization and compliance year **derived live** from the source
+        parent entity (so parent updates are reflected immediately).
+        Returns ``(records, total)``.
+        """
+        entity_meta = self._entity_meta_subquery()
+
+        where_clauses = [entity_meta.c.live_org_id == organization_id]
+        if visibility_filter:
+            where_clauses.append(InternalComment.visibility == visibility_filter)
+
+        total = (
+            await self.db.execute(
+                select(func.count(InternalComment.internal_comment_id))
+                .select_from(InternalComment)
+                .join(
+                    entity_meta,
+                    entity_meta.c.ic_id == InternalComment.internal_comment_id,
+                )
+                .where(*where_clauses)
+            )
+        ).scalar_one()
+
+        if total == 0:
+            return ([], 0)
+
+        full_name_col = (UserProfile.first_name + " " + UserProfile.last_name).label(
+            "full_name"
+        )
+
+        offset = max(page - 1, 0) * max(size, 1)
+
+        query = (
+            select(
+                InternalComment.internal_comment_id,
+                InternalComment.comment,
+                InternalComment.comment_search_text.label("plain_text_comment"),
+                entity_meta.c.live_org_id.label("organization_id"),
+                entity_meta.c.live_year.label("compliance_year"),
+                InternalComment.visibility,
+                InternalComment.audience_scope,
+                InternalComment.create_user,
+                InternalComment.create_date,
+                InternalComment.update_date,
+                Organization.name.label("organization_name"),
+                CommentCategory.display_name.label("category"),
+                full_name_col,
+                entity_meta.c.entity_type,
+                entity_meta.c.entity_id,
+            )
+            .select_from(InternalComment)
+            .join(
+                entity_meta,
+                entity_meta.c.ic_id == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                Organization,
+                Organization.organization_id == entity_meta.c.live_org_id,
+            )
+            .outerjoin(
+                CommentCategory,
+                CommentCategory.comment_category_id
+                == InternalComment.comment_category_id,
+            )
+            .outerjoin(
+                UserProfile,
+                UserProfile.keycloak_username == InternalComment.create_user,
+            )
+            .where(*where_clauses)
+            .order_by(
+                desc(InternalComment.create_date),
+                desc(InternalComment.internal_comment_id),
+            )
+            .limit(size)
+            .offset(offset)
+        )
+
+        rows = (await self.db.execute(query)).mappings().all()
+        return ([dict(r) for r in rows], int(total))

--- a/backend/lcfs/web/api/internal_comment/schema.py
+++ b/backend/lcfs/web/api/internal_comment/schema.py
@@ -40,12 +40,14 @@ class InternalCommentCreateSchema(BaseSchema):
     comment: str
     audience_scope: Optional[AudienceScopeEnum] = None
     visibility: CommentVisibilityEnum = CommentVisibilityEnum.INTERNAL
+    comment_category: Optional[str] = None
 
 
 class InternalCommentUpdateSchema(BaseSchema):
     comment: Optional[str] = None
     audience_scope: Optional[AudienceScopeEnum] = None
     visibility: Optional[CommentVisibilityEnum] = None
+    comment_category: Optional[str] = None
 
 
 class InternalCommentResponseSchema(BaseSchema):
@@ -57,3 +59,34 @@ class InternalCommentResponseSchema(BaseSchema):
     create_date: Optional[datetime] = None
     update_date: Optional[datetime] = None
     full_name: Optional[str] = None
+
+
+class OrganizationCommentRecordSchema(BaseSchema):
+    internal_comment_id: int
+    comment: Optional[str] = None
+    plain_text_comment: Optional[str] = None
+    entity_type: Optional[str] = None
+    entity_id: Optional[int] = None
+    category: Optional[str] = None
+    compliance_year: Optional[int] = None
+    organization_id: Optional[int] = None
+    organization_name: Optional[str] = None
+    visibility: Optional[CommentVisibilityEnum] = None
+    audience_scope: Optional[AudienceScopeEnum] = None
+    create_user: Optional[str] = None
+    full_name: Optional[str] = None
+    create_date: Optional[datetime] = None
+    update_date: Optional[datetime] = None
+    can_edit: bool = False
+
+
+class OrganizationCommentsPaginationSchema(BaseSchema):
+    page: int
+    size: int
+    total: int
+    total_pages: int
+
+
+class OrganizationCommentsResponseSchema(BaseSchema):
+    comments: list[OrganizationCommentRecordSchema]
+    pagination: OrganizationCommentsPaginationSchema

--- a/backend/lcfs/web/api/internal_comment/services.py
+++ b/backend/lcfs/web/api/internal_comment/services.py
@@ -1,7 +1,10 @@
+import re
 import structlog
+from math import ceil
 from typing import List, Optional
 
 from fastapi import Depends, Request, HTTPException
+from sqlalchemy import func
 
 from lcfs.web.core.decorators import service_handler
 from lcfs.db.models.user.Role import RoleEnum
@@ -17,10 +20,34 @@ from .schema import (
     InternalCommentUpdateSchema,
     InternalCommentResponseSchema,
     EntityTypeEnum,
+    OrganizationCommentRecordSchema,
+    OrganizationCommentsPaginationSchema,
+    OrganizationCommentsResponseSchema,
 )
 
-
 logger = structlog.get_logger(__name__)
+
+
+DEFAULT_CATEGORY_BY_ENTITY: dict[EntityTypeEnum, str] = {
+    EntityTypeEnum.COMPLIANCE_REPORT: "Compliance notes",
+    EntityTypeEnum.TRANSFER: "Transfer notes",
+    EntityTypeEnum.INITIATIVE_AGREEMENT: "IA notes",
+    EntityTypeEnum.ADMIN_ADJUSTMENT: "Penalty notes",
+    EntityTypeEnum.CI_APPLICATION: "CI application notes",
+}
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]*>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def sanitize_comment_text(html: Optional[str]) -> str:
+    """Strip HTML tags and collapse whitespace. Matches the SQL backfill."""
+    if not html:
+        return ""
+    text = _HTML_TAG_RE.sub(" ", html)
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip()
 
 
 class InternalCommentService:
@@ -46,6 +73,46 @@ class InternalCommentService:
 
     def _is_government_user(self) -> bool:
         return RoleEnum.GOVERNMENT in self.request.user.role_names
+
+    async def _populate_comment_metadata(
+        self,
+        comment: InternalComment,
+        entity_type: Optional[EntityTypeEnum],
+        entity_id: Optional[int],
+        category_display_name: Optional[str] = None,
+    ) -> InternalComment:
+        """
+        Single source of truth for the Comment Log denormalized columns:
+        ``organization_id``, ``compliance_year``, ``comment_category_id``,
+        ``comment_search_text``, and ``comment_search_vector``.
+        """
+        # 1. Search text + tsvector (always refreshed when comment text set).
+        if comment.comment is not None:
+            search_text = sanitize_comment_text(comment.comment)
+            comment.comment_search_text = search_text
+            comment.comment_search_vector = func.to_tsvector("english", search_text)
+
+        # 2. organization_id / compliance_year derived from the source entity.
+        if entity_type is not None and entity_id is not None:
+            org_id, year = await self.repo.get_entity_org_and_year(
+                entity_type, entity_id
+            )
+            if org_id is not None:
+                comment.organization_id = org_id
+            if year is not None:
+                comment.compliance_year = year
+
+        # 3. comment_category_id — explicit override wins, else fall back to
+        #    the agreed default for the entity type.
+        category_name = category_display_name
+        if not category_name and entity_type is not None:
+            category_name = DEFAULT_CATEGORY_BY_ENTITY.get(entity_type)
+        if category_name:
+            category_id = await self.repo.get_category_id_by_name(category_name)
+            if category_id is not None:
+                comment.comment_category_id = category_id
+
+        return comment
 
     def _get_audience_scope_for_user(self) -> Optional[AudienceScopeEnum]:
         role_names = self.request.user.role_names
@@ -101,6 +168,12 @@ class InternalCommentService:
             audience_scope=data.audience_scope,
             visibility=data.visibility,
             create_user=username,
+        )
+        await self._populate_comment_metadata(
+            comment,
+            entity_type=data.entity_type,
+            entity_id=data.entity_id,
+            category_display_name=data.comment_category,
         )
         created_comment = await self.repo.create_internal_comment(
             comment, data.entity_type, data.entity_id
@@ -173,7 +246,9 @@ class InternalCommentService:
         """
         is_government_user = self._is_government_user()
 
-        existing_comment = await self.repo.get_internal_comment_by_id(internal_comment_id)
+        existing_comment = await self.repo.get_internal_comment_by_id(
+            internal_comment_id
+        )
 
         current_visibility = existing_comment.visibility
         if not isinstance(current_visibility, CommentVisibilityEnum):
@@ -212,6 +287,17 @@ class InternalCommentService:
                     detail="audience_scope is required for internal comments.",
                 )
 
+        refresh_text = (
+            data.comment if data.comment is not None else existing_comment.comment
+        )
+        transient = InternalComment(comment=refresh_text)
+        await self._populate_comment_metadata(
+            transient,
+            entity_type=None,
+            entity_id=None,
+            category_display_name=data.comment_category,
+        )
+
         updated_comment = await self.repo.update_internal_comment(
             internal_comment_id=internal_comment_id,
             new_comment_text=data.comment,
@@ -219,6 +305,9 @@ class InternalCommentService:
             audience_scope=(
                 next_audience_scope.value if next_audience_scope is not None else None
             ),
+            comment_category_id=transient.comment_category_id,
+            comment_search_text=transient.comment_search_text,
+            comment_search_vector=transient.comment_search_vector,
         )
         return InternalCommentResponseSchema.model_validate(updated_comment)
 
@@ -261,3 +350,83 @@ class InternalCommentService:
                 error=str(e),
             )
             raise
+
+    @service_handler
+    async def get_organization_comments(
+        self,
+        organization_id: int,
+        page: int = 1,
+        size: int = 25,
+    ) -> OrganizationCommentsResponseSchema:
+        """
+        Paginated organization-scoped Comment Log feed.
+
+        RBAC:
+        - IDIR / government: sees both ``Internal`` and ``Public`` comments
+          for any organization.
+        - BCeID: may only access their own organization; sees ``Public``
+          comments only.
+        """
+        # --- Authorization -------------------------------------------
+        is_government_user = self._is_government_user()
+        current_user = self.request.user
+
+        if not is_government_user:
+            user_org = getattr(current_user, "organization", None)
+            user_org_id = (
+                getattr(user_org, "organization_id", None)
+                if user_org is not None
+                else getattr(current_user, "organization_id", None)
+            )
+            if user_org_id is None or user_org_id != organization_id:
+                raise HTTPException(status_code=403, detail="Forbidden resource")
+            visibility_filter: Optional[str] = CommentVisibilityEnum.PUBLIC.value
+        else:
+            visibility_filter = None
+
+        # --- Pagination bounds ---------------------------------------
+        page = page if page and page >= 1 else 1
+        size = size if size and size >= 1 else 25
+        if size > 100:
+            size = 100
+
+        rows, total = await self.repo.get_comments_for_organization(
+            organization_id=organization_id,
+            page=page,
+            size=size,
+            visibility_filter=visibility_filter,
+        )
+
+        username = getattr(current_user, "keycloak_username", None)
+        records = [
+            OrganizationCommentRecordSchema(
+                internal_comment_id=row["internal_comment_id"],
+                comment=row["comment"],
+                plain_text_comment=row["plain_text_comment"],
+                entity_type=row["entity_type"],
+                entity_id=row["entity_id"],
+                category=row["category"],
+                compliance_year=row["compliance_year"],
+                organization_id=row["organization_id"],
+                organization_name=row["organization_name"],
+                visibility=row["visibility"],
+                audience_scope=row["audience_scope"],
+                create_user=row["create_user"],
+                full_name=row["full_name"],
+                create_date=row["create_date"],
+                update_date=row["update_date"],
+                can_edit=bool(username is not None and row["create_user"] == username),
+            )
+            for row in rows
+        ]
+
+        total_pages = ceil(total / size) if total and size else 0
+        return OrganizationCommentsResponseSchema(
+            comments=records,
+            pagination=OrganizationCommentsPaginationSchema(
+                page=page,
+                size=size,
+                total=total,
+                total_pages=total_pages,
+            ),
+        )

--- a/backend/lcfs/web/api/internal_comment/views.py
+++ b/backend/lcfs/web/api/internal_comment/views.py
@@ -1,7 +1,7 @@
 import structlog
 from typing import List
 
-from fastapi import APIRouter, Body, Depends, status, Request, HTTPException
+from fastapi import APIRouter, Body, Depends, Query, status, Request, HTTPException
 
 from lcfs.db import dependencies
 from lcfs.web.core.decorators import view_handler
@@ -11,13 +11,46 @@ from .schema import (
     InternalCommentCreateSchema,
     InternalCommentUpdateSchema,
     InternalCommentResponseSchema,
+    OrganizationCommentsResponseSchema,
 )
 from lcfs.db.models.user.Role import RoleEnum
 
-
 logger = structlog.get_logger(__name__)
 router = APIRouter()
+org_comments_router = APIRouter()
 get_async_db = dependencies.get_async_db_session
+
+
+@org_comments_router.get(
+    "/{organization_id}/comments",
+    response_model=OrganizationCommentsResponseSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.GOVERNMENT, RoleEnum.SUPPLIER])
+async def get_organization_comments(
+    request: Request,
+    organization_id: int,
+    page: int = Query(1, ge=1),
+    size: int = Query(25, ge=1, le=100),
+    service: InternalCommentService = Depends(),
+):
+    """
+    Organization-scoped Comment Log feed (mounted in ``lcfs.web.api.router``
+    at ``/organizations``).
+
+    Returns all internal comments for the organization, regardless of
+    source entity type, paginated.
+
+    Visibility:
+    - IDIR / government users: ``Internal`` + ``Public``.
+    - BCeID users: ``Public`` only, and only for their own organization
+      (otherwise the service returns ``403``).
+    """
+    return await service.get_organization_comments(
+        organization_id=organization_id,
+        page=page,
+        size=size,
+    )
 
 
 @router.post(
@@ -104,6 +137,4 @@ async def update_comment(
             status_code=403, detail="User is not the creator of the comment."
         )
 
-    return await service.update_internal_comment(
-        internal_comment_id, comment_data
-    )
+    return await service.update_internal_comment(internal_comment_id, comment_data)

--- a/backend/lcfs/web/api/organizations/views.py
+++ b/backend/lcfs/web/api/organizations/views.py
@@ -52,7 +52,6 @@ from .schema import (
 )
 from lcfs.db.models.user.Role import RoleEnum
 
-
 logger = structlog.get_logger(__name__)
 router = APIRouter()
 get_async_db = dependencies.get_async_db_session
@@ -199,8 +198,7 @@ async def get_penalty_analytics(
     """
     user = request.user
     if not user.is_government and (
-        not user.organization
-        or user.organization.organization_id != organization_id
+        not user.organization or user.organization.organization_id != organization_id
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -224,8 +222,7 @@ async def get_penalty_logs(
     """Fetch paginated penalty log entries for an organization."""
     user = request.user
     if not user.is_government and (
-        not user.organization
-        or user.organization.organization_id != organization_id
+        not user.organization or user.organization.organization_id != organization_id
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/lcfs/web/api/router.py
+++ b/backend/lcfs/web/api/router.py
@@ -73,6 +73,11 @@ api_router.include_router(
 api_router.include_router(
     internal_comment.router, prefix="/internal_comments", tags=["internal_comments"]
 )
+api_router.include_router(
+    internal_comment.org_comments_router,
+    prefix="/organizations",
+    tags=["internal_comments"],
+)
 api_router.include_router(fuel_code.router, prefix="/fuel-codes", tags=["fuel-codes"])
 api_router.include_router(
     ci_application.router, prefix="/ci-applications", tags=["ci_applications"]


### PR DESCRIPTION
This PR adds comment metadata population and the organization comments endpoint.

- Populate comment metadata on save
- Refresh search metadata on edit
- Add organization comments endpoint
- Support pagination and canEdit
- Enforce IDIR and BCeID access

Closes #4451
Closes #4452
Closes #4454