### PR TITLE
fix: FSE legacy-year guard + period-aware decommission checks (cherry-pick #4494) [prod/main]

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -397,9 +397,9 @@ jobs:
         uses: actions/cache@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-node-modules-v2-
 
       - name: Install frontend dependencies
         run: |
@@ -414,12 +414,15 @@ jobs:
       #     wait $TYPE_CHECK_PID
 
       - name: Cache node_modules for test shards
-        uses: actions/cache@v5.0.4
+        # Save-only on purpose. Restoring here (via restore-keys) could pull a
+        # cache built for a different lockfile and overwrite the node_modules we
+        # just installed with `npm ci`, making the shards run a mismatched
+        # dependency version (e.g. a stale Vitest). The `-v2-` salt bypasses
+        # previously poisoned caches.
+        uses: actions/cache/save@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Mark setup as complete
         id: setup-complete
@@ -482,13 +485,13 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-restore
-        uses: actions/cache@v5.0.4
+        # Restore-only with an exact (salted) key: only reuse a cache built for
+        # this exact lockfile. No restore-keys, so a stale cache can never be
+        # partially restored; on a miss the fallback step below runs `npm ci`.
+        uses: actions/cache/restore@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
-            ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install frontend dependencies (fallback)
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/prod-ci.yaml
+++ b/.github/workflows/prod-ci.yaml
@@ -368,9 +368,9 @@ jobs:
         uses: actions/cache@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-node-modules-v2-
 
       - name: Install frontend dependencies
         run: |
@@ -385,12 +385,15 @@ jobs:
       #     wait $TYPE_CHECK_PID
 
       - name: Cache node_modules for test shards
-        uses: actions/cache@v5.0.4
+        # Save-only on purpose. Restoring here (via restore-keys) could pull a
+        # cache built for a different lockfile and overwrite the node_modules we
+        # just installed with `npm ci`, making the shards run a mismatched
+        # dependency version (e.g. a stale Vitest). The `-v2-` salt bypasses
+        # previously poisoned caches.
+        uses: actions/cache/save@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Mark setup as complete
         id: setup-complete
@@ -452,13 +455,13 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-restore
-        uses: actions/cache@v5.0.4
+        # Restore-only with an exact (salted) key: only reuse a cache built for
+        # this exact lockfile. No restore-keys, so a stale cache can never be
+        # partially restored; on a miss the fallback step below runs `npm ci`.
+        uses: actions/cache/restore@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
-            ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install frontend dependencies (fallback)
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-ci.yaml
+++ b/.github/workflows/test-ci.yaml
@@ -366,9 +366,9 @@ jobs:
         uses: actions/cache@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-node-modules-v2-
 
       - name: Install frontend dependencies
         run: |
@@ -381,12 +381,15 @@ jobs:
       #     npm run type-check
 
       - name: Cache node_modules for test shards
-        uses: actions/cache@v5.0.4
+        # Save-only on purpose. Restoring here (via restore-keys) could pull a
+        # cache built for a different lockfile and overwrite the node_modules we
+        # just installed with `npm ci`, making the shards run a mismatched
+        # dependency version (e.g. a stale Vitest). The `-v2-` salt bypasses
+        # previously poisoned caches.
+        uses: actions/cache/save@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Mark setup as complete
         id: setup-complete
@@ -448,13 +451,13 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-restore
-        uses: actions/cache@v5.0.4
+        # Restore-only with an exact (salted) key: only reuse a cache built for
+        # this exact lockfile. No restore-keys, so a stale cache can never be
+        # partially restored; on a miss the fallback step below runs `npm ci`.
+        uses: actions/cache/restore@v5.0.4
         with:
           path: frontend/node_modules
-          key: ${{ runner.os }}-node-modules-shared-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-shared-
-            ${{ runner.os }}-node-modules-
+          key: ${{ runner.os }}-node-modules-shared-v2-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install frontend dependencies (fallback)
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/backend/lcfs/tests/compliance_report/test_update_service.py
+++ b/backend/lcfs/tests/compliance_report/test_update_service.py
@@ -348,6 +348,7 @@ async def test_handle_submitted_status_auto_submits_fse_records(
     mock_report.compliance_report_id = report_id
     mock_report.organization_id = 123
     mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period = MagicMock(description="2024")
     mock_report.summary = MagicMock(spec=ComplianceReportSummary)
     mock_report.summary.line_20_surplus_deficit_units = 100
 
@@ -438,6 +439,7 @@ async def test_handle_submitted_status_rejects_decommissioned_fse(
     mock_report.compliance_report_id = 1
     mock_report.organization_id = 123
     mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period = MagicMock(description="2024")
 
     mock_user_has_roles.return_value = True
     compliance_report_update_service.final_supply_equipment_repo.has_decommissioned_fse_in_report = AsyncMock(
@@ -452,6 +454,114 @@ async def test_handle_submitted_status_rejects_decommissioned_fse(
     assert exc_info.value.status_code == 400
     assert "decommissioned FSE" in exc_info.value.detail
     compliance_report_update_service._charging_equipment_service.auto_submit_equipment_for_report.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_handle_submitted_status_skips_fse_for_legacy_year(
+    compliance_report_update_service,
+    mock_repo,
+    mock_summary_repo,
+    mock_user_has_roles,
+    mock_org_service,
+    mock_summary_service,
+):
+    """Reports for 2023 and earlier predate FSE — all FSE submission logic must be skipped."""
+    mock_report = MagicMock(spec=ComplianceReport)
+    mock_report.compliance_report_id = 1
+    mock_report.organization_id = 123
+    mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period = MagicMock(description="2023")
+    mock_report.summary = MagicMock(spec=ComplianceReportSummary)
+    mock_report.summary.line_20_surplus_deficit_units = 0
+
+    mock_user_has_roles.return_value = True
+    compliance_report_update_service.request = MagicMock()
+    compliance_report_update_service.request.user = MagicMock()
+
+    # Any decommissioned-FSE noise should not block a legacy submission
+    compliance_report_update_service.final_supply_equipment_repo.has_decommissioned_fse_in_report = AsyncMock(
+        return_value=True
+    )
+
+    mock_summary_service.calculate_compliance_report_summary = AsyncMock(
+        return_value=MagicMock(line_20_surplus_deficit_units=0)
+    )
+    compliance_report_update_service.org_service = mock_org_service
+    mock_org_service.adjust_balance.return_value = MagicMock()
+
+    await compliance_report_update_service.handle_submitted_status(
+        mock_report, UserProfile()
+    )
+
+    compliance_report_update_service.final_supply_equipment_repo.sync_reporting_associations_to_latest_equipment.assert_not_awaited()
+    compliance_report_update_service.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report.assert_not_awaited()
+    compliance_report_update_service.final_supply_equipment_repo.has_decommissioned_fse_in_report.assert_not_awaited()
+    compliance_report_update_service._charging_equipment_service.auto_submit_equipment_for_report.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_handle_submitted_status_refreshes_decommissioned_fse_for_original_report(
+    compliance_report_update_service,
+    mock_user_has_roles,
+):
+    mock_report = MagicMock(spec=ComplianceReport)
+    mock_report.compliance_report_id = 1
+    mock_report.organization_id = 123
+    mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period = MagicMock(description="2024")
+    mock_report.supplemental_initiator = None
+    mock_report.compliance_period.description = "2024"
+
+    mock_user_has_roles.return_value = True
+    compliance_report_update_service.summary_service.calculate_compliance_report_summary = AsyncMock(
+        return_value=MagicMock(line_20_surplus_deficit_units=0)
+    )
+    compliance_report_update_service._create_or_update_reserve_transaction = AsyncMock(
+        return_value=0
+    )
+    compliance_report_update_service._validate_organization_details_for_submission = (
+        AsyncMock()
+    )
+
+    await compliance_report_update_service.handle_submitted_status(
+        mock_report, UserProfile()
+    )
+
+    # Deactivation is now compliance-period-aware and matches the whole report
+    # group: only FSE decommissioned before the reported year are deactivated.
+    compliance_report_update_service.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report.assert_awaited_once_with(
+        "report-group-123", compliance_year=2024
+    )
+
+
+@pytest.mark.anyio
+async def test_handle_submitted_status_skips_decommissioned_refresh_for_supplemental(
+    compliance_report_update_service,
+    mock_user_has_roles,
+):
+    mock_report = MagicMock(spec=ComplianceReport)
+    mock_report.compliance_report_id = 1
+    mock_report.organization_id = 123
+    mock_report.compliance_report_group_uuid = "report-group-123"
+    mock_report.compliance_period = MagicMock(description="2024")
+    mock_report.supplemental_initiator = SupplementalInitiatorType.SUPPLIER_SUPPLEMENTAL
+
+    mock_user_has_roles.return_value = True
+    compliance_report_update_service.summary_service.calculate_compliance_report_summary = AsyncMock(
+        return_value=MagicMock(line_20_surplus_deficit_units=0)
+    )
+    compliance_report_update_service._create_or_update_reserve_transaction = AsyncMock(
+        return_value=0
+    )
+    compliance_report_update_service._validate_organization_details_for_submission = (
+        AsyncMock()
+    )
+
+    await compliance_report_update_service.handle_submitted_status(
+        mock_report, UserProfile()
+    )
+
+    compliance_report_update_service.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -1071,6 +1181,39 @@ async def test_handle_recommended_by_analyst_status_not_superseded(
 
 
 @pytest.mark.anyio
+async def test_handle_recommended_by_analyst_status_skips_fse_for_legacy_year(
+    compliance_report_update_service: ComplianceReportUpdateService,
+    mock_repo: AsyncMock,
+    mock_user_profile_analyst: MagicMock,
+    mock_compliance_report_recommended_analyst: MagicMock,
+):
+    """FSE didn't exist before 2024 — analyst adjustments of legacy reports must
+    not auto-validate (mutate) FSE records, mirroring the supplier submission guard."""
+    # Arrange a legacy compliance year
+    mock_compliance_report_recommended_analyst.compliance_period.description = "2023"
+    mock_repo.get_draft_report_by_group_uuid = AsyncMock(return_value=None)
+    mock_charging_equipment_service = AsyncMock()
+    mock_charging_equipment_service.auto_validate_equipment_for_report = AsyncMock(
+        return_value=0
+    )
+    compliance_report_update_service._charging_equipment_service = (
+        mock_charging_equipment_service
+    )
+
+    with patch(
+        "lcfs.web.api.compliance_report.update_service.user_has_roles",
+        return_value=True,
+    ):
+        # Act
+        await compliance_report_update_service.handle_recommended_by_analyst_status(
+            mock_compliance_report_recommended_analyst, mock_user_profile_analyst
+        )
+
+        # Assert FSE auto-validation skipped for legacy year
+        mock_charging_equipment_service.auto_validate_equipment_for_report.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_handle_recommended_by_analyst_status_superseded(
     compliance_report_update_service: ComplianceReportUpdateService,
     mock_repo: AsyncMock,
@@ -1564,6 +1707,7 @@ async def test_handle_recommended_by_analyst_government_reassessment_calls_with_
     mock_report.supplemental_initiator = (
         SupplementalInitiatorType.GOVERNMENT_REASSESSMENT
     )
+    mock_report.compliance_period = MagicMock(description="2024")
     # Start with no summary, will be assigned during execution
     mock_report.summary = None
 
@@ -1619,6 +1763,7 @@ async def test_handle_recommended_by_analyst_auto_validates_fse(
     mock_report.compliance_report_id = 456
     mock_report.organization_id = 91
     mock_report.version = 0
+    mock_report.compliance_period = MagicMock(description="2024")
     mock_report.summary = None
 
     mock_repo.get_draft_report_by_group_uuid = AsyncMock(return_value=None)
@@ -1670,6 +1815,7 @@ async def test_handle_recommended_by_analyst_non_government_reassessment_no_calc
     mock_report.supplemental_initiator = (
         SupplementalInitiatorType.SUPPLIER_SUPPLEMENTAL
     )  # Not government
+    mock_report.compliance_period = MagicMock(description="2024")
 
     mock_repo.get_draft_report_by_group_uuid = AsyncMock(return_value=None)
 

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from sqlalchemy import select, literal
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -530,18 +531,89 @@ async def test_get_fse_reporting_list_paginated(repo, fake_db):
 async def test_has_decommissioned_fse_in_report_true(repo, fake_db):
     fake_db.scalar.return_value = 1
 
-    result = await repo.has_decommissioned_fse_in_report(10)
+    result = await repo.has_decommissioned_fse_in_report("group-10")
 
     assert result is True
+
+    # Queries the selected-rows base view (not the heavier pref/editing view)
+    # and matches the whole report group, so supplementals see the original
+    # report's selections.
+    stmt = fake_db.scalar.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "v_fse_reporting_base" in compiled
+    assert "v_fse_reporting_base_pref" not in compiled
+    assert "compliance_report_group_uuid = 'group-10'" in compiled
+    assert "compliance_report_id" not in compiled
 
 
 @pytest.mark.anyio
 async def test_has_decommissioned_fse_in_report_false(repo, fake_db):
     fake_db.scalar.return_value = 0
 
-    result = await repo.has_decommissioned_fse_in_report(10)
+    result = await repo.has_decommissioned_fse_in_report("group-10")
 
     assert result is False
+
+
+@pytest.mark.anyio
+async def test_deactivate_decommissioned_fse_for_report(repo, fake_db):
+    execute_result = MagicMock()
+    execute_result.rowcount = 2
+    fake_db.execute.return_value = execute_result
+
+    result = await repo.deactivate_decommissioned_fse_for_report("group-10")
+
+    assert result == 2
+    fake_db.flush.assert_awaited_once()
+
+    executed_query = fake_db.execute.call_args[0][0]
+    compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+    assert "UPDATE compliance_report_charging_equipment" in compiled_sql
+    assert "charging_equipment_status = 'Decommissioned'" in compiled_sql
+    assert "is_active IS true" in compiled_sql
+    # Sources rows from the selected-rows base view, matched by report group.
+    assert "v_fse_reporting_base" in compiled_sql
+    assert "v_fse_reporting_base_pref" not in compiled_sql
+    assert "compliance_report_group_uuid = 'group-10'" in compiled_sql
+
+
+@pytest.mark.anyio
+async def test_deactivate_decommissioned_fse_for_report_filters_by_compliance_year(
+    repo, fake_db
+):
+    execute_result = MagicMock()
+    execute_result.rowcount = 1
+    fake_db.execute.return_value = execute_result
+
+    result = await repo.deactivate_decommissioned_fse_for_report(
+        "group-10", compliance_year=2024
+    )
+
+    assert result == 1
+    executed_query = fake_db.execute.call_args[0][0]
+    compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+    # Period-aware path only deactivates equipment decommissioned before the
+    # reported year.
+    assert "EXTRACT(year FROM charging_equipment.update_date) < 2024" in compiled_sql
+
+
+@pytest.mark.anyio
+async def test_has_decommissioned_fse_in_report_filters_by_compliance_year(
+    repo, fake_db
+):
+    fake_db.scalar.return_value = 0
+
+    result = await repo.has_decommissioned_fse_in_report(
+        "group-10", compliance_year=2024
+    )
+
+    assert result is False
+    stmt = fake_db.scalar.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    # Period-aware path joins charging_equipment and only counts rows
+    # decommissioned before the reported year.
+    assert "charging_equipment" in compiled
+    assert "EXTRACT(year FROM charging_equipment.update_date) < 2024" in compiled
 
 
 @pytest.mark.anyio
@@ -975,40 +1047,50 @@ async def test_bulk_update_deactivate_takes_precedence_over_activate(repo, fake_
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_returns_status(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_returns_status(repo, fake_db):
+    decommissioned_at = datetime(2025, 6, 1)
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = "Submitted"
+    result_mock.first.return_value = ("Decommissioned", decommissioned_at)
     fake_db.execute.return_value = result_mock
 
-    status_value = await repo.get_latest_equipment_status(charging_equipment_id=42)
+    status_value, decommissioned_date = (
+        await repo.get_latest_equipment_status_with_date(charging_equipment_id=42)
+    )
 
-    assert status_value == "Submitted"
+    assert status_value == "Decommissioned"
+    assert decommissioned_date == decommissioned_at
     fake_db.execute.assert_called_once()
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_returns_none_when_not_found(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_returns_none_when_not_found(
+    repo, fake_db
+):
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
+    result_mock.first.return_value = None
     fake_db.execute.return_value = result_mock
 
-    status_value = await repo.get_latest_equipment_status(charging_equipment_id=999)
+    status_value, decommissioned_date = (
+        await repo.get_latest_equipment_status_with_date(charging_equipment_id=999)
+    )
 
     assert status_value is None
+    assert decommissioned_date is None
 
 
 @pytest.mark.anyio
-async def test_get_latest_equipment_status_query_compiles(repo, fake_db):
+async def test_get_latest_equipment_status_with_date_query_compiles(repo, fake_db):
     result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
+    result_mock.first.return_value = None
     fake_db.execute.return_value = result_mock
 
-    await repo.get_latest_equipment_status(charging_equipment_id=1)
+    await repo.get_latest_equipment_status_with_date(charging_equipment_id=1)
 
     stmt = fake_db.execute.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
 
     assert "charging_equipment" in compiled
     assert "charging_equipment_status" in compiled
+    assert "charging_equipment.update_date" in compiled
     assert "FROM charging_equipment JOIN charging_equipment_status" in compiled
     assert "ORDER BY charging_equipment.version DESC" in compiled

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 from lcfs.db.models import LevelOfEquipment, Organization
 from lcfs.db.models.compliance import FinalSupplyEquipment
+from lcfs.db.models.compliance.ComplianceReport import ComplianceReport
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.final_supply_equipment.schema import (
     LevelOfEquipmentSchema,
@@ -39,6 +40,8 @@ def mock_repo():
     repo = AsyncMock()
     repo.get_charging_power_output.return_value = None
     repo.get_total_kwh_usage_for_report_group.return_value = 0
+    # Default: equipment is active (not decommissioned).
+    repo.get_latest_equipment_status_with_date.return_value = ("Submitted", None)
     return repo
 
 
@@ -47,7 +50,12 @@ def mock_comp_report_repo():
     """
     Return an AsyncMock for the ComplianceReportRepository.
     """
-    return AsyncMock()
+    repo = AsyncMock()
+    # Default: reports resolve to the 2024 compliance period.
+    default_report = MagicMock()
+    default_report.compliance_period.description = "2024"
+    repo.get_compliance_report_by_id.return_value = default_report
+    return repo
 
 
 @pytest.fixture
@@ -382,6 +390,44 @@ async def test_copy_fse_between_reports(
 
 
 @pytest.mark.anyio
+async def test_copy_fse_to_new_report_skipped_for_legacy_year(service, mock_repo):
+    """FSE reporting didn't exist before 2024 — copy must be a no-op for legacy years."""
+    report = MagicMock(spec=ComplianceReport)
+    report.compliance_report_id = 42
+    report.organization_id = 1
+    report.compliance_report_group_uuid = "group-legacy"
+    report.compliance_period = MagicMock(description="2023")
+
+    result = await service.copy_fse_to_new_report(report)
+
+    assert result == {"created": 0}
+    mock_repo.get_latest_active_equipments.assert_not_awaited()
+    mock_repo.create_fse_reporting_batch.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_create_fse_reporting_batch_rejected_for_legacy_year(
+    service, mock_repo, mock_comp_report_repo
+):
+    """Direct API writes to legacy-year (pre-2024) reports must be rejected,
+    not just hidden in the UI."""
+    legacy_report = MagicMock(spec=ComplianceReport)
+    legacy_report.compliance_period = MagicMock(description="2023")
+    mock_comp_report_repo.get_compliance_report_by_id.return_value = legacy_report
+
+    item = MagicMock()
+    item.compliance_report_id = 42
+    item.charging_equipment_id = 7
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_fse_reporting_batch([item])
+
+    assert exc_info.value.status_code == 400
+    assert "before 2024" in exc_info.value.detail
+    mock_repo.create_fse_reporting_batch.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_get_fse_reporting_list_paginated_success(
     service, mock_repo, mock_comp_report_repo
 ):
@@ -519,11 +565,17 @@ async def test_create_fse_reporting_batch_success(service, mock_repo):
 async def test_create_fse_reporting_batch_rejects_decommissioned_equipment(
     service, mock_repo
 ):
-    mock_repo.get_latest_equipment_status.return_value = "Decommissioned"
+    # Decommissioned in 2023, reported for the 2024 period -> already retired
+    # before the period began, so it must be rejected.
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2023, 5, 1),
+    )
 
     data = [
         MagicMock(
             charging_equipment_id=99,
+            compliance_report_id=10,
             model_dump=lambda: {
                 "charging_equipment_id": 99,
                 "compliance_report_id": 10,
@@ -542,12 +594,43 @@ async def test_create_fse_reporting_batch_rejects_decommissioned_equipment(
 
 
 @pytest.mark.anyio
+async def test_create_fse_reporting_batch_allows_post_period_decommissioned_equipment(
+    service, mock_repo
+):
+    # Decommissioned in 2025 but reported for the 2024 period -> the equipment
+    # was still active during 2024, so the batch must be allowed. This is the
+    # core fix for prior-year supplementals (issue #4485).
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2025, 3, 1),
+    )
+    mock_repo.create_fse_reporting_batch.return_value = {"message": "Success"}
+
+    data = [
+        MagicMock(
+            charging_equipment_id=99,
+            compliance_report_id=10,
+            model_dump=lambda: {
+                "charging_equipment_id": 99,
+                "compliance_report_id": 10,
+                "supply_from_date": "2024-01-01",
+                "supply_to_date": "2024-12-31",
+            },
+        )
+    ]
+
+    result = await service.create_fse_reporting_batch(data)
+
+    assert result["message"] == "Success"
+    mock_repo.create_fse_reporting_batch.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_update_fse_reporting_success(service, mock_repo):
     """Test successful update of FSE reporting"""
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.update_fse_reporting.return_value = {"id": 1, "kwh_usage": 1500.0}
 
     data = MagicMock(model_dump=lambda: {"kwh_usage": 1500.0})
@@ -584,9 +667,8 @@ async def test_delete_fse_reporting_batch_success(service, mock_repo):
 async def test_update_fse_reporting_active_status(service, mock_repo):
     """Test toggling FSE reporting active status"""
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.update_reporting_active_status.return_value = 3
 
     data = MagicMock(reporting_ids=[1, 2, 3], is_active=False)
@@ -605,9 +687,13 @@ async def test_update_fse_reporting_active_status_rejects_activating_decommissio
     service, mock_repo
 ):
     mock_repo.get_reporting_record_by_id.return_value = MagicMock(
-        charging_equipment_id=1
+        charging_equipment_id=1, compliance_report_id=10
     )
-    mock_repo.get_latest_equipment_status.return_value = "Decommissioned"
+    # Decommissioned in 2023, report is for the 2024 period -> reject activation.
+    mock_repo.get_latest_equipment_status_with_date.return_value = (
+        "Decommissioned",
+        datetime(2023, 5, 1),
+    )
 
     data = MagicMock(reporting_ids=[1], is_active=True)
 
@@ -622,11 +708,11 @@ async def test_update_fse_reporting_active_status_rejects_activating_decommissio
 @pytest.mark.anyio
 async def test_set_default_dates_fse_reporting_success(service, mock_repo):
     """Test successful setting of default dates for FSE reporting"""
-    mock_repo.get_latest_equipment_status.return_value = "Submitted"
     mock_repo.bulk_update_reporting_dates.return_value = 3
 
     data = MagicMock(
         equipment_ids=[1, 2, 3],
+        compliance_report_id=10,
         supply_from_date="2024-01-01",
         supply_to_date="2024-12-31",
     )

--- a/backend/lcfs/web/api/compliance_report/update_service.py
+++ b/backend/lcfs/web/api/compliance_report/update_service.py
@@ -343,30 +343,47 @@ class ComplianceReportUpdateService:
             report.compliance_report_id
         )
 
-        if report.compliance_report_group_uuid:
-            await self.final_supply_equipment_repo.sync_reporting_associations_to_latest_equipment(
-                report.compliance_report_group_uuid,
-                report.organization_id,
-            )
+        # FSE reporting did not exist before 2024. Skip all FSE submission logic
+        # for legacy years so we do not mutate FSE data or block submission on
+        # validations that should not apply.
+        compliance_year = int(report.compliance_period.description)
+        if compliance_year >= 2024:
+            if report.compliance_report_group_uuid:
+                await self.final_supply_equipment_repo.sync_reporting_associations_to_latest_equipment(
+                    report.compliance_report_group_uuid,
+                    report.organization_id,
+                )
 
-        has_decommissioned_fse = (
-            await self.final_supply_equipment_repo.has_decommissioned_fse_in_report(
-                report.compliance_report_id,
-                only_active=True,
-            )
-        )
-        if has_decommissioned_fse:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "This draft report includes decommissioned FSE. Remove or deactivate those rows before submission."
-                ),
-            )
+            # Only act on FSE that were decommissioned before the report's
+            # compliance period. Equipment retired during or after the reported
+            # year was still valid for that year (e.g. a 2024 report must not be
+            # blocked by a 2025 decommission), so it stays reportable. Inside
+            # this guard the compliance year is already a valid int.
+            if report.supplemental_initiator is None:
+                await self.final_supply_equipment_repo.deactivate_decommissioned_fse_for_report(
+                    report.compliance_report_group_uuid,
+                    compliance_year=compliance_year,
+                )
 
-        # Auto-submit all FSE records in Draft or Updated status to Submitted status
-        await self.charging_equipment_service.auto_submit_equipment_for_report(
-            report.compliance_report_id, report.organization_id
-        )
+            has_decommissioned_fse = (
+                await self.final_supply_equipment_repo.has_decommissioned_fse_in_report(
+                    report.compliance_report_group_uuid,
+                    only_active=True,
+                    compliance_year=compliance_year,
+                )
+            )
+            if has_decommissioned_fse:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "This draft report includes decommissioned FSE. Remove or deactivate those rows before submission."
+                    ),
+                )
+
+            # Auto-submit all FSE records in Draft or Updated status to Submitted status
+            await self.charging_equipment_service.auto_submit_equipment_for_report(
+                report.compliance_report_id, report.organization_id
+            )
 
         # Ensure summary exists and snapshot user-entered lines before transaction creation
         calculated_summary = (
@@ -416,10 +433,16 @@ class ComplianceReportUpdateService:
         if not has_analyst_or_director_role:
             raise HTTPException(status_code=403, detail="Forbidden.")
 
-        # Auto-validate all submitted FSE records associated with this report
-        await self.charging_equipment_service.auto_validate_equipment_for_report(
-            report.compliance_report_id, report.organization_id
-        )
+        # FSE reporting did not exist before 2024. Skip FSE auto-validation for
+        # legacy years so analyst adjustments/reassessments of pre-2024 reports
+        # do not mutate FSE data — mirroring the supplier submission guard in
+        # handle_submitted_status.
+        compliance_year = int(report.compliance_period.description)
+        if compliance_year >= 2024:
+            # Auto-validate all submitted FSE records associated with this report
+            await self.charging_equipment_service.auto_validate_equipment_for_report(
+                report.compliance_report_id, report.organization_id
+            )
 
         # Lock the summary when report is recommended by analyst - this is the snapshot point
         await self._calculate_and_lock_summary(report, user, skip_can_sign_check=True)

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -1,5 +1,5 @@
-from datetime import date
-from typing import Any, List, Sequence
+from datetime import date, datetime
+from typing import Any, List, Optional, Sequence, Tuple
 
 import structlog
 from fastapi import Depends
@@ -8,6 +8,7 @@ from sqlalchemy import (
     delete,
     distinct,
     exists,
+    extract,
     func,
     select,
     update,
@@ -1070,10 +1071,21 @@ class FinalSupplyEquipmentRepository:
         return float(await self.db.scalar(total_query) or 0)
 
     @repo_handler
-    async def get_latest_equipment_status(self, charging_equipment_id: int) -> str | None:
+    async def get_latest_equipment_status_with_date(
+        self, charging_equipment_id: int
+    ) -> Tuple[Optional[str], Optional[datetime]]:
         """
-        Return the current status for the latest version in the same logical
-        charging equipment series as the provided equipment id.
+        Return the status and last-updated time for the latest version in the
+        same logical charging equipment series as the provided equipment id.
+
+        ``update_date`` doubles as a proxy for when the equipment was
+        decommissioned: decommissioning is an in-place status change with no
+        dedicated timestamp, so the last-updated time of the decommissioned
+        row stands in for the decommission date. Callers compare it against a
+        report's compliance period to decide whether the equipment was already
+        decommissioned for that period.
+
+        Returns ``(None, None)`` when the equipment series is not found.
         """
         group_uuid_subquery = (
             select(ChargingEquipment.group_uuid)
@@ -1082,7 +1094,7 @@ class FinalSupplyEquipmentRepository:
         )
 
         stmt = (
-            select(ChargingEquipmentStatus.status)
+            select(ChargingEquipmentStatus.status, ChargingEquipment.update_date)
             .select_from(ChargingEquipment)
             .join(
                 ChargingEquipmentStatus,
@@ -1096,7 +1108,10 @@ class FinalSupplyEquipmentRepository:
             )
             .limit(1)
         )
-        return (await self.db.execute(stmt)).scalar_one_or_none()
+        row = (await self.db.execute(stmt)).first()
+        if row is None:
+            return None, None
+        return row[0], row[1]
 
     @repo_handler
     async def get_reporting_record_by_id(
@@ -1114,23 +1129,115 @@ class FinalSupplyEquipmentRepository:
 
     @repo_handler
     async def has_decommissioned_fse_in_report(
-        self, compliance_report_id: int, only_active: bool = True
+        self,
+        compliance_report_group_uuid: str,
+        only_active: bool = True,
+        compliance_year: Optional[int] = None,
     ) -> bool:
         """
-        Check whether the current draft/report view contains any decommissioned
-        FSE rows that are still attached to the report.
+        Check whether the report's reporting set contains decommissioned FSE
+        rows that should block submission.
+
+        Reporting selections live at the compliance-report-group level and carry
+        across report versions, so we match on ``compliance_report_group_uuid``
+        (not a single ``compliance_report_id``) — otherwise a supplemental would
+        miss equipment selected on the original report. ``v_fse_reporting_base``
+        already contains only the actually-selected reporting rows (one per
+        ``compliance_report_charging_equipment``), so it is queried directly
+        rather than the heavier "preferred"/editing view.
+
+        A decommissioned FSE only blocks the report when it was decommissioned
+        *before* the report's compliance period. Equipment decommissioned during
+        or after the reported year was still valid for that year (e.g. a 2024
+        report must not be blocked by a 2025 decommission), so it is allowed.
+        The equipment's ``update_date`` stands in for the decommission date
+        (in-place status change, no dedicated timestamp).
+
+        When ``compliance_year`` is ``None`` the period check is skipped and any
+        decommissioned row counts (legacy behaviour).
         """
-        vt = FSEReportingBasePrefView.__table__
+        vt = FSEReportingBaseView.__table__
         conditions = [
-            vt.c.compliance_report_id == compliance_report_id,
+            vt.c.compliance_report_group_uuid == compliance_report_group_uuid,
             vt.c.charging_equipment_compliance_id.is_not(None),
             vt.c.charging_equipment_status == "Decommissioned",
         ]
         if only_active:
             conditions.append(vt.c.is_active.is_(True))
 
-        stmt = select(func.count()).select_from(vt).where(*conditions)
+        stmt = select(func.count()).select_from(vt)
+
+        if compliance_year is not None:
+            stmt = stmt.join(
+                ChargingEquipment,
+                and_(
+                    ChargingEquipment.charging_equipment_id
+                    == vt.c.charging_equipment_id,
+                    ChargingEquipment.version == vt.c.charging_equipment_version,
+                ),
+            )
+            conditions.append(
+                extract("year", ChargingEquipment.update_date) < compliance_year
+            )
+
+        stmt = stmt.where(*conditions)
         return bool(await self.db.scalar(stmt))
+
+    @repo_handler
+    async def deactivate_decommissioned_fse_for_report(
+        self, compliance_report_group_uuid: str, compliance_year: Optional[int] = None
+    ) -> int:
+        """
+        Deactivate active FSE reporting rows whose equipment has been
+        decommissioned.
+
+        Matches the report group's reporting set via
+        ``compliance_report_group_uuid`` against ``v_fse_reporting_base`` (the
+        selected-rows view), consistent with ``has_decommissioned_fse_in_report``.
+
+        Period-aware: when ``compliance_year`` is provided, only rows for
+        equipment decommissioned *before* that compliance period are
+        deactivated. Equipment retired during or after the reported year was
+        still valid for that year and is left active. The equipment's
+        ``update_date`` stands in for the decommission date (in-place status
+        change, no dedicated timestamp). When ``compliance_year`` is ``None``
+        every decommissioned row is deactivated (legacy behaviour).
+        """
+        vt = FSEReportingBaseView.__table__
+        base_select = select(vt.c.charging_equipment_compliance_id)
+        conditions = [
+            vt.c.compliance_report_group_uuid == compliance_report_group_uuid,
+            vt.c.charging_equipment_compliance_id.is_not(None),
+            vt.c.charging_equipment_status == "Decommissioned",
+            vt.c.is_active.is_(True),
+        ]
+        if compliance_year is not None:
+            base_select = base_select.join(
+                ChargingEquipment,
+                and_(
+                    ChargingEquipment.charging_equipment_id
+                    == vt.c.charging_equipment_id,
+                    ChargingEquipment.version == vt.c.charging_equipment_version,
+                ),
+            )
+            conditions.append(
+                extract("year", ChargingEquipment.update_date) < compliance_year
+            )
+        decommissioned_reporting_ids = base_select.where(*conditions).subquery()
+
+        result = await self.db.execute(
+            update(ComplianceReportChargingEquipment)
+            .where(
+                ComplianceReportChargingEquipment.charging_equipment_compliance_id.in_(
+                    select(
+                        decommissioned_reporting_ids.c.charging_equipment_compliance_id
+                    )
+                )
+            )
+            .values(is_active=False)
+        )
+        await self.db.flush()
+        return result.rowcount or 0
 
     @repo_handler
     async def get_fse_reporting_list_paginated(

--- a/backend/lcfs/web/api/final_supply_equipment/services.py
+++ b/backend/lcfs/web/api/final_supply_equipment/services.py
@@ -38,6 +38,9 @@ logger = structlog.get_logger(__name__)
 class FinalSupplyEquipmentServices:
     DEFAULT_OPERATIONAL_HOURS = 24
     DECOMMISSIONED_STATUS = "Decommissioned"
+    # FSE reporting did not exist before this compliance year. Reports for
+    # earlier years must not gain or mutate FSE reporting data.
+    MIN_FSE_COMPLIANCE_YEAR = 2024
 
     def __init__(
         self,
@@ -328,11 +331,64 @@ class FinalSupplyEquipmentServices:
 
         return compliance_report
 
+    async def _validate_report_supports_fse(self, compliance_report_id: int) -> None:
+        """Reject FSE reporting writes against legacy-year reports (pre-2024).
+
+        FSE reporting did not exist before 2024, so the UI hides the section for
+        those years. This guard closes the gap for direct API calls so legacy
+        reports can never gain or mutate FSE reporting rows server-side, even if
+        a client bypasses the UI.
+        """
+        if compliance_report_id is None:
+            return
+        report = await self.compliance_report_repo.get_compliance_report_by_id(
+            compliance_report_id
+        )
+        if report is None:
+            return
+        try:
+            compliance_year = int(report.compliance_period.description)
+        except (AttributeError, TypeError, ValueError):
+            return
+        if compliance_year < self.MIN_FSE_COMPLIANCE_YEAR:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "FSE reporting is not available for compliance periods before "
+                    f"{self.MIN_FSE_COMPLIANCE_YEAR}."
+                ),
+            )
+
+    async def _get_report_compliance_year(self, compliance_report_id: int) -> int:
+        """Resolve the compliance period year for a report id."""
+        report = await self.compliance_report_repo.get_compliance_report_by_id(
+            compliance_report_id
+        )
+        if not report:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Compliance report not found",
+            )
+        return int(report.compliance_period.description)
+
     async def _validate_equipment_is_not_decommissioned(
-        self, charging_equipment_id: int
+        self, charging_equipment_id: int, compliance_year: int
     ) -> None:
-        latest_status = await self.repo.get_latest_equipment_status(charging_equipment_id)
-        if latest_status == self.DECOMMISSIONED_STATUS:
+        latest_status, decommissioned_date = (
+            await self.repo.get_latest_equipment_status_with_date(charging_equipment_id)
+        )
+        # The decommission restriction is period-aware: equipment is only
+        # off-limits for periods that begin after it was decommissioned. A
+        # report for an earlier year (e.g. a 2024 supplemental for FSE retired
+        # in 2025) stays editable because the equipment was still active during
+        # the reported period. update_date stands in for the decommission date
+        # (in-place status change, no dedicated timestamp). When the date is
+        # unavailable we err on the side of allowing the edit.
+        if (
+            latest_status == self.DECOMMISSIONED_STATUS
+            and decommissioned_date is not None
+            and decommissioned_date.year < compliance_year
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -350,8 +406,11 @@ class FinalSupplyEquipmentServices:
                 detail="FSE reporting record not found",
             )
 
+        compliance_year = await self._get_report_compliance_year(
+            reporting_record.compliance_report_id
+        )
         await self._validate_equipment_is_not_decommissioned(
-            reporting_record.charging_equipment_id
+            reporting_record.charging_equipment_id, compliance_year
         )
         return reporting_record
 
@@ -428,6 +487,10 @@ class FinalSupplyEquipmentServices:
         compliance period year as the default supply date range.
         """
         compliance_year = int(report.compliance_period.description)
+        # FSE reporting did not exist before 2024. Skip entirely so legacy reports
+        # do not create ComplianceReportChargingEquipment rows or mutate FSE data.
+        if compliance_year < 2024:
+            return {"created": 0}
         supply_from_date = date(compliance_year, 1, 1)
         supply_to_date = date(compliance_year, 12, 31)
 
@@ -530,10 +593,17 @@ class FinalSupplyEquipmentServices:
         """
         Create FSE compliance reporting data
         """
-        for item in data:
-            await self._validate_equipment_is_not_decommissioned(
-                item.charging_equipment_id
+        for report_id in {item.compliance_report_id for item in data}:
+            await self._validate_report_supports_fse(report_id)
+
+        if data:
+            compliance_year = await self._get_report_compliance_year(
+                data[0].compliance_report_id
             )
+            for item in data:
+                await self._validate_equipment_is_not_decommissioned(
+                    item.charging_equipment_id, compliance_year
+                )
 
         # Convert Pydantic schemas to dict format for SQLAlchemy
         model_data = [item.model_dump() for item in data]
@@ -546,7 +616,12 @@ class FinalSupplyEquipmentServices:
         """
         Update FSE compliance reporting data
         """
-        await self._validate_reporting_record_is_not_decommissioned(reporting_id)
+        reporting_record = await self._validate_reporting_record_is_not_decommissioned(
+            reporting_id
+        )
+        await self._validate_report_supports_fse(
+            reporting_record.compliance_report_id
+        )
         return await self.repo.update_fse_reporting(reporting_id, data.model_dump())
 
     @service_handler
@@ -573,6 +648,8 @@ class FinalSupplyEquipmentServices:
         if not data.reporting_ids:
             return {"updated": 0, "is_active": data.is_active}
 
+        await self._validate_report_supports_fse(data.compliance_report_id)
+
         if data.is_active:
             for reporting_id in data.reporting_ids:
                 await self._validate_reporting_record_is_not_decommissioned(
@@ -596,14 +673,21 @@ class FinalSupplyEquipmentServices:
         if not data.equipment_ids:
             return {"created": 0, "updated": 0}
 
+        await self._validate_report_supports_fse(data.compliance_report_id)
+
         if not data.supply_from_date or not data.supply_to_date:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Supply from and to dates are required",
             )
 
+        compliance_year = await self._get_report_compliance_year(
+            data.compliance_report_id
+        )
         for equipment_id in data.equipment_ids:
-            await self._validate_equipment_is_not_decommissioned(equipment_id)
+            await self._validate_equipment_is_not_decommissioned(
+                equipment_id, compliance_year
+            )
 
         updated_count = await self.repo.bulk_update_reporting_dates(data)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -90,8 +90,8 @@
         "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
-        "@vitest/coverage-v8": "^3.2.4",
-        "@vitest/ui": "^3.2.4",
+        "@vitest/coverage-v8": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "axe-core": "^4.10.3",
         "cross-env": "^7.0.3",
         "cypress": "^14.2.1",
@@ -121,7 +121,7 @@
         "storybook": "^8.6.17",
         "typescript": "^5.8.3",
         "vite-plugin-terminal": "^1.3.0",
-        "vitest": "^3.2.4"
+        "vitest": "3.2.4"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.6.1"
@@ -416,18 +416,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2208,9 +2208,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6633,15 +6633,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
-      "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
@@ -6655,9 +6655,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9679,9 +9679,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9825,9 +9825,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -18631,9 +18631,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18665,6 +18665,19 @@
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
       "funding": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,8 +121,8 @@
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
-    "@vitest/coverage-v8": "^3.2.4",
-    "@vitest/ui": "^3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/ui": "3.2.4",
     "axe-core": "^4.10.3",
     "cross-env": "^7.0.3",
     "cypress": "^14.2.1",
@@ -152,7 +152,7 @@
     "storybook": "^8.6.17",
     "typescript": "^5.8.3",
     "vite-plugin-terminal": "^1.3.0",
-    "vitest": "^3.2.4"
+    "vitest": "3.2.4"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.6.1"


### PR DESCRIPTION
## Summary

Prod cherry-pick of #4494 (consolidated FSE legacy-year guard + period-aware decommission checks) onto **main**. Full develop parity, including the auto-deactivate path — identical feature behaviour to the release port (`hotfix/alex-fse-legacy-decom-4494-release`, PR #4496).

## What's included
- **Legacy-year gating**: FSE reporting did not exist before 2024. `copy_fse_to_new_report` no-ops for pre-2024 reports; submission skips FSE sync / decommission check / auto-submit for legacy years (supplier *and* analyst-adjustment paths); FSE reporting write endpoints reject pre-2024 reports server-side.
- **Period-aware decommission**: an FSE only blocks/deactivates a report when decommissioned *before* that report's compliance period. `has_decommissioned_fse_in_report` and `deactivate_decommissioned_fse_for_report` query `v_fse_reporting_base` (selected-rows view) and match on `compliance_report_group_uuid` so supplementals see the original report's selections.

## Conflict resolution vs. main (mirrors the release port)
- `handle_submitted_status`: FSE logic wrapped in the `compliance_year >= 2024` guard; decommission calls made period-aware and group-uuid matched.
- `repo.py`: added `deactivate_decommissioned_fse_for_report` (main had no such method); `has_decommissioned` switched to base view + group uuid; `get_latest_equipment_status_with_date` brought in.
- Dropped `test_get_fse_reporting_list_paginated_excludes_decommissioned_when_requested` — it covers `include_decommissioned_attached`, an unrelated develop-only list feature **not** part of #4494 and not present on main.

## Testing
- `test_update_service.py` + `test_final_supply_equipment_repo.py` (fake-db): **128 passed** locally.
- `test_final_supply_equipment_services.py` requires a live Postgres — validated in CI here.

## Related
- Develop: #4494 (merged). Release: #4496. Decommission main/release companions: #4486 / #4487.
- A separate prod data patch is still required to clean up legacy FSE rows (tracked on #4423); no destructive data migration is included.
