### PR TITLE
Fix: LCFS - Verification and analyst columns of ci application

### DIFF
--- a/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
@@ -29,6 +29,7 @@ from lcfs.web.api.ci_application.services import (
     _initials,
     _to_assigned_analyst,
     _to_list_item,
+    _verification_level_from_progress,
 )
 
 
@@ -91,6 +92,8 @@ def _application(
     organization=None,
     priority_score=None,
     verification_level=None,
+    verification_1_date=None,
+    verification_2_date=None,
 ):
     ci = CIApplication(
         ci_application_id=ci_application_id,
@@ -105,6 +108,8 @@ def _application(
         proposed_fuel_code_effective_date=date(2026, 6, 1),
         priority_score=priority_score,
         verification_level=verification_level,
+        verification_1_date=verification_1_date,
+        verification_2_date=verification_2_date,
         group_uuid="abc",
         version=0,
     )
@@ -399,12 +404,36 @@ class TestToListItem:
         ci = _application(
             assigned_analyst=_user(user_profile_id=2, first="Hamed", last="Bayeki"),
             priority_score=511,
-            verification_level="VX2 - High",
+            verification_2_date=datetime(2026, 5, 20, tzinfo=timezone.utc),
         )
         out = _to_list_item(ci, last_comment_entry=None)
         assert out.assigned_analyst.initials == "HB"
         assert out.priority_score == 511
-        assert out.verification_level == "VX2 - High"
+        assert out.verification_level == "VX2"
+
+    @pytest.mark.parametrize(
+        "verification_1_date,verification_2_date,expected",
+        [
+            (None, None, None),
+            (datetime(2026, 5, 19, tzinfo=timezone.utc), None, "VX1"),
+            (
+                datetime(2026, 5, 19, tzinfo=timezone.utc),
+                datetime(2026, 5, 20, tzinfo=timezone.utc),
+                "VX2",
+            ),
+        ],
+    )
+    def test_verification_level_follows_progress_dates(
+        self, verification_1_date, verification_2_date, expected
+    ):
+        ci = _application(
+            verification_level="VX2 - High",
+            verification_1_date=verification_1_date,
+            verification_2_date=verification_2_date,
+        )
+
+        assert _verification_level_from_progress(ci) == expected
+        assert _to_list_item(ci).verification_level == expected
 
     def test_populates_last_comment_when_provided(self):
         ci = _application()

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -780,6 +780,7 @@ async def test_recommend_to_director_transitions_status_to_recommended(
 ):
     mock_user.role_names = {RoleEnum.ANALYST}
     ci = _ci_application(status=_status("Submitted", 2))
+    ci.assigned_analyst_id = 12
     ci.preliminary_risk_assessment = "Low"
     ci.verification_1_date = datetime(2026, 5, 20, tzinfo=timezone.utc)
     recommended = _status("Recommended", 3)
@@ -791,6 +792,7 @@ async def test_recommend_to_director_transitions_status_to_recommended(
     result = await service.recommend_to_director(ci, mock_user)
 
     assert ci.status_id == recommended.ci_application_status_id
+    assert ci.assigned_analyst_id == 12
     assert ci.recommendation_date is not None
     repo.get_status_by_name.assert_awaited_with("Recommended")
     assert isinstance(result, CIApplicationSchema)
@@ -881,7 +883,7 @@ async def test_step5_decision_can_return_submitted_to_draft_for_pathway_changes(
     )
 
     assert ci.status_id == draft.ci_application_status_id
-    assert ci.assigned_analyst_id is None
+    assert ci.assigned_analyst_id == 12
     assert ci.preliminary_risk_assessment is None
     assert ci.priority_score is None
     assert ci.verification_1_user_id is None
@@ -916,6 +918,7 @@ async def test_step5_decision_rejects_draft_pathway_change_for_non_analyst(
 async def test_step5_decision_transitions_to_completed(service, repo, mock_user):
     mock_user.role_names = {RoleEnum.DIRECTOR}
     ci = _ci_application(status=_status("Recommended", 3))
+    ci.assigned_analyst_id = 12
     completed = _status("Completed", 4)
     repo.get_status_by_name.return_value = completed
     repo.update.side_effect = lambda obj: obj
@@ -927,7 +930,29 @@ async def test_step5_decision_transitions_to_completed(service, repo, mock_user)
     )
 
     assert ci.status_id == completed.ci_application_status_id
+    assert ci.assigned_analyst_id == 12
     repo.add_history.assert_awaited_once()
+    assert isinstance(result, CIApplicationSchema)
+
+
+@pytest.mark.anyio
+async def test_step5_decision_clears_assigned_analyst_when_withdrawn(
+    service, repo, mock_user
+):
+    ci = _ci_application(status=_status("Submitted", 2))
+    ci.assigned_analyst_id = 12
+    withdrawn = _status("Withdrawn", 5)
+    repo.get_status_by_name.return_value = withdrawn
+    repo.update.side_effect = lambda obj: obj
+    repo.add_history.return_value = MagicMock()
+    repo.get_by_id.return_value = ci
+
+    result = await service.record_decision(
+        ci, _decision_payload("Withdrawn"), mock_user, is_government=True
+    )
+
+    assert ci.status_id == withdrawn.ci_application_status_id
+    assert ci.assigned_analyst_id is None
     assert isinstance(result, CIApplicationSchema)
 
 
@@ -939,6 +964,7 @@ async def test_step5_decision_ignores_inline_comment_field(
     dropped — comments now live in the shared internal_comments framework.
     """
     ci = _ci_application(status=_status("Submitted", 2))
+    ci.assigned_analyst_id = 12
     repo.get_status_by_name.return_value = _status("Withdrawn", 4)
     repo.update.side_effect = lambda obj: obj
     repo.get_by_id.return_value = ci
@@ -952,6 +978,7 @@ async def test_step5_decision_ignores_inline_comment_field(
 
     # No legacy add_comment call should be made by the decision flow.
     assert not hasattr(repo, "add_comment") or not repo.add_comment.await_count
+    assert ci.assigned_analyst_id is None
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 import structlog
 from fastapi import Depends
-from sqlalchemy import and_, asc, desc, func, select
+from sqlalchemy import and_, asc, case, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -49,6 +49,12 @@ from lcfs.web.core.decorators import repo_handler
 
 logger = structlog.get_logger(__name__)
 
+VERIFICATION_LEVEL_EXPR = case(
+    (CIApplication.verification_2_date.isnot(None), "VX2"),
+    (CIApplication.verification_1_date.isnot(None), "VX1"),
+    else_=None,
+)
+
 # Grid-facing filter / sort resolvers. Keys use the post-validation
 # snake_case form (FilterModel.field / SortOrder.field route incoming
 # values through camel_to_snake). Unknown fields are silently dropped.
@@ -60,7 +66,7 @@ _DIRECT_FILTER_COLUMNS = {
     "facility_nameplate_capacity": CIApplication.facility_nameplate_capacity,
     "proposed_fuel_code_effective_date": CIApplication.proposed_fuel_code_effective_date,
     "priority_score": CIApplication.priority_score,
-    "verification_level": CIApplication.verification_level,
+    "verification_level": VERIFICATION_LEVEL_EXPR,
     "update_date": CIApplication.update_date,
     "create_date": CIApplication.create_date,
 }

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -236,6 +236,14 @@ def _to_assigned_analyst(user) -> Optional[AssignedAnalystSchema]:
     )
 
 
+def _verification_level_from_progress(ci: CIApplication) -> Optional[str]:
+    if getattr(ci, "verification_2_date", None):
+        return "VX2"
+    if getattr(ci, "verification_1_date", None):
+        return "VX1"
+    return None
+
+
 def _to_list_item(
     ci: CIApplication,
     last_comment_entry: Optional[Tuple] = None,
@@ -268,7 +276,7 @@ def _to_list_item(
         ),
         last_comment=last_comment,
         priority_score=getattr(ci, "priority_score", None),
-        verification_level=getattr(ci, "verification_level", None),
+        verification_level=_verification_level_from_progress(ci),
     )
 
 
@@ -291,6 +299,14 @@ class CIApplicationServices:
             if display_name:
                 display_name = display_name.strip() or None
         return _to_full_schema(ci, signature_user_display_name=display_name)
+
+    def _apply_status_change_side_effects(
+        self,
+        ci_application: CIApplication,
+        target_status: CIApplicationStatusEnum,
+    ) -> None:
+        if target_status == CIApplicationStatusEnum.Withdrawn:
+            ci_application.assigned_analyst_id = None
 
     # ------------------------------------------------------------------
     # Reference data
@@ -510,6 +526,9 @@ class CIApplicationServices:
                 f"Status '{CIApplicationStatusEnum.Recommended.value}' is not configured."
             )
         ci_application.status_id = recommended_status.ci_application_status_id
+        self._apply_status_change_side_effects(
+            ci_application, CIApplicationStatusEnum.Recommended
+        )
         ci_application.update_user = user.keycloak_username
         ci_application.action_type = ActionTypeEnum.UPDATE
         await self.repo.update(ci_application)
@@ -849,6 +868,9 @@ class CIApplicationServices:
         )
         ci_application.signature_date_time = datetime.now(timezone.utc)
         ci_application.status_id = submitted_status.ci_application_status_id
+        self._apply_status_change_side_effects(
+            ci_application, CIApplicationStatusEnum.Submitted
+        )
         ci_application.update_user = user.keycloak_username
         ci_application.action_type = ActionTypeEnum.UPDATE
 
@@ -942,6 +964,7 @@ class CIApplicationServices:
             )
 
         ci_application.status_id = target_status.ci_application_status_id
+        self._apply_status_change_side_effects(ci_application, data.status)
         if data.status == CIApplicationStatusEnum.Completed:
             ci_application.approval_user_id = user.user_profile_id
             ci_application.approval_date = datetime.now(timezone.utc)
@@ -951,7 +974,6 @@ class CIApplicationServices:
             ci_application.approval_user_id = None
             ci_application.approval_date = None
         elif data.status == CIApplicationStatusEnum.Draft:
-            ci_application.assigned_analyst_id = None
             ci_application.preliminary_risk_assessment = None
             ci_application.priority_score = None
             ci_application.verification_1_user_id = None

--- a/frontend/src/views/CarbonIntensity/__tests__/_schema.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/_schema.test.jsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   ciApplicationsColDefs,
   defaultSortModel,
+  getVerificationColumnValue,
   getResumeStep
 } from '@/views/CarbonIntensity/_schema'
 
@@ -89,6 +90,40 @@ describe('ciApplicationsColDefs (IDIR)', () => {
     const analyst = cols.find((c) => c.field === 'assignedAnalyst')
 
     expect(analyst.cellRendererParams).toMatchObject({ onRefresh })
+  })
+
+  it('derives the Verification column from verification progress', () => {
+    const cols = ciApplicationsColDefs(t, { isGovernment: true })
+    const verification = cols.find((c) => c.field === 'verificationLevel')
+
+    expect(verification.valueGetter({ data: {} })).toBeNull()
+    expect(
+      verification.valueGetter({
+        data: { verification1Date: '2026-05-19T00:00:00Z' }
+      })
+    ).toBe('VX1')
+    expect(
+      verification.valueGetter({
+        data: {
+          verification1Date: '2026-05-19T00:00:00Z',
+          verification2Date: '2026-05-20T00:00:00Z'
+        }
+      })
+    ).toBe('VX2')
+    expect(
+      verification.valueGetter({ data: { verificationLevel: 'VX2 - High' } })
+    ).toBeNull()
+  })
+})
+
+describe('getVerificationColumnValue', () => {
+  it('uses completed verification stages before the API fallback value', () => {
+    expect(
+      getVerificationColumnValue({
+        verificationLevel: 'VX1',
+        verification2Date: '2026-05-20T00:00:00Z'
+      })
+    ).toBe('VX2')
   })
 })
 

--- a/frontend/src/views/CarbonIntensity/_schema.tsx
+++ b/frontend/src/views/CarbonIntensity/_schema.tsx
@@ -178,9 +178,19 @@ const priorityScoreCol = (t) => ({
   suppressFloatingFilterButton: true
 })
 
+export const getVerificationColumnValue = (data) => {
+  if (data?.verification2Date) return 'VX2'
+  if (data?.verification1Date) return 'VX1'
+  if (['VX1', 'VX2'].includes(data?.verificationLevel)) {
+    return data.verificationLevel
+  }
+  return null
+}
+
 const verificationCol = (t) => ({
   field: 'verificationLevel',
   headerName: t('carbonIntensity:columns.verification'),
+  valueGetter: ({ data }) => getVerificationColumnValue(data),
   minWidth: 220,
   filter: 'agTextColumnFilter',
   filterParams: TEXT_FILTER_PARAMS,


### PR DESCRIPTION
Fixes #4464, #4465

github workflow fixes:

- Always runs npm ci in frontend shard jobs.
- Verifies installed Vitest matches frontend/package.json.
- Clears .vitest-reports before each shard run.
- Uploads only blob-*.json, not the whole report directory.
- Ignores missing blob files for empty shards.
- Adds version-aware blob validation before merge.