### PR TITLE
Fix: Resolve Fuel Code Tab Visibility and Filtering - 4380 (cherry-pick to release-v1.3.4)

### DIFF
--- a/backend/lcfs/web/api/fuel_code/bulletin_export.py
+++ b/backend/lcfs/web/api/fuel_code/bulletin_export.py
@@ -7,10 +7,10 @@ from starlette.responses import StreamingResponse
 from lcfs.utils.constants import FILE_MEDIA_TYPE
 from lcfs.utils.spreadsheet_builder import SpreadsheetBuilder, SpreadsheetColumn
 from lcfs.web.api.base import PaginationRequestSchema
+from lcfs.web.api.fuel_code.export import FUEL_CODE_EXPORT_COLUMNS
 from lcfs.web.api.fuel_code.repo import FuelCodeRepository
 from lcfs.web.core.decorators import service_handler
 from lcfs.web.exception.exceptions import DataNotFoundException
-
 
 FUEL_CODE_BULLETIN_EXPORT_COLUMNS = [
     SpreadsheetColumn("Fuel Code", "text"),
@@ -38,8 +38,10 @@ class FuelCodeBulletinExporter:
 
     def _get_compliance_period_start(self, today: date) -> date:
         period_anchor_this_year = date(today.year, 3, 31)
-        return period_anchor_this_year if today >= period_anchor_this_year else date(
-            today.year - 1, 3, 31
+        return (
+            period_anchor_this_year
+            if today >= period_anchor_this_year
+            else date(today.year - 1, 3, 31)
         )
 
     @service_handler
@@ -48,6 +50,7 @@ class FuelCodeBulletinExporter:
         bulletin_type: str,
         export_format: str,
         pagination: PaginationRequestSchema | None = None,
+        is_idir: bool = False,
     ) -> StreamingResponse:
         if export_format not in ["xls", "xlsx", "csv"]:
             raise DataNotFoundException("Export format not supported")
@@ -72,22 +75,57 @@ class FuelCodeBulletinExporter:
             sort_orders=sort_orders,
         )
 
-        spreadsheet_rows = [
-            [
-                row["fuel_code"],
-                row["fuel"],
-                row["company"],
-                row["carbon_intensity"],
-                row["effective_date"],
-                row["expiry_date"],
+        if is_idir:
+            columns = FUEL_CODE_EXPORT_COLUMNS
+            spreadsheet_rows = [
+                [
+                    row.get("status"),
+                    row.get("prefix"),
+                    row.get("fuel_suffix"),
+                    row.get("carbon_intensity"),
+                    row.get("edrms"),
+                    row.get("company"),
+                    row.get("contact_name"),
+                    row.get("contact_email"),
+                    row.get("application_date"),
+                    row.get("approval_date"),
+                    row.get("effective_date"),
+                    row.get("expiry_date"),
+                    row.get("fuel"),
+                    row.get("feedstock"),
+                    row.get("feedstock_location"),
+                    row.get("feedstock_misc"),
+                    row.get("co_processed"),
+                    row.get("fuel_production_facility_city"),
+                    row.get("fuel_production_facility_province_state"),
+                    row.get("fuel_production_facility_country"),
+                    row.get("facility_nameplate_capacity"),
+                    row.get("facility_nameplate_capacity_unit"),
+                    (", ".join(row.get("feedstock_fuel_transport_modes") or [])),
+                    (", ".join(row.get("finished_fuel_transport_modes") or [])),
+                    row.get("former_company"),
+                    row.get("notes"),
+                ]
+                for row in rows
             ]
-            for row in rows
-        ]
+        else:
+            columns = FUEL_CODE_BULLETIN_EXPORT_COLUMNS
+            spreadsheet_rows = [
+                [
+                    row["fuel_code"],
+                    row["fuel"],
+                    row["company"],
+                    row["carbon_intensity"],
+                    row["effective_date"],
+                    row["expiry_date"],
+                ]
+                for row in rows
+            ]
 
         builder = SpreadsheetBuilder(file_format=export_format)
         builder.add_sheet(
             sheet_name=FUEL_CODE_BULLETIN_SHEET_NAMES[bulletin_type],
-            columns=FUEL_CODE_BULLETIN_EXPORT_COLUMNS,
+            columns=columns,
             rows=spreadsheet_rows,
             styles={"bold_headers": True},
         )

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -145,6 +145,25 @@ class FuelCodeRepository:
             FuelCodeListView.carbon_intensity,
             FuelCodeListView.effective_date,
             FuelCodeListView.expiration_date,
+            FuelCodeListView.status,
+            FuelCodeListView.edrms,
+            FuelCodeListView.contact_name,
+            FuelCodeListView.contact_email,
+            FuelCodeListView.application_date,
+            FuelCodeListView.approval_date,
+            FuelCodeListView.feedstock,
+            FuelCodeListView.feedstock_location,
+            FuelCodeListView.feedstock_misc,
+            FuelCodeListView.co_processed,
+            FuelCodeListView.fuel_production_facility_city,
+            FuelCodeListView.fuel_production_facility_province_state,
+            FuelCodeListView.fuel_production_facility_country,
+            FuelCodeListView.facility_nameplate_capacity,
+            FuelCodeListView.facility_nameplate_capacity_unit,
+            FuelCodeListView.feedstock_fuel_transport_modes,
+            FuelCodeListView.finished_fuel_transport_modes,
+            FuelCodeListView.former_company,
+            FuelCodeListView.notes,
         ).where(
             cast(FuelCodeListView.status, String) == FuelCodeStatusEnum.Approved.value
         )
@@ -230,11 +249,17 @@ class FuelCodeRepository:
             r = row._mapping
             effective_date = r["effective_date"]
             expiration_date = r["expiration_date"]
+            application_date = r["application_date"]
+            approval_date = r["approval_date"]
 
             if isinstance(effective_date, datetime):
                 effective_date = effective_date.date()
             if isinstance(expiration_date, datetime):
                 expiration_date = expiration_date.date()
+            if isinstance(application_date, datetime):
+                application_date = application_date.date()
+            if isinstance(approval_date, datetime):
+                approval_date = approval_date.date()
 
             formatted_rows.append(
                 {
@@ -244,6 +269,35 @@ class FuelCodeRepository:
                     "carbon_intensity": r["carbon_intensity"],
                     "effective_date": effective_date,
                     "expiry_date": expiration_date,
+                    "prefix": r["prefix"],
+                    "fuel_suffix": r["fuel_suffix"],
+                    "status": r["status"],
+                    "edrms": r["edrms"],
+                    "contact_name": r["contact_name"],
+                    "contact_email": r["contact_email"],
+                    "application_date": application_date,
+                    "approval_date": approval_date,
+                    "feedstock": r["feedstock"],
+                    "feedstock_location": r["feedstock_location"],
+                    "feedstock_misc": r["feedstock_misc"],
+                    "co_processed": r["co_processed"],
+                    "fuel_production_facility_city": r["fuel_production_facility_city"],
+                    "fuel_production_facility_province_state": r[
+                        "fuel_production_facility_province_state"
+                    ],
+                    "fuel_production_facility_country": r[
+                        "fuel_production_facility_country"
+                    ],
+                    "facility_nameplate_capacity": r["facility_nameplate_capacity"],
+                    "facility_nameplate_capacity_unit": r[
+                        "facility_nameplate_capacity_unit"
+                    ],
+                    "feedstock_fuel_transport_modes": r[
+                        "feedstock_fuel_transport_modes"
+                    ],
+                    "finished_fuel_transport_modes": r["finished_fuel_transport_modes"],
+                    "former_company": r["former_company"],
+                    "notes": r["notes"],
                 }
             )
 

--- a/backend/lcfs/web/api/fuel_code/schema.py
+++ b/backend/lcfs/web/api/fuel_code/schema.py
@@ -191,7 +191,9 @@ class FuelCodeSchema(BaseSchema):
     fuel_production_facility_province_state: Optional[str] = None
     fuel_production_facility_country: Optional[str] = None
     facility_nameplate_capacity: Optional[int] = None
-    facility_nameplate_capacity_unit: Optional[Union[FuelTypeQuantityUnitsEnumSchema, str]] = None
+    facility_nameplate_capacity_unit: Optional[
+        Union[FuelTypeQuantityUnitsEnumSchema, str]
+    ] = None
     former_company: Optional[str] = None
     notes: Optional[str] = None
     fuel_code_status: Optional[FuelCodeStatusSchema] = None
@@ -214,19 +216,19 @@ class FuelCodeSchema(BaseSchema):
     def default_co_processed(cls, value):
         return normalize_co_processed(value)
 
+
 class FuelCodeHistorySchema(BaseSchema):
     fuel_code_history_id: int
     fuel_code_id: int
     fuel_status_id: int
     fuel_code_snapshot: Optional[Dict[str, Any]] = Field(
-        None,
-        description="Complete snapshot of fuel code data at time of change"
+        None, description="Complete snapshot of fuel code data at time of change"
     )
     group_uuid: Optional[str] = None
     version: Optional[int] = 0
     action_type: Optional[str] = None
 
-    @field_validator('fuel_code_snapshot', mode='before')
+    @field_validator("fuel_code_snapshot", mode="before")
     @classmethod
     def parse_fuel_code_snapshot(cls, v):
         """Parse fuel_code_snapshot if it comes as a JSON string"""
@@ -364,6 +366,28 @@ class FuelCodeBulletinRowSchema(BaseSchema):
     carbon_intensity: float
     effective_date: Optional[date] = None
     expiry_date: Optional[date] = None
+    # Extra fields exposed for IDIR view (optional for public view)
+    prefix: Optional[str] = None
+    fuel_suffix: Optional[str] = None
+    status: Optional[str] = None
+    edrms: Optional[str] = None
+    contact_name: Optional[str] = None
+    contact_email: Optional[str] = None
+    application_date: Optional[date] = None
+    approval_date: Optional[date] = None
+    feedstock: Optional[str] = None
+    feedstock_location: Optional[str] = None
+    feedstock_misc: Optional[str] = None
+    co_processed: Optional[str] = None
+    fuel_production_facility_city: Optional[str] = None
+    fuel_production_facility_province_state: Optional[str] = None
+    fuel_production_facility_country: Optional[str] = None
+    facility_nameplate_capacity: Optional[float] = None
+    facility_nameplate_capacity_unit: Optional[str] = None
+    feedstock_fuel_transport_modes: Optional[List[str]] = None
+    finished_fuel_transport_modes: Optional[List[str]] = None
+    former_company: Optional[str] = None
+    notes: Optional[str] = None
 
 
 class FuelCodeBulletinsSchema(BaseSchema):

--- a/backend/lcfs/web/api/fuel_code/views.py
+++ b/backend/lcfs/web/api/fuel_code/views.py
@@ -229,9 +229,7 @@ async def export_fuel_codes(
     Note: Only the first sheet data is used for the CSV format,
         as CSV files do not support multiple sheets.
     """
-    return await exporter.export(
-        format, pagination, exclude_archived=exclude_archived
-    )
+    return await exporter.export(format, pagination, exclude_archived=exclude_archived)
 
 
 @router.post(
@@ -272,11 +270,17 @@ async def export_fuel_code_bulletins(
     bulletin_type_snake: Optional[str] = Query(
         None, alias="bulletin_type", description="Type: 'current' or 'archived'"
     ),
+    idir: bool = Query(
+        default=False,
+        description="If true, export the full IDIR column set.",
+    ),
     pagination: PaginationRequestSchema | None = Body(None),
     exporter: FuelCodeBulletinExporter = Depends(),
 ):
     resolved_bulletin_type = resolve_bulletin_type(bulletin_type, bulletin_type_snake)
-    return await exporter.export(resolved_bulletin_type, format, pagination)
+    return await exporter.export(
+        resolved_bulletin_type, format, pagination, is_idir=idir
+    )
 
 
 @router.get(

--- a/frontend/src/hooks/useFuelCode.ts
+++ b/frontend/src/hooks/useFuelCode.ts
@@ -1,9 +1,16 @@
 import { apiRoutes } from '@/constants/routes'
 import { useApiService } from '@/services/useApiService'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import type { QueryOptions, PaginationParams, ExtMutationOptions } from './types'
+import type {
+  QueryOptions,
+  PaginationParams,
+  ExtMutationOptions
+} from './types'
 
-export const useFuelCodeOptions = (_params: Record<string, any>, options: QueryOptions<unknown>) => {
+export const useFuelCodeOptions = (
+  _params: Record<string, any>,
+  options: QueryOptions<unknown>
+) => {
   const client = useApiService()
   return useQuery({
     queryKey: ['fuel-code-options'],
@@ -14,7 +21,10 @@ export const useFuelCodeOptions = (_params: Record<string, any>, options: QueryO
   })
 }
 
-export const useGetFuelCode = (fuelCodeID: any, options: QueryOptions<unknown>) => {
+export const useGetFuelCode = (
+  fuelCodeID: any,
+  options: QueryOptions<unknown>
+) => {
   const client = useApiService()
   return useQuery({
     enabled: !!fuelCodeID,
@@ -32,7 +42,16 @@ export const useGetFuelCode = (fuelCodeID: any, options: QueryOptions<unknown>) 
   })
 }
 
-export const useGetFuelCodes = ({ page = 1, size = 10, sortOrders = [], filters = [], excludeArchived = false }: any = {}, options: QueryOptions<unknown>) => {
+export const useGetFuelCodes = (
+  {
+    page = 1,
+    size = 10,
+    sortOrders = [],
+    filters = [],
+    excludeArchived = false
+  }: any = {},
+  options: QueryOptions<unknown>
+) => {
   const client = useApiService()
   return useQuery({
     queryKey: ['fuel-codes', page, size, sortOrders, filters, excludeArchived],
@@ -93,7 +112,11 @@ export const useFuelCodeStatuses = (options: QueryOptions<unknown>) => {
   })
 }
 
-export const useFuelCodeBulletins = (bulletinType: any, paginationOptions: PaginationParams, options: QueryOptions<unknown>) => {
+export const useFuelCodeBulletins = (
+  bulletinType: any,
+  paginationOptions: PaginationParams,
+  options: QueryOptions<unknown>
+) => {
   const client = useApiService()
   return useQuery({
     queryKey: ['fuel-code-bulletins', bulletinType, paginationOptions],
@@ -116,10 +139,12 @@ export const useFuelCodeBulletins = (bulletinType: any, paginationOptions: Pagin
   })
 }
 
-export const useDownloadFuelCodeBulletins = (options: ExtMutationOptions<unknown, any>) => {
+export const useDownloadFuelCodeBulletins = (
+  options: ExtMutationOptions<unknown, any>
+) => {
   const client = useApiService()
   return useMutation({
-    mutationFn: async ({ bulletinType, format = 'xlsx', body }: any) => {
+    mutationFn: async ({ bulletinType, format = 'xlsx', body, idir }: any) => {
       if (!bulletinType) {
         throw new Error('bulletinType is required for bulletin download')
       }
@@ -127,7 +152,7 @@ export const useDownloadFuelCodeBulletins = (options: ExtMutationOptions<unknown
       return await client.download({
         url: apiRoutes.exportFuelCodeBulletins,
         method: 'post',
-        params: { bulletinType, format },
+        params: { bulletinType, format, ...(idir ? { idir: true } : {}) },
         data: body
       })
     },
@@ -150,7 +175,9 @@ export const useTransportModes = (options: QueryOptions<unknown>) => {
 }
 
 // Single unified mutation hook for all fuel code operations
-export const useFuelCodeMutation = (options: ExtMutationOptions<unknown, any> = {}) => {
+export const useFuelCodeMutation = (
+  options: ExtMutationOptions<unknown, any> = {}
+) => {
   const client = useApiService()
   const queryClient = useQueryClient()
 
@@ -166,7 +193,10 @@ export const useFuelCodeMutation = (options: ExtMutationOptions<unknown, any> = 
           if (!fuelCodeId)
             throw new Error('fuelCodeId is required for update operation')
           return await client.put(
-            apiRoutes.updateFuelCodeStatus.replace(':fuelCodeId', String(fuelCodeId ?? '')),
+            apiRoutes.updateFuelCodeStatus.replace(
+              ':fuelCodeId',
+              String(fuelCodeId ?? '')
+            ),
             data
           )
 
@@ -174,7 +204,10 @@ export const useFuelCodeMutation = (options: ExtMutationOptions<unknown, any> = 
           if (!fuelCodeId)
             throw new Error('fuelCodeId is required for delete operation')
           return await client.delete(
-            apiRoutes.deleteFuelCode.replace(':fuelCodeId', String(fuelCodeId ?? ''))
+            apiRoutes.deleteFuelCode.replace(
+              ':fuelCodeId',
+              String(fuelCodeId ?? '')
+            )
           )
 
         case 'download':
@@ -249,7 +282,9 @@ export const useFuelCodeMutation = (options: ExtMutationOptions<unknown, any> = 
 }
 
 // Convenience hooks for backward compatibility (optional)
-export const useCreateFuelCode = (options: ExtMutationOptions<unknown, any>) => {
+export const useCreateFuelCode = (
+  options: ExtMutationOptions<unknown, any>
+) => {
   const mutation = useFuelCodeMutation(options)
   return {
     ...mutation,
@@ -257,7 +292,10 @@ export const useCreateFuelCode = (options: ExtMutationOptions<unknown, any>) => 
   }
 }
 
-export const useUpdateFuelCode = (fuelCodeId: any, options: ExtMutationOptions<unknown, any>) => {
+export const useUpdateFuelCode = (
+  fuelCodeId: any,
+  options: ExtMutationOptions<unknown, any>
+) => {
   const mutation = useFuelCodeMutation(options)
   return {
     ...mutation,
@@ -266,7 +304,9 @@ export const useUpdateFuelCode = (fuelCodeId: any, options: ExtMutationOptions<u
   }
 }
 
-export const useDeleteFuelCode = (options: ExtMutationOptions<unknown, any>) => {
+export const useDeleteFuelCode = (
+  options: ExtMutationOptions<unknown, any>
+) => {
   const mutation = useFuelCodeMutation(options)
   return {
     ...mutation,
@@ -275,7 +315,9 @@ export const useDeleteFuelCode = (options: ExtMutationOptions<unknown, any>) => 
   }
 }
 
-export const useApproveFuelCode = (options: ExtMutationOptions<unknown, any>) => {
+export const useApproveFuelCode = (
+  options: ExtMutationOptions<unknown, any>
+) => {
   const mutation = useFuelCodeMutation(options)
   return {
     ...mutation,
@@ -284,10 +326,13 @@ export const useApproveFuelCode = (options: ExtMutationOptions<unknown, any>) =>
   }
 }
 
-export const useDownloadFuelCodes = (options: ExtMutationOptions<unknown, any>) => {
+export const useDownloadFuelCodes = (
+  options: ExtMutationOptions<unknown, any>
+) => {
   const mutation = useFuelCodeMutation(options)
   return {
     ...mutation,
-    mutateAsync: (data: any) => mutation.mutateAsync({ action: 'download', data })
+    mutateAsync: (data: any) =>
+      mutation.mutateAsync({ action: 'download', data })
   }
 }

--- a/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
+++ b/frontend/src/views/CarbonIntensity/components/FuelCodesTabs.jsx
@@ -9,10 +9,13 @@ import ROUTES from '@/routes/routes'
 import breakpoints from '@/themes/base/breakpoints'
 
 const BULLETINS_PATH = ROUTES.FUEL_CODES.BULLETINS
+const APPROVED_CI_PATH = ROUTES.APPROVED_CARBON_INTENSITIES
 const FUEL_CODES_PATH = ROUTES.FUEL_CODES.LIST
 const CI_APPLICATIONS_PATH = ROUTES.CI_APPLICATIONS.LIST
 
 const isOnBulletins = (loc) => loc.pathname === BULLETINS_PATH
+const isOnApprovedCI = (loc) => loc.pathname === APPROVED_CI_PATH
+const isOnBulletinsOrPublic = (loc) => isOnBulletins(loc) || isOnApprovedCI(loc)
 const isOnInternalFuelCodes = (loc) => loc.pathname === FUEL_CODES_PATH
 const isOnCIApplications = (loc) =>
   loc.pathname.startsWith(CI_APPLICATIONS_PATH)
@@ -104,18 +107,21 @@ const buildTabs = ({
   }
 
   if (!isGovernment) {
+    const basePath = isOnApprovedCI(location)
+      ? APPROVED_CI_PATH
+      : BULLETINS_PATH
     tabs.push(
       {
         key: 'current',
         labelKey: 'carbonIntensity:tabs.currentFuelCodes',
-        path: BULLETINS_PATH,
-        isActive: (loc) => isOnBulletins(loc) && !isArchivedQuery(loc)
+        path: basePath,
+        isActive: (loc) => isOnBulletinsOrPublic(loc) && !isArchivedQuery(loc)
       },
       {
         key: 'archived',
         labelKey: 'carbonIntensity:tabs.archivedFuelCodes',
-        path: `${BULLETINS_PATH}?type=archived`,
-        isActive: (loc) => isOnBulletins(loc) && isArchivedQuery(loc)
+        path: `${basePath}?type=archived`,
+        isActive: (loc) => isOnBulletinsOrPublic(loc) && isArchivedQuery(loc)
       }
     )
   }

--- a/frontend/src/views/FuelCodeBulletins/__tests__/FuelCodeBulletins.test.tsx
+++ b/frontend/src/views/FuelCodeBulletins/__tests__/FuelCodeBulletins.test.tsx
@@ -184,14 +184,21 @@ describe('FuelCodeBulletins UI', () => {
     expect(gridProps.overlayNoRowsTemplate).toBe('No bulletin rows found')
     expect(mockUseFuelCodeBulletins).toHaveBeenCalledWith(
       'current',
-      expect.objectContaining({ page: 1, size: 25, sortOrders: [], filters: [] })
+      expect.objectContaining({
+        page: 1,
+        size: 25,
+        sortOrders: [],
+        filters: []
+      })
     )
   })
 
   it('updates pagination options after grid pagination change', async () => {
     render(<CurrentFuelCodes />, { wrapper })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Change pagination' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Change pagination' })
+    )
 
     await waitFor(() => {
       expect(mockUseFuelCodeBulletins).toHaveBeenCalledWith(
@@ -225,12 +232,15 @@ describe('FuelCodeBulletins UI', () => {
   it('downloads current bulletin with current filters and sorting', async () => {
     render(<CurrentFuelCodes />, { wrapper })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Download Excel' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Download Excel' })
+    )
 
     await waitFor(() => {
       expect(mockDownloadMutate).toHaveBeenCalledWith({
         bulletinType: 'current',
         format: 'xlsx',
+        idir: false,
         body: {
           page: 1,
           size: 25,
@@ -246,7 +256,9 @@ describe('FuelCodeBulletins UI', () => {
 
     render(<ArchivedFuelCodes />, { wrapper })
 
-    await userEvent.click(screen.getByRole('button', { name: 'Download Excel' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Download Excel' })
+    )
 
     await waitFor(() => {
       expect(

--- a/frontend/src/views/FuelCodeBulletins/_schema.tsx
+++ b/frontend/src/views/FuelCodeBulletins/_schema.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { ColDef } from '@ag-grid-community/core'
 import { TFunction } from 'i18next'
+import { fuelCodeColDefs as idirFuelCodeColDefs } from '@/views/FuelCodes/_schema'
 
 const dateFormatter = new Intl.DateTimeFormat('en-CA', {
   year: 'numeric',
@@ -32,55 +33,60 @@ export const dateSortComparator = (a: string, b: string): number => {
   return left - right
 }
 
-export const buildColumnDefs = (t: TFunction): ColDef[] => [
-  {
-    headerName: t('columns.fuelCode'),
-    field: 'fuelCode',
-    filter: 'agTextColumnFilter',
-    sortable: true,
-    minWidth: 80
-  },
-  {
-    headerName: t('columns.fuel'),
-    field: 'fuel',
-    filter: 'agTextColumnFilter',
-    sortable: true,
-    minWidth: 80
-  },
-  {
-    headerName: t('columns.company'),
-    field: 'company',
-    filter: 'agTextColumnFilter',
-    sortable: true,
-    minWidth: 300
-  },
-  {
-    headerName: t('columns.carbonIntensity'),
-    field: 'carbonIntensity',
-    filter: false,
-    sortable: true,
-    minWidth: 210,
-    valueFormatter: (params: any) => formatCarbonIntensity(params.value)
-  },
-  {
-    headerName: t('columns.effectiveDate'),
-    field: 'effectiveDate',
-    filter: false,
-    sortable: true,
-    minWidth: 180,
-    comparator: dateSortComparator,
-    valueFormatter: (params: any) => formatDate(params.value)
-  },
-  {
-    headerName: t('columns.expiryDate'),
-    field: 'expiryDate',
-    filter: false,
-    sortable: true,
-    minWidth: 180,
-    comparator: dateSortComparator,
-    valueFormatter: (params: any) => formatDate(params.value)
+export const buildColumnDefs = (t: TFunction, isIdir = false): ColDef[] => {
+  if (isIdir) {
+    return idirFuelCodeColDefs(t)
   }
-]
+  return [
+    {
+      headerName: t('columns.fuelCode'),
+      field: 'fuelCode',
+      filter: 'agTextColumnFilter',
+      sortable: true,
+      minWidth: 80
+    },
+    {
+      headerName: t('columns.fuel'),
+      field: 'fuel',
+      filter: 'agTextColumnFilter',
+      sortable: true,
+      minWidth: 80
+    },
+    {
+      headerName: t('columns.company'),
+      field: 'company',
+      filter: 'agTextColumnFilter',
+      sortable: true,
+      minWidth: 300
+    },
+    {
+      headerName: t('columns.carbonIntensity'),
+      field: 'carbonIntensity',
+      filter: false,
+      sortable: true,
+      minWidth: 210,
+      valueFormatter: (params: any) => formatCarbonIntensity(params.value)
+    },
+    {
+      headerName: t('columns.effectiveDate'),
+      field: 'effectiveDate',
+      filter: false,
+      sortable: true,
+      minWidth: 180,
+      comparator: dateSortComparator,
+      valueFormatter: (params: any) => formatDate(params.value)
+    },
+    {
+      headerName: t('columns.expiryDate'),
+      field: 'expiryDate',
+      filter: false,
+      sortable: true,
+      minWidth: 180,
+      comparator: dateSortComparator,
+      valueFormatter: (params: any) => formatDate(params.value)
+    }
+  ]
+}
 
 export interface FuelCodeRow {
   id: string
@@ -90,15 +96,14 @@ export interface FuelCodeRow {
   carbonIntensity: number
   effectiveDate: string
   expiryDate: string
+  [key: string]: any
 }
 
 export const normalizeRows = (rows: any[] = []): FuelCodeRow[] =>
   rows.map((row, index) => ({
+    ...row,
     id: `${row.fuelCode}-${row.effectiveDate || index}`,
-    fuelCode: row.fuelCode,
-    fuel: row.fuel,
-    company: row.company,
-    carbonIntensity: row.carbonIntensity,
-    effectiveDate: row.effectiveDate,
-    expiryDate: row.expiryDate
+    // Aliases so the canonical IDIR fuelCodeColDefs can render unchanged
+    fuelType: row.fuel,
+    expirationDate: row.expiryDate
   }))

--- a/frontend/src/views/FuelCodeBulletins/components/ArchivedFuelCodes.tsx
+++ b/frontend/src/views/FuelCodeBulletins/components/ArchivedFuelCodes.tsx
@@ -22,7 +22,7 @@ const initialPaginationOptions = {
 }
 
 export const ArchivedFuelCodes = () => {
-  const { t } = useTranslation(['bulletins'])
+  const { t } = useTranslation(['bulletins', 'fuelCode'])
   const { hasAnyRole } = useCurrentUser()
   const isIdirView = hasAnyRole(...govRoles)
   const gridRef = useRef<any>(null)
@@ -38,7 +38,7 @@ export const ArchivedFuelCodes = () => {
     paginationOptions
   )
 
-  const colDefs = useMemo(() => buildColumnDefs(t), [t])
+  const colDefs = useMemo(() => buildColumnDefs(t, isIdirView), [t, isIdirView])
   const queryData = useMemo(
     () => ({
       data: {
@@ -60,6 +60,7 @@ export const ArchivedFuelCodes = () => {
       await downloadBulletins({
         bulletinType: 'archived',
         format: 'xlsx',
+        idir: isIdirView,
         body: {
           page: 1,
           size: paginationOptions.size || 25,

--- a/frontend/src/views/FuelCodeBulletins/components/CurrentFuelCodes.tsx
+++ b/frontend/src/views/FuelCodeBulletins/components/CurrentFuelCodes.tsx
@@ -22,7 +22,7 @@ const initialPaginationOptions = {
 }
 
 export const CurrentFuelCodes = () => {
-  const { t } = useTranslation(['bulletins'])
+  const { t } = useTranslation(['bulletins', 'fuelCode'])
   const { hasAnyRole } = useCurrentUser()
   const isIdirView = hasAnyRole(...govRoles)
   const gridRef = useRef<any>(null)
@@ -38,7 +38,7 @@ export const CurrentFuelCodes = () => {
     paginationOptions
   )
 
-  const colDefs = useMemo(() => buildColumnDefs(t), [t])
+  const colDefs = useMemo(() => buildColumnDefs(t, isIdirView), [t, isIdirView])
   const queryData = useMemo(
     () => ({
       data: {
@@ -63,6 +63,7 @@ export const CurrentFuelCodes = () => {
       await downloadBulletins({
         bulletinType: 'current',
         format: 'xlsx',
+        idir: isIdirView,
         body: {
           page: 1,
           size: paginationOptions.size || 25,

--- a/frontend/src/views/FuelCodes/FuelCodes.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodes.jsx
@@ -21,6 +21,7 @@ import { fuelCodeColDefs, defaultSortModel } from './_schema'
 import { defaultInitialPagination } from '@/constants/schedules'
 import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
 import { ArchivedFuelCodes } from '@/views/FuelCodeBulletins/components/ArchivedFuelCodes'
+import { CurrentFuelCodes } from '@/views/FuelCodeBulletins/components/CurrentFuelCodes'
 
 const convertToBackendFilters = (model = {}) =>
   Object.entries(model).map(([field, cfg]) => ({
@@ -61,8 +62,9 @@ const FuelCodesBase = () => {
   const isCurrent = tabType === 'current'
 
   const queryData = useGetFuelCodes(
-    { ...paginationOptions, excludeArchived: isCurrent },
+    { ...paginationOptions },
     {
+      enabled: !isArchived && !isCurrent,
       cacheTime: 0,
       staleTime: 0
     }
@@ -112,8 +114,7 @@ const FuelCodesBase = () => {
     try {
       await downloadFuelCodes({
         format: 'xlsx',
-        body: buildExportPayload(),
-        excludeArchived: isCurrent
+        body: buildExportPayload()
       })
       setIsDownloading(false)
     } catch (error) {
@@ -139,6 +140,8 @@ const FuelCodesBase = () => {
 
       {isArchived ? (
         <ArchivedFuelCodes />
+      ) : isCurrent ? (
+        <CurrentFuelCodes />
       ) : (
         <>
           <div>
@@ -149,9 +152,7 @@ const FuelCodesBase = () => {
             )}
           </div>
           <BCTypography variant="h5" color="primary" data-test="title">
-            {isCurrent
-              ? t('fuelCode:currentFuelCodes')
-              : t('fuelCode:fuelCodes')}
+            {t('fuelCode:fuelCodes')}
           </BCTypography>
           <Stack
             direction={{ md: 'column', lg: 'row' }}

--- a/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
+++ b/frontend/src/views/FuelCodes/__tests__/FuelCodes.test.jsx
@@ -23,7 +23,8 @@ vi.mock('react-i18next', () => ({
         'fuelCode:newFuelCodeBtn': 'New fuel code',
         'fuelCode:fuelCodeDownloadBtn': 'Download fuel codes information',
         'fuelCode:fuelCodeDownloadingMsg': 'Downloading fuel codes information',
-        'fuelCode:fuelCodeDownloadFailMsg': 'Failed to download fuel code information',
+        'fuelCode:fuelCodeDownloadFailMsg':
+          'Failed to download fuel code information',
         'fuelCode:noFuelCodesFound': 'No fuel codes found',
         'common:ClearFilters': 'Clear filters'
       }
@@ -180,14 +181,16 @@ describe('FuelCodes Component Tests', () => {
           dateFrom: cfg.dateFrom,
           dateTo: cfg.dateTo
         }))
-        expect(result).toEqual([{
-          field: 'name',
-          filterType: 'text',
-          type: 'contains',
-          filter: 'test',
-          dateFrom: undefined,
-          dateTo: undefined
-        }])
+        expect(result).toEqual([
+          {
+            field: 'name',
+            filterType: 'text',
+            type: 'contains',
+            filter: 'test',
+            dateFrom: undefined,
+            dateTo: undefined
+          }
+        ])
       })
 
       it('should convert filter model with date filters', () => {
@@ -207,14 +210,16 @@ describe('FuelCodes Component Tests', () => {
           dateFrom: cfg.dateFrom,
           dateTo: cfg.dateTo
         }))
-        expect(result).toEqual([{
-          field: 'applicationDate',
-          filterType: 'date',
-          type: 'inRange',
-          filter: undefined,
-          dateFrom: '2024-01-01',
-          dateTo: '2024-12-31'
-        }])
+        expect(result).toEqual([
+          {
+            field: 'applicationDate',
+            filterType: 'date',
+            type: 'inRange',
+            filter: undefined,
+            dateFrom: '2024-01-01',
+            dateTo: '2024-12-31'
+          }
+        ])
       })
 
       it('should handle missing filterType with default text type', () => {
@@ -232,14 +237,16 @@ describe('FuelCodes Component Tests', () => {
           dateFrom: cfg.dateFrom,
           dateTo: cfg.dateTo
         }))
-        expect(result).toEqual([{
-          field: 'code',
-          filterType: 'text',
-          type: 'equals',
-          filter: '001',
-          dateFrom: undefined,
-          dateTo: undefined
-        }])
+        expect(result).toEqual([
+          {
+            field: 'code',
+            filterType: 'text',
+            type: 'equals',
+            filter: '001',
+            dateFrom: undefined,
+            dateTo: undefined
+          }
+        ])
       })
     })
   })
@@ -268,7 +275,9 @@ describe('FuelCodes Component Tests', () => {
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
       expect(downloadButton).toBeInTheDocument()
       expect(downloadButton).toBeEnabled()
-      expect(downloadButton).toHaveTextContent('Download fuel codes information')
+      expect(downloadButton).toHaveTextContent(
+        'Download fuel codes information'
+      )
     })
 
     it('should render new fuel code button for analysts', () => {
@@ -277,7 +286,6 @@ describe('FuelCodes Component Tests', () => {
       expect(newFuelCodeBtn).toBeInTheDocument()
       expect(newFuelCodeBtn).toHaveTextContent('New fuel code')
     })
-
   })
 
   describe('Alert Message Handling', () => {
@@ -293,9 +301,9 @@ describe('FuelCodes Component Tests', () => {
         message: 'Test success message',
         severity: 'success'
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       await waitFor(() => {
         const alertBox = screen.getByTestId('alert-box')
         expect(alertBox).toBeInTheDocument()
@@ -307,9 +315,9 @@ describe('FuelCodes Component Tests', () => {
       mockLocationState.state = {
         message: 'Test message without severity'
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       await waitFor(() => {
         const alertBox = screen.getByTestId('alert-box')
         expect(alertBox).toBeInTheDocument()
@@ -322,9 +330,9 @@ describe('FuelCodes Component Tests', () => {
         message: 'Test error message',
         severity: 'error'
       }
-      
+
       render(<FuelCodes />, { wrapper })
-      
+
       await waitFor(() => {
         const alertBox = screen.getByTestId('alert-box')
         expect(alertBox).toBeInTheDocument()
@@ -350,7 +358,6 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
-          excludeArchived: false,
           body: {
             page: 1,
             size: 10000,
@@ -365,7 +372,6 @@ describe('FuelCodes Component Tests', () => {
         })
       })
     })
-
   })
 
   describe('Download Functionality', () => {
@@ -378,7 +384,9 @@ describe('FuelCodes Component Tests', () => {
       fireEvent.click(downloadButton)
 
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Downloading fuel codes information...')
+        expect(downloadButton).toHaveTextContent(
+          'Downloading fuel codes information...'
+        )
         expect(downloadButton).toBeDisabled()
       })
     })
@@ -392,13 +400,17 @@ describe('FuelCodes Component Tests', () => {
       fireEvent.click(downloadButton)
 
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Download fuel codes information')
+        expect(downloadButton).toHaveTextContent(
+          'Download fuel codes information'
+        )
         expect(downloadButton).toBeEnabled()
       })
     })
 
     it('should display error message on download failure', async () => {
-      mockDownloadMutate = vi.fn().mockRejectedValue(new Error('Download failed'))
+      mockDownloadMutate = vi
+        .fn()
+        .mockRejectedValue(new Error('Download failed'))
 
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
@@ -408,12 +420,16 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         const alertBox = screen.getByTestId('alert-box')
         expect(alertBox).toBeInTheDocument()
-        expect(alertBox).toHaveTextContent('Failed to download fuel code information')
+        expect(alertBox).toHaveTextContent(
+          'Failed to download fuel code information'
+        )
       })
     })
 
     it('should reset button state after download failure', async () => {
-      mockDownloadMutate = vi.fn().mockRejectedValue(new Error('Download failed'))
+      mockDownloadMutate = vi
+        .fn()
+        .mockRejectedValue(new Error('Download failed'))
 
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
@@ -421,7 +437,9 @@ describe('FuelCodes Component Tests', () => {
       fireEvent.click(downloadButton)
 
       await waitFor(() => {
-        expect(downloadButton).toHaveTextContent('Download fuel codes information')
+        expect(downloadButton).toHaveTextContent(
+          'Download fuel codes information'
+        )
         expect(downloadButton).toBeEnabled()
       })
     })
@@ -443,7 +461,6 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
-          excludeArchived: false,
           body: expect.objectContaining({
             page: 1,
             size: 10000,
@@ -463,7 +480,6 @@ describe('FuelCodes Component Tests', () => {
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith({
           format: 'xlsx',
-          excludeArchived: false,
           body: {
             page: 1,
             size: 10000,
@@ -479,7 +495,7 @@ describe('FuelCodes Component Tests', () => {
       })
     })
 
-    it('should pass excludeArchived: false on the default (Fuel codes) tab', async () => {
+    it('should include format on the default (Fuel codes) tab', async () => {
       mockDownloadMutate = vi.fn().mockResolvedValue(undefined)
       render(<FuelCodes />, { wrapper })
       const downloadButton = screen.getByTestId('fuel-code-download-btn')
@@ -488,7 +504,7 @@ describe('FuelCodes Component Tests', () => {
 
       await waitFor(() => {
         expect(mockDownloadMutate).toHaveBeenCalledWith(
-          expect.objectContaining({ excludeArchived: false })
+          expect.objectContaining({ format: 'xlsx' })
         )
       })
     })
@@ -568,7 +584,7 @@ describe('FuelCodes Component Tests', () => {
     it('should handle different fuel code IDs', () => {
       const params1 = { data: { fuelCodeId: 1 } }
       const params2 = { data: { fuelCodeId: '002' } }
-      
+
       expect(params1.data.fuelCodeId.toString()).toBe('1')
       expect(params2.data.fuelCodeId.toString()).toBe('002')
     })
@@ -587,7 +603,7 @@ describe('FuelCodes Component Tests', () => {
           }
         ]
       }
-      
+
       expect(payload.page).toBe(1)
       expect(payload.size).toBe(10000)
       expect(Array.isArray(payload.filters)).toBe(true)
@@ -605,7 +621,7 @@ describe('FuelCodes Component Tests', () => {
         dateFrom: cfg.dateFrom,
         dateTo: cfg.dateTo
       }))
-      
+
       expect(filters).toEqual([])
     })
   })
@@ -637,7 +653,7 @@ describe('FuelCodes Component Tests', () => {
       }
 
       render(<FuelCodes />, { wrapper })
-      
+
       await waitFor(() => {
         expect(screen.getByTestId('alert-box')).toBeInTheDocument()
       })
@@ -660,7 +676,7 @@ describe('FuelCodes Component Tests', () => {
 
     it('should always render download button', () => {
       render(<FuelCodes />, { wrapper })
-      
+
       expect(screen.getByTestId('fuel-code-download-btn')).toBeInTheDocument()
     })
   })
@@ -671,7 +687,9 @@ describe('FuelCodes Component Tests', () => {
 
       expect(screen.getByText('Fuel codes')).toBeInTheDocument()
       expect(screen.getByText('New fuel code')).toBeInTheDocument()
-      expect(screen.getByText('Download fuel codes information')).toBeInTheDocument()
+      expect(
+        screen.getByText('Download fuel codes information')
+      ).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary

Cherry-pick of #4482 into `release-v1.3.4`.

- Picked the net change of the original PR (merge commit `6f2ee3fbd`, `-m 1`); applied cleanly with no conflicts.
- Resulting tree is identical to the post-merge state on `develop`, which passed CI.
- Original authorship preserved.