### PR TITLE
chore: upgrade vitest to v4 and update tests for breaking changes (#4529)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -90,8 +90,8 @@
         "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
-        "@vitest/coverage-v8": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "axe-core": "^4.10.3",
         "cross-env": "^7.0.3",
         "cypress": "^14.2.1",
@@ -121,7 +121,7 @@
         "storybook": "^8.6.17",
         "typescript": "^5.8.3",
         "vite-plugin-terminal": "^1.3.0",
-        "vitest": "3.2.4"
+        "vitest": "4.1.8"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.6.1"
@@ -222,20 +222,6 @@
       "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-32.3.9.tgz",
       "integrity": "sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==",
       "license": "MIT"
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -2207,16 +2193,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.5.0.tgz",
@@ -3396,6 +3372,13 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -5761,38 +5744,70 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
       }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
@@ -5860,22 +5875,22 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -5887,14 +5902,11 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -5907,16 +5919,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -5943,57 +5945,64 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/runner/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -6001,17 +6010,39 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/spy": {
       "version": "2.0.5",
@@ -6027,54 +6058,61 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
-      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.8.tgz",
+      "integrity": "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "4.1.8",
         "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "pathe": "^2.0.3",
-        "sirv": "^3.0.1",
-        "tinyglobby": "^0.2.14",
-        "tinyrainbow": "^2.0.0"
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.4"
+        "vitest": "4.1.8"
       }
     },
     "node_modules/@vitest/ui/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui/node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/ui/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.9",
@@ -6633,9 +6671,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
-      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7031,16 +7069,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cachedir": {
@@ -8817,9 +8845,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11788,21 +11816,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -13082,15 +13095,45 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/magicast/node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/magicast/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/make-dir": {
@@ -14041,6 +14084,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -17110,9 +17167,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -17411,26 +17468,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -17608,21 +17645,6 @@
         "tcomb": "^3.0.0"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^10.2.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -17691,11 +17713,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -17713,20 +17738,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18465,29 +18480,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite-plugin-svgr": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.5.0.tgz",
@@ -18541,65 +18533,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -18610,89 +18616,84 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vitest/node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/vitest/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/void-elements": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,8 +121,8 @@
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
-    "@vitest/coverage-v8": "3.2.4",
-    "@vitest/ui": "3.2.4",
+    "@vitest/coverage-v8": "4.1.8",
+    "@vitest/ui": "4.1.8",
     "axe-core": "^4.10.3",
     "cross-env": "^7.0.3",
     "cypress": "^14.2.1",
@@ -152,7 +152,7 @@
     "storybook": "^8.6.17",
     "typescript": "^5.8.3",
     "vite-plugin-terminal": "^1.3.0",
-    "vitest": "3.2.4"
+    "vitest": "4.1.8"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.6.1"

--- a/frontend/src/components/BCDataGrid/__tests__/BCGridBase.test.jsx
+++ b/frontend/src/components/BCDataGrid/__tests__/BCGridBase.test.jsx
@@ -94,6 +94,9 @@ describe('BCGridBase Component', () => {
   afterEach(() => {
     window.innerHeight = originalInnerHeight
     vi.restoreAllMocks()
+    // vitest 4: restoreAllMocks only affects vi.spyOn spies, so also reset
+    // vi.fn() module mocks (e.g. AgGridReact) back to their factory impls
+    vi.resetAllMocks()
   })
 
   describe('Basic Rendering', () => {
@@ -447,7 +450,8 @@ describe('BCGridBase Component', () => {
       )
 
       await act(async () => {
-        // Wait for initial setup
+        // Wait for the mocked AgGridReact's setTimeout(0) to fire onGridReady
+        await new Promise((resolve) => setTimeout(resolve, 0))
       })
 
       // Trigger resize event

--- a/frontend/src/components/BCDataGrid/components/StatusBar/__tests__/BCPaginationActions.test.jsx
+++ b/frontend/src/components/BCDataGrid/components/StatusBar/__tests__/BCPaginationActions.test.jsx
@@ -349,7 +349,9 @@ describe('BCPaginationActions', () => {
 
       // Mock current date
       const mockDate = new Date('2023-01-15T10:00:00Z')
-      vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+      vi.spyOn(global, 'Date').mockImplementation(function () {
+        return mockDate
+      })
       Date.prototype.toISOString = vi.fn(() => '2023-01-15T10:00:00.000Z')
 
       renderWithTheme(<BCPaginationActions {...defaultProps} />)

--- a/frontend/src/utils/__tests__/cellRenderers.test.jsx
+++ b/frontend/src/utils/__tests__/cellRenderers.test.jsx
@@ -14,11 +14,13 @@ import {
 import { wrapper } from '@/tests/utils/wrapper'
 
 // Mock ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn()
-}))
+global.ResizeObserver = vi.fn().mockImplementation(function () {
+  return {
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn()
+  }
+})
 
 vi.mock('react-router-dom', () => ({
   Link: ({ children, to }) => <a href={to}>{children}</a>,

--- a/frontend/src/utils/__tests__/keycloak.test.js
+++ b/frontend/src/utils/__tests__/keycloak.test.js
@@ -7,20 +7,22 @@ vi.mock('keycloak-js', () => {
     .fn()
     .mockImplementation(() => Promise.resolve(true))
   return {
-    default: vi.fn().mockImplementation(() => ({
-      clientId: 'mock-client-id',
-      authenticated: true,
-      token: 'mock-token',
-      idToken: 'mock-id-token',
-      tokenParsed: {
-        exp: Math.floor(Date.now() / 1000) + 300, // 5 minutes expiry
-        idToken: 'mock-id-token'
-      },
-      updateToken: mockUpdateToken,
-      endpoints: {
-        logout: () => 'mock-logout-endpoint'
+    default: vi.fn().mockImplementation(function () {
+      return {
+        clientId: 'mock-client-id',
+        authenticated: true,
+        token: 'mock-token',
+        idToken: 'mock-id-token',
+        tokenParsed: {
+          exp: Math.floor(Date.now() / 1000) + 300, // 5 minutes expiry
+          idToken: 'mock-id-token'
+        },
+        updateToken: mockUpdateToken,
+        endpoints: {
+          logout: () => 'mock-logout-endpoint'
+        }
       }
-    }))
+    })
   }
 })
 

--- a/frontend/src/utils/__tests__/logout-cache-clearing.test.js
+++ b/frontend/src/utils/__tests__/logout-cache-clearing.test.js
@@ -4,19 +4,21 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 // Mock Keycloak first
 vi.mock('keycloak-js', () => {
   return {
-    default: vi.fn().mockImplementation(() => ({
-      clientId: 'mock-client-id',
-      authenticated: true,
-      token: 'mock-token',
-      idToken: 'mock-id-token',
-      tokenParsed: {
-        exp: Math.floor(Date.now() / 1000) + 300,
-        idToken: 'mock-id-token'
-      },
-      endpoints: {
-        logout: () => 'mock-logout-endpoint'
+    default: vi.fn().mockImplementation(function () {
+      return {
+        clientId: 'mock-client-id',
+        authenticated: true,
+        token: 'mock-token',
+        idToken: 'mock-id-token',
+        tokenParsed: {
+          exp: Math.floor(Date.now() / 1000) + 300,
+          idToken: 'mock-id-token'
+        },
+        endpoints: {
+          logout: () => 'mock-logout-endpoint'
+        }
       }
-    }))
+    })
   }
 })
 

--- a/frontend/src/views/ComplianceReports/__tests__/CreditCalculator.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/CreditCalculator.test.jsx
@@ -936,7 +936,9 @@ describe('CreditCalculator', () => {
     it('calculates default compliance period correctly for dates before March 31', () => {
       // Mock date to February (before March 31)
       const mockDate = new Date('2023-02-15')
-      vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+      vi.spyOn(global, 'Date').mockImplementation(function () {
+        return mockDate
+      })
       
       render(
         <TestWrapper>

--- a/frontend/src/views/ComplianceReports/__tests__/EditViewComplianceReport.test.jsx
+++ b/frontend/src/views/ComplianceReports/__tests__/EditViewComplianceReport.test.jsx
@@ -1487,7 +1487,9 @@ describe('EditViewComplianceReport', () => {
 
         // Mock Date to be January of future year
         const mockDate = new Date(futureYear, 0, 15) // January 15th
-        vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+        vi.spyOn(global, 'Date').mockImplementation(function () {
+          return mockDate
+        })
 
         const futureDraftReport = {
           ...defaultReportData,
@@ -1519,7 +1521,9 @@ describe('EditViewComplianceReport', () => {
 
         // Mock Date to be January 2025 (after 2024 compliance period)
         const mockDate = new Date(2025, 0, 15) // January 15, 2025
-        vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+        vi.spyOn(global, 'Date').mockImplementation(function () {
+          return mockDate
+        })
 
         const draftReport = {
           ...defaultReportData,
@@ -1585,7 +1589,9 @@ describe('EditViewComplianceReport', () => {
 
         // Mock Date to be February 2025
         const mockDate = new Date(2025, 1, 15) // February 15, 2025
-        vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+        vi.spyOn(global, 'Date').mockImplementation(function () {
+          return mockDate
+        })
 
         const draftReport = {
           ...defaultReportData,
@@ -1617,7 +1623,9 @@ describe('EditViewComplianceReport', () => {
 
         // Mock Date to be March 2025 (well past compliance period)
         const mockDate = new Date(2025, 2, 15) // March 15, 2025
-        vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+        vi.spyOn(global, 'Date').mockImplementation(function () {
+          return mockDate
+        })
 
         const draftReport = {
           ...defaultReportData,
@@ -1650,7 +1658,9 @@ describe('EditViewComplianceReport', () => {
 
         // Mock Date to be January 2025 (11 years after 2014 compliance period)
         const mockDate = new Date(2025, 0, 15) // January 15, 2025
-        vi.spyOn(global, 'Date').mockImplementation(() => mockDate)
+        vi.spyOn(global, 'Date').mockImplementation(function () {
+          return mockDate
+        })
 
         const draftReport = {
           ...defaultReportData,

--- a/frontend/src/views/FinalSupplyEquipments/components/__tests__/MapComponents.test.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/components/__tests__/MapComponents.test.jsx
@@ -75,7 +75,9 @@ describe('MapComponents', () => {
     }
 
     vi.mocked(useMap).mockReturnValue(mockMap)
-    vi.mocked(Control).mockImplementation(() => mockControl)
+    vi.mocked(Control).mockImplementation(function () {
+      return mockControl
+    })
     vi.mocked(DomUtil.create).mockReturnValue(mockSection)
   })
 

--- a/frontend/src/views/FinalSupplyEquipments/components/__tests__/utils.test.js
+++ b/frontend/src/views/FinalSupplyEquipments/components/__tests__/utils.test.js
@@ -12,18 +12,22 @@ import {
 
 // Mock Leaflet
 vi.mock('leaflet', () => {
-  const mockDefaultIcon = vi.fn().mockImplementation(() => ({
-    type: 'default-icon'
-  }))
+  const mockDefaultIcon = vi.fn().mockImplementation(function () {
+    return {
+      type: 'default-icon'
+    }
+  })
 
-  const mockIcon = vi.fn().mockImplementation((options) => ({
-    options,
-    iconUrl: options.iconUrl,
-    shadowUrl: options.shadowUrl,
-    iconSize: options.iconSize,
-    iconAnchor: options.iconAnchor,
-    popupAnchor: options.popupAnchor
-  }))
+  const mockIcon = vi.fn().mockImplementation(function (options) {
+    return {
+      options,
+      iconUrl: options.iconUrl,
+      shadowUrl: options.shadowUrl,
+      iconSize: options.iconSize,
+      iconAnchor: options.iconAnchor,
+      popupAnchor: options.popupAnchor
+    }
+  })
 
   mockDefaultIcon.prototype = {
     _getIconUrl: vi.fn()

--- a/frontend/src/views/Organizations/OrganizationView/__tests__/OrganizationDetailsCard.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/__tests__/OrganizationDetailsCard.test.jsx
@@ -90,7 +90,9 @@ const mockNonGovUser = { hasRoles: () => false }
 describe('OrganizationDetailsCard', () => {
   afterEach(() => {
     cleanup()
-    vi.restoreAllMocks()
+    // vitest 4: restoreAllMocks only affects vi.spyOn spies, so use
+    // resetAllMocks to return vi.fn(impl) module mocks to their defaults
+    vi.resetAllMocks()
   })
 
   it('renders core org fields', () => {

--- a/frontend/testSetup.js
+++ b/frontend/testSetup.js
@@ -34,269 +34,270 @@ beforeAll(async () => {
   testServer.listen({
     onUnhandledRequest: 'bypass'
   })
-  vi.mock('react-snowfall')
-  
-  // Mock AG Grid enterprise to prevent import errors
-  vi.mock('ag-grid-enterprise', () => ({}))
-  
-  // Mock ag-grid-react with complete API
-  vi.mock('ag-grid-react', () => ({
-    AgGridReact: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        api: {
-          autoSizeAllColumns: vi.fn(),
-          sizeColumnsToFit: vi.fn(),
-          getDisplayedRowAtIndex: vi.fn(),
-          getRowNode: vi.fn(),
-          refreshCells: vi.fn(),
-          setRowData: vi.fn(),
-          getSelectedRows: vi.fn(),
-          deselectAll: vi.fn(),
-          selectAll: vi.fn(),
-          stopEditing: vi.fn(),
-          startEditingCell: vi.fn()
-        },
-        columnApi: {
-          autoSizeAllColumns: vi.fn(),
-          sizeColumnsToFit: vi.fn(),
-          getAllColumns: vi.fn(() => []),
-          setColumnVisible: vi.fn(),
-          getColumn: vi.fn()
-        }
-      }))
-      
-      const { 
-        columnDefs, rowData, onGridReady, onCellValueChanged, onCellEditingStopped,
-        defaultColDef, suppressMovableColumns, suppressRowClickSelection,
-        rowSelection, onSelectionChanged, getRowId, loading, suppressNoRowsOverlay,
-        ...domProps 
-      } = props
-
-      React.useEffect(() => {
-        if (onGridReady && ref?.current) {
-          onGridReady({
-            api: ref.current.api,
-            columnApi: ref.current.columnApi
-          })
-        }
-      }, [onGridReady])
-
-      // Also trigger cell value changed callbacks with proper API
-      React.useEffect(() => {
-        if (onCellValueChanged) {
-          // Mock cell change events should include our API
-          const mockEvent = {
-            api: ref?.current?.api || {
-              autoSizeAllColumns: vi.fn(),
-              refreshCells: vi.fn(),
-              getSelectedRows: vi.fn(() => []),
-              sizeColumnsToFit: vi.fn()
-            },
-            columnApi: ref?.current?.columnApi,
-            node: {
-              setDataValue: vi.fn(),
-              updateData: vi.fn()
-            },
-            data: {},
-            column: { colId: 'test' }
-          }
-          // Store this for tests that need to trigger events manually
-          if (ref?.current) {
-            ref.current.mockEvent = mockEvent
-          }
-        }
-      }, [onCellValueChanged])
-      
-      return React.createElement('div', {
-        ref,
-        ...domProps,
-        'data-test': 'ag-grid',
-        'data-loading': loading || false
-      }, 'AgGrid Mock')
-    })
-  }))
-  
-  // Mock problematic leaflet components
-  vi.mock('react-leaflet-custom-control', () => ({
-    default: ({ children }) => children
-  }))
-
-  vi.mock('react-leaflet-cluster', () => ({
-    default: ({ children }) => children
-  }))
-
-  vi.mock('react-leaflet', () => ({
-    useMap: () => ({
-      fitBounds: vi.fn()
-    }),
-    Marker: ({ children }) => children,
-    Popup: ({ children }) => children,
-    TileLayer: () => null
-  }))
-
-  // Global component mocks to fix common warnings
-  vi.mock('@/components/BCBox', () => ({
-    default: React.forwardRef(({ children, jsx, justifyContent, flexWrap, ...props }, ref) => {
-      // Filter out non-DOM props that cause warnings
-      const { 
-        variant, bgColor, color, opacity, borderRadius, shadow, coloredShadow,
-        component, ...domProps 
-      } = props
-      return React.createElement('div', { ref, ...domProps, style: { justifyContent, flexWrap } }, children)
-    })
-  }))
-
-  vi.mock('@/components/BCAlert', () => ({
-    default: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        triggerAlert: vi.fn(),
-        show: vi.fn(),
-        hide: vi.fn()
-      }))
-      const { children, severity, dismissible, noFade, delay, ...domProps } = props
-      return React.createElement('div', { 'data-test': 'bc-alert', ...domProps, 'data-severity': severity }, children)
-    }),
-    BCAlert2: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        triggerAlert: vi.fn(),
-        show: vi.fn(),
-        hide: vi.fn(),
-        clearAlert: vi.fn()
-      }))
-      const { children, severity, dismissible, noFade, delay, ...domProps } = props
-      const testId = domProps['data-test'] || 'bc-alert-2'
-      return React.createElement('div', { 'data-test': testId, ...domProps, 'data-severity': severity }, children)
-    }),
-    FloatingAlert: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        triggerAlert: vi.fn(),
-        show: vi.fn(),
-        hide: vi.fn(),
-        clearAlert: vi.fn()
-      }))
-      const { children, severity, dismissible, noFade, delay, ...domProps } = props
-      return React.createElement('div', { 'data-test': 'floating-alert', ...domProps, 'data-severity': severity }, children)
-    })
-  }))
-
-  vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
-    BCGridViewer: React.forwardRef((props, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        api: vi.fn(),
-        columnApi: vi.fn()
-      }))
-      const { 
-        children, jsx, justifyContent, gridRef, gridKey, columnDefs, 
-        rowData, defaultColDef, onGridReady, onCellValueChanged,
-        ...domProps 
-      } = props
-      return React.createElement('div', {
-        ref,
-        ...domProps,
-        'data-test': 'bc-grid-container',
-        style: { justifyContent }
-      }, children)
-    })
-  }))
-
-  // Mock form components
-  vi.mock('@/components/BCForm', () => ({
-    BCFormText: ({ name, control, label, optional, checkbox, checkboxLabel, onCheckboxChange, isChecked, disabled, ...props }) => {
-      const { variant, fullWidth, ...domProps } = props
-      // Create a properly labeled input that Testing Library can find by accessible name
-      // Also handle form values correctly for React Hook Form integration
-      return React.createElement('input', {
-        id: name,
-        name: name,
-        'data-test': name,
-        'data-testid': name,
-        'data-variant': variant || 'outlined',
-        'data-fullwidth': fullWidth || true,
-        required: !optional,
-        disabled: disabled,
-        'aria-label': label, // This provides the accessible name
-        placeholder: label, // Also add as placeholder for additional context
-        ...domProps
-      })
-    },
-    BCFormRadio: ({ name, control, options = [], ...props }) => {
-      return React.createElement(
-        'div',
-        { 'data-test': `${name}-radio-group` },
-        options.map((option, index) =>
-          React.createElement('input', {
-            key: `${name}-${index}`,
-            type: 'radio',
-            name: name,
-            value: option.value || option,
-            'data-testid': option.dataTestId || `${name}${index + 1}`,
-            'data-test': option.dataTestId || `${name}${index + 1}`
-          })
-        )
-      )
-    },
-    BCFormCheckbox: ({ name, form, options = [], ...props }) => {
-      return React.createElement('div', { 'data-test': `${name}-checkbox-group` },
-        options.map((option, index) =>
-          React.createElement('input', {
-            key: `${name}-${index}`,
-            type: 'checkbox',
-            'data-test': option.dataTestId || `${name}${index + 1}`,
-            'data-testid': option.dataTestId || `${name}${index + 1}`
-          })
-        )
-      )
-    },
-    BCFormAddressAutocomplete: ({ name, control, label, checkbox, checkboxLabel, onCheckboxChange, isChecked, disabled, onSelectAddress, ...props }) => {
-      return React.createElement('input', {
-        'data-test': name,
-        'data-name': name,
-        'aria-label': label,
-        placeholder: label,
-        disabled: disabled,
-        defaultValue: '',
-        ...props
-      })
-    }
-  }))
-
-  // Mock BCModal
-  vi.mock('@/components/BCModal', () => ({
-    default: ({ open, onClose, data }) => {
-      if (!open || !data) return null
-      return React.createElement('div', 
-        { 'data-test': 'modal', 'role': 'dialog' },
-        [
-          React.createElement('div', { key: 'title' }, data.title),
-          React.createElement('div', { key: 'content' }, data.content),
-          React.createElement('button', { 
-            key: 'primary', 
-            onClick: data.primaryButtonAction,
-            'role': 'button'
-          }, data.primaryButtonText || 'Confirm'),
-          React.createElement('button', { 
-            key: 'secondary', 
-            onClick: onClose,
-            'role': 'button',
-            'aria-label': data.secondaryButtonText || 'Cancel'
-          }, data.secondaryButtonText || 'Cancel')
-        ]
-      )
-    }
-  }))
-
-  // Mock AddressAutocomplete component
-  vi.mock('@/components/BCForm/AddressAutocomplete', () => ({
-    default: ({ name, ...props }) => {
-      return React.createElement('input', {
-        'data-test': 'address-autocomplete',
-        'data-name': name,
-        defaultValue: '',
-        ...props
-      })
-    }
-  }))
 })
+
+vi.mock('react-snowfall')
+
+// Mock AG Grid enterprise to prevent import errors
+vi.mock('ag-grid-enterprise', () => ({}))
+
+// Mock ag-grid-react with complete API
+vi.mock('ag-grid-react', () => ({
+  AgGridReact: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      api: {
+        autoSizeAllColumns: vi.fn(),
+        sizeColumnsToFit: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn(),
+        getRowNode: vi.fn(),
+        refreshCells: vi.fn(),
+        setRowData: vi.fn(),
+        getSelectedRows: vi.fn(),
+        deselectAll: vi.fn(),
+        selectAll: vi.fn(),
+        stopEditing: vi.fn(),
+        startEditingCell: vi.fn()
+      },
+      columnApi: {
+        autoSizeAllColumns: vi.fn(),
+        sizeColumnsToFit: vi.fn(),
+        getAllColumns: vi.fn(() => []),
+        setColumnVisible: vi.fn(),
+        getColumn: vi.fn()
+      }
+    }))
+    
+    const { 
+      columnDefs, rowData, onGridReady, onCellValueChanged, onCellEditingStopped,
+      defaultColDef, suppressMovableColumns, suppressRowClickSelection,
+      rowSelection, onSelectionChanged, getRowId, loading, suppressNoRowsOverlay,
+      ...domProps 
+    } = props
+
+    React.useEffect(() => {
+      if (onGridReady && ref?.current) {
+        onGridReady({
+          api: ref.current.api,
+          columnApi: ref.current.columnApi
+        })
+      }
+    }, [onGridReady])
+
+    // Also trigger cell value changed callbacks with proper API
+    React.useEffect(() => {
+      if (onCellValueChanged) {
+        // Mock cell change events should include our API
+        const mockEvent = {
+          api: ref?.current?.api || {
+            autoSizeAllColumns: vi.fn(),
+            refreshCells: vi.fn(),
+            getSelectedRows: vi.fn(() => []),
+            sizeColumnsToFit: vi.fn()
+          },
+          columnApi: ref?.current?.columnApi,
+          node: {
+            setDataValue: vi.fn(),
+            updateData: vi.fn()
+          },
+          data: {},
+          column: { colId: 'test' }
+        }
+        // Store this for tests that need to trigger events manually
+        if (ref?.current) {
+          ref.current.mockEvent = mockEvent
+        }
+      }
+    }, [onCellValueChanged])
+    
+    return React.createElement('div', {
+      ref,
+      ...domProps,
+      'data-test': 'ag-grid',
+      'data-loading': loading || false
+    }, 'AgGrid Mock')
+  })
+}))
+
+// Mock problematic leaflet components
+vi.mock('react-leaflet-custom-control', () => ({
+  default: ({ children }) => children
+}))
+
+vi.mock('react-leaflet-cluster', () => ({
+  default: ({ children }) => children
+}))
+
+vi.mock('react-leaflet', () => ({
+  useMap: () => ({
+    fitBounds: vi.fn()
+  }),
+  Marker: ({ children }) => children,
+  Popup: ({ children }) => children,
+  TileLayer: () => null
+}))
+
+// Global component mocks to fix common warnings
+vi.mock('@/components/BCBox', () => ({
+  default: React.forwardRef(({ children, jsx, justifyContent, flexWrap, ...props }, ref) => {
+    // Filter out non-DOM props that cause warnings
+    const { 
+      variant, bgColor, color, opacity, borderRadius, shadow, coloredShadow,
+      component, ...domProps 
+    } = props
+    return React.createElement('div', { ref, ...domProps, style: { justifyContent, flexWrap } }, children)
+  })
+}))
+
+vi.mock('@/components/BCAlert', () => ({
+  default: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      triggerAlert: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn()
+    }))
+    const { children, severity, dismissible, noFade, delay, ...domProps } = props
+    return React.createElement('div', { 'data-test': 'bc-alert', ...domProps, 'data-severity': severity }, children)
+  }),
+  BCAlert2: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      triggerAlert: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      clearAlert: vi.fn()
+    }))
+    const { children, severity, dismissible, noFade, delay, ...domProps } = props
+    const testId = domProps['data-test'] || 'bc-alert-2'
+    return React.createElement('div', { 'data-test': testId, ...domProps, 'data-severity': severity }, children)
+  }),
+  FloatingAlert: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      triggerAlert: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      clearAlert: vi.fn()
+    }))
+    const { children, severity, dismissible, noFade, delay, ...domProps } = props
+    return React.createElement('div', { 'data-test': 'floating-alert', ...domProps, 'data-severity': severity }, children)
+  })
+}))
+
+vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
+  BCGridViewer: React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      api: vi.fn(),
+      columnApi: vi.fn()
+    }))
+    const { 
+      children, jsx, justifyContent, gridRef, gridKey, columnDefs, 
+      rowData, defaultColDef, onGridReady, onCellValueChanged,
+      ...domProps 
+    } = props
+    return React.createElement('div', {
+      ref,
+      ...domProps,
+      'data-test': 'bc-grid-container',
+      style: { justifyContent }
+    }, children)
+  })
+}))
+
+// Mock form components
+vi.mock('@/components/BCForm', () => ({
+  BCFormText: ({ name, control, label, optional, checkbox, checkboxLabel, onCheckboxChange, isChecked, disabled, ...props }) => {
+    const { variant, fullWidth, ...domProps } = props
+    // Create a properly labeled input that Testing Library can find by accessible name
+    // Also handle form values correctly for React Hook Form integration
+    return React.createElement('input', {
+      id: name,
+      name: name,
+      'data-test': name,
+      'data-testid': name,
+      'data-variant': variant || 'outlined',
+      'data-fullwidth': fullWidth || true,
+      required: !optional,
+      disabled: disabled,
+      'aria-label': label, // This provides the accessible name
+      placeholder: label, // Also add as placeholder for additional context
+      ...domProps
+    })
+  },
+  BCFormRadio: ({ name, control, options = [], ...props }) => {
+    return React.createElement(
+      'div',
+      { 'data-test': `${name}-radio-group` },
+      options.map((option, index) =>
+        React.createElement('input', {
+          key: `${name}-${index}`,
+          type: 'radio',
+          name: name,
+          value: option.value || option,
+          'data-testid': option.dataTestId || `${name}${index + 1}`,
+          'data-test': option.dataTestId || `${name}${index + 1}`
+        })
+      )
+    )
+  },
+  BCFormCheckbox: ({ name, form, options = [], ...props }) => {
+    return React.createElement('div', { 'data-test': `${name}-checkbox-group` },
+      options.map((option, index) =>
+        React.createElement('input', {
+          key: `${name}-${index}`,
+          type: 'checkbox',
+          'data-test': option.dataTestId || `${name}${index + 1}`,
+          'data-testid': option.dataTestId || `${name}${index + 1}`
+        })
+      )
+    )
+  },
+  BCFormAddressAutocomplete: ({ name, control, label, checkbox, checkboxLabel, onCheckboxChange, isChecked, disabled, onSelectAddress, ...props }) => {
+    return React.createElement('input', {
+      'data-test': name,
+      'data-name': name,
+      'aria-label': label,
+      placeholder: label,
+      disabled: disabled,
+      defaultValue: '',
+      ...props
+    })
+  }
+}))
+
+// Mock BCModal
+vi.mock('@/components/BCModal', () => ({
+  default: ({ open, onClose, data }) => {
+    if (!open || !data) return null
+    return React.createElement('div', 
+      { 'data-test': 'modal', 'role': 'dialog' },
+      [
+        React.createElement('div', { key: 'title' }, data.title),
+        React.createElement('div', { key: 'content' }, data.content),
+        React.createElement('button', { 
+          key: 'primary', 
+          onClick: data.primaryButtonAction,
+          'role': 'button'
+        }, data.primaryButtonText || 'Confirm'),
+        React.createElement('button', { 
+          key: 'secondary', 
+          onClick: onClose,
+          'role': 'button',
+          'aria-label': data.secondaryButtonText || 'Cancel'
+        }, data.secondaryButtonText || 'Cancel')
+      ]
+    )
+  }
+}))
+
+// Mock AddressAutocomplete component
+vi.mock('@/components/BCForm/AddressAutocomplete', () => ({
+  default: ({ name, ...props }) => {
+    return React.createElement('input', {
+      'data-test': 'address-autocomplete',
+      'data-name': name,
+      defaultValue: '',
+      ...props
+    })
+  }
+}))
 
 afterEach(() => {
   cleanup()

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './testSetup.js',
+    // vitest 4 no longer excludes cypress/dist by default, so scope to src
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
     coverage: {
       provider: 'v8',
       // thresholds: {


### PR DESCRIPTION
## Summary

Upgrades the frontend test stack from **vitest 3.2.4 to 4.1.8** (`vitest`, `@vitest/coverage-v8`, `@vitest/ui` — these must move together), resolving the **critical severity Dependabot alert** on vitest, and migrates the test suite for the v4 breaking changes.

Closes #4529. Supersedes #4518 (the automated bump, which failed 14+ of 32 frontend test shards because of the breaking changes below).

## Breaking changes handled

**1. Mocks follow real JS constructor semantics** ([migration guide](https://vitest.dev/guide/migration.html))
`vi.fn(() => obj)` / `.mockImplementation(() => obj)` can no longer be invoked with `new` — arrow functions aren't constructible. Converted constructor-style mocks to regular functions in:
- `Date` mocks — `BCPaginationActions`, `CreditCalculator`, `EditViewComplianceReport` tests
- `ResizeObserver` — `cellRenderers` tests
- Keycloak default export — `keycloak` and `logout-cache-clearing` tests (these previously crashed at module level)
- leaflet `Control` / `Icon` — `MapComponents` and FSE `utils` tests

**2. `vi.restoreAllMocks()` no longer resets `vi.fn()` module mocks** (spies only)
Per-test `mockImplementation`/`mockReturnValue` overrides leaked into subsequent tests. Switched the affected suites (`OrganizationDetailsCard`, `BCGridBase`) to `vi.resetAllMocks()`, which in v4 restores the factory implementations.

**3. Default `exclude` slimmed to `node_modules`/`.git`**
v4 no longer excludes `cypress/`/`dist/` by default, and this repo has `*.test.js` files under `cypress/e2e/` that vitest started collecting. Scoped `test.include` to `src/` in `vite.config.ts`.

**4. Nested `vi.mock()` deprecation**
Moved the `vi.mock()` calls in `testSetup.js` from inside `beforeAll` to top level — they were always hoisted anyway, and nested calls will become an error in a future vitest version.

**5. Timing fix**
One `BCGridBase` test relied on an empty `act()` to flush a `setTimeout(0)`-based `onGridReady`; it now awaits the timer explicitly.

## Verification

- Full local suite: **5,542 passed, 0 failed** (11 pre-existing skips), exit 0
- 43 more tests run than on `develop`'s baseline — tests in suites that previously crashed during collection under v4
- Coverage (`v8` provider, now AST-based remapping) verified working with the existing config
- CI shard/blob/merge pipeline audited: all flags used by the workflows (`--shard`, `--reporter=blob`, `--reporter=github-actions`, `--merge-reports`) still exist in v4, and shard + merge jobs both install from the lockfile so versions stay in sync
- Lockfile diff is vitest-ecosystem only (e.g. `vite-node` removed — v4 uses Vite's Module Runner)