### PR TITLE
fix: restrict legacy petroleum determining-CI to one provision per fuel category - 4435 (cherry-pick to release-v1.3.4)

### DIFF
--- a/backend/lcfs/tests/fuel_supply/test_fuel_supplies_repo.py
+++ b/backend/lcfs/tests/fuel_supply/test_fuel_supplies_repo.py
@@ -317,6 +317,40 @@ async def test_get_fuel_supply_table_options_excludes_other_fuel_types_pre_2024(
 
 
 @pytest.mark.anyio
+async def test_get_fuel_supply_table_options_legacy_petroleum_provision_by_category(
+    fuel_supply_repo, mock_db_session
+):
+    """#4435: For legacy reports (<2024) the prescribed-CI provision offered for
+    petroleum-based fuels must be determined by fuel category — Gasoline maps to
+    Section 6 (5) (a) (provision 4) and Diesel maps to Section 6 (5) (b)
+    (provision 5) — so only one valid option is presented per fuel rather than
+    both being offered for every legacy fuel."""
+    captured = {}
+
+    async def mock_execute(query, *args, **kwargs):
+        captured["query"] = query
+        result = MagicMock()
+        result.all = MagicMock(return_value=[])
+        return result
+
+    mock_db_session.execute = mock_execute
+
+    await fuel_supply_repo.get_fuel_supply_table_options("2020")
+    legacy_sql = str(
+        captured["query"].compile(compile_kwargs={"literal_binds": True})
+    )
+
+    # The category-aware pairing is present: Gasoline -> 4, Diesel -> 5.
+    assert "category = 'Gasoline'" in legacy_sql
+    assert "category = 'Diesel'" in legacy_sql
+    assert "provision_of_the_act_id = 4" in legacy_sql
+    assert "provision_of_the_act_id = 5" in legacy_sql
+
+    # The old category-blind blanket (both provisions for every legacy fuel) is gone.
+    assert "IN (4, 5)" not in legacy_sql.upper()
+
+
+@pytest.mark.anyio
 async def test_get_fuel_supply_list_with_valid_group_uuid(
     fuel_supply_repo, mock_db_session
 ):

--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -189,12 +189,25 @@ class FuelSupplyRepository:
                         ),
                         # Pre-2024 petroleum-based fuel types (is_legacy=True
                         # — Petroleum-based diesel/gasoline, Natural gas-based
-                        # gasoline): Section 6 prescribed (IDs 4, 5) only.
+                        # gasoline): the prescribed-CI provision is determined by
+                        # fuel category, so only one option is valid per fuel —
+                        # Gasoline -> Section 6 (5) (a) (ID 4), Diesel ->
+                        # Section 6 (5) (b) (ID 5). Offering both for every fuel
+                        # created duplicate/invalid pathways (#4435).
                         and_(
                             current_year
                             < int(LCFS_Constants.LEGISLATION_TRANSITION_YEAR),
                             FuelType.is_legacy == True,
-                            ProvisionOfTheAct.provision_of_the_act_id.in_([4, 5]),
+                            or_(
+                                and_(
+                                    FuelCategory.category == "Gasoline",
+                                    ProvisionOfTheAct.provision_of_the_act_id == 4,
+                                ),
+                                and_(
+                                    FuelCategory.category == "Diesel",
+                                    ProvisionOfTheAct.provision_of_the_act_id == 5,
+                                ),
+                            ),
                         ),
                         # Pre-2024 renewable fuel types (is_legacy=False, reused
                         # across eras): all legacy provisions except the


### PR DESCRIPTION
## Summary

Cherry-pick of #4517 into `release-v1.3.4`.

- Picked the net change of the original PR (merge commit `de5097366`, `-m 1`); applied cleanly with no conflicts.
- Applied diff is identical to the change that merged into `develop` and passed CI there.
- Original authorship preserved.