### PR TITLE
fix: CI application wizard refinements (#4531, #4532, #4534, #4536, #4537)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-06-15-00-00_f3a8c1d2e4b5.py
+++ b/backend/lcfs/db/migrations/versions/2026-06-15-00-00_f3a8c1d2e4b5.py
@@ -1,0 +1,60 @@
+"""CI application facility nameplate capacity unit -> QuantityUnitsEnum
+
+Switches ci_application.facility_nameplate_capacity_unit_id (an FK to the
+energy-density `unit_of_measure` table — the wrong lookup, surfacing MJ/L,
+gCO²e/MJ, etc. in the form) to facility_nameplate_capacity_unit storing the
+QuantityUnitsEnum (L, kg, kWh, Gj, m³), matching how fuel codes model a
+facility nameplate capacity unit.
+
+Revision ID: f3a8c1d2e4b5
+Revises: e5f7a9b1c3d4
+Create Date: 2026-06-15 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "f3a8c1d2e4b5"
+down_revision = "e5f7a9b1c3d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Reuse the existing `quantityunitsenum` Postgres type (created for fuel
+    # codes); do not recreate it.
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "facility_nameplate_capacity_unit",
+            postgresql.ENUM(name="quantityunitsenum", create_type=False),
+            nullable=True,
+            comment="Unit of measure for the facility nameplate capacity",
+        ),
+    )
+    # Existing values pointed at energy-density units and cannot be mapped to a
+    # physical capacity unit, so they are intentionally not migrated (left NULL).
+    # Dropping the column also drops its foreign-key constraint.
+    op.drop_column("ci_application", "facility_nameplate_capacity_unit_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "facility_nameplate_capacity_unit_id",
+            sa.Integer(),
+            nullable=True,
+            comment="Unit of measure for the facility nameplate capacity",
+        ),
+    )
+    op.create_foreign_key(
+        "ci_application_facility_nameplate_capacity_unit_id_fkey",
+        "ci_application",
+        "unit_of_measure",
+        ["facility_nameplate_capacity_unit_id"],
+        ["uom_id"],
+    )
+    op.drop_column("ci_application", "facility_nameplate_capacity_unit")

--- a/backend/lcfs/db/migrations/versions/2026-06-17-00-00_f3a8c1d2e4b5.py
+++ b/backend/lcfs/db/migrations/versions/2026-06-17-00-00_f3a8c1d2e4b5.py
@@ -7,8 +7,8 @@ QuantityUnitsEnum (L, kg, kWh, Gj, m³), matching how fuel codes model a
 facility nameplate capacity unit.
 
 Revision ID: f3a8c1d2e4b5
-Revises: e5f7a9b1c3d4
-Create Date: 2026-06-15 00:00:00.000000
+Revises: d9c8b7a6e5f4
+Create Date: 2026-06-17 00:00:00.000000
 """
 
 from alembic import op
@@ -17,7 +17,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "f3a8c1d2e4b5"
-down_revision = "e5f7a9b1c3d4"
+down_revision = "d9c8b7a6e5f4"
 branch_labels = None
 depends_on = None
 

--- a/backend/lcfs/db/models/ci_application/CIApplication.py
+++ b/backend/lcfs/db/models/ci_application/CIApplication.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     String,
     Text,
     Date,
+    Enum,
     ForeignKey,
     Table,
     TIMESTAMP,
@@ -12,6 +13,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from lcfs.db.base import BaseModel, Auditable, Versioning
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 
 # Association table linking CI applications to uploaded documents
 ci_application_document_association = Table(
@@ -126,10 +128,9 @@ class CIApplication(BaseModel, Auditable, Versioning):
         nullable=False,
         comment="Annual nameplate capacity of the fuel production facility",
     )
-    facility_nameplate_capacity_unit_id = Column(
-        Integer,
-        ForeignKey("unit_of_measure.uom_id"),
-        nullable=False,
+    facility_nameplate_capacity_unit = Column(
+        Enum(QuantityUnitsEnum),
+        nullable=True,
         comment="Unit of measure for the facility nameplate capacity",
     )
 
@@ -292,10 +293,6 @@ class CIApplication(BaseModel, Auditable, Versioning):
     assigned_analyst = relationship(
         "UserProfile",
         foreign_keys=[assigned_analyst_id],
-        lazy="selectin",
-    )
-    facility_nameplate_capacity_unit = relationship(
-        "UnitOfMeasure",
         lazy="selectin",
     )
     assigned_analyst = relationship(

--- a/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_list_view.py
@@ -8,6 +8,7 @@ from lcfs.db.models.ci_application import (
     CIApplication,
     CIApplicationStatus,
 )
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 from lcfs.web.api.base import (
     FilterModel,
     PaginationRequestSchema,
@@ -104,7 +105,7 @@ def _application(
         facility_country="Argentina",
         facility_iso="AR",
         facility_nameplate_capacity=1000,
-        facility_nameplate_capacity_unit_id=1,
+        facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
         proposed_fuel_code_effective_date=date(2026, 6, 1),
         priority_score=priority_score,
         verification_level=verification_level,

--- a/backend/lcfs/tests/ci_application/test_ci_application_repo.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_repo.py
@@ -10,7 +10,7 @@ from lcfs.db.models.ci_application import (
     CIApplicationHistory,
     CIApplicationStatus,
 )
-from lcfs.db.models.fuel.UnitOfMeasure import UnitOfMeasure
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 from lcfs.web.api.base import FilterModel, PaginationRequestSchema, SortOrder
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 
@@ -47,10 +47,6 @@ def _make_status(name="Draft", ident=1):
     )
 
 
-def _make_uom(uom_id=1, name="Litres"):
-    return UnitOfMeasure(uom_id=uom_id, name=name, description=name)
-
-
 def _make_application(
     ci_application_id=10,
     organization_id=1,
@@ -67,7 +63,7 @@ def _make_application(
         facility_country=facility_country,
         facility_iso="AR",
         facility_nameplate_capacity=facility_nameplate_capacity,
-        facility_nameplate_capacity_unit_id=1,
+        facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
         proposed_fuel_code_effective_date=date(2026, 6, 1),
         group_uuid="abc",
         version=0,
@@ -112,17 +108,6 @@ async def test_get_status_by_name_missing(repo, mock_db):
     mock_db.execute.return_value = result
 
     assert await repo.get_status_by_name("Nope") is None
-
-
-@pytest.mark.anyio
-async def test_get_units_of_measure(repo, mock_db):
-    uoms = [_make_uom(1, "Litres"), _make_uom(2, "Kilograms")]
-    result = MagicMock()
-    result.scalars.return_value.all.return_value = uoms
-    mock_db.execute.return_value = result
-
-    items = await repo.get_units_of_measure()
-    assert items == uoms
 
 
 # ---------------------------------------------------------------------------

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -8,7 +8,7 @@ import pytest
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models.ci_application import CIApplication, CIApplicationStatus
-from lcfs.db.models.fuel.UnitOfMeasure import UnitOfMeasure
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
@@ -64,10 +64,6 @@ def _status(name="Draft", ident=1):
     )
 
 
-def _uom(uom_id=1, name="Litres"):
-    return UnitOfMeasure(uom_id=uom_id, name=name, description=name)
-
-
 def _organization(org_id=1, name="Fuel Producer Ltd."):
     return SimpleNamespace(
         organization_id=org_id,
@@ -94,7 +90,7 @@ def _ci_application(
 ):
     status = status or _status()
     organization = organization or _organization()
-    unit = unit or _uom()
+    unit = unit or QuantityUnitsEnum.Litres
     return SimpleNamespace(
         ci_application_id=ci_application_id,
         organization_id=organization.organization_id,
@@ -106,7 +102,6 @@ def _ci_application(
         facility_country="Argentina",
         facility_iso="AR",
         facility_nameplate_capacity=1000,
-        facility_nameplate_capacity_unit_id=unit.uom_id,
         facility_nameplate_capacity_unit=unit,
         proposed_fuel_code_effective_date=date(2026, 6, 1),
         pathway_description=None,
@@ -131,7 +126,7 @@ def _step1_payload(**overrides):
         facility_country="Argentina",
         facility_iso="AR",
         facility_nameplate_capacity=1000,
-        facility_nameplate_capacity_unit_id=1,
+        facility_nameplate_capacity_unit="L",
         proposed_fuel_code_effective_date=date(2026, 6, 1),
     )
     base.update(overrides)
@@ -152,8 +147,6 @@ async def test_get_table_options_returns_lookup_data(service, repo):
         _status("Completed", 4),
         _status("Withdrawn", 5),
     ]
-    repo.get_units_of_measure.return_value = [_uom(1, "Litres"), _uom(2, "Kilograms")]
-
     result = await service.get_table_options()
 
     assert isinstance(result, CITableOptionsSchema)
@@ -164,7 +157,7 @@ async def test_get_table_options_returns_lookup_data(service, repo):
         CIApplicationStatusEnum.Completed,
         CIApplicationStatusEnum.Withdrawn,
     ]
-    assert {u.name for u in result.units_of_measure} == {"Litres", "Kilograms"}
+    assert set(result.units_of_measure) == {u.value for u in QuantityUnitsEnum}
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +225,7 @@ async def test_get_ci_application_returns_full_schema(service, repo):
         result.organization.address_line
         == "123 Main St, Suite 200, Victoria, BC, Canada, V8V 1A1"
     )
-    assert result.facility_nameplate_capacity_unit.name == "Litres"
+    assert result.facility_nameplate_capacity_unit == "L"
 
 
 @pytest.mark.anyio
@@ -312,7 +305,7 @@ async def test_update_step1_writes_fields_and_marks_update(service, repo, mock_u
         facility_country="Canada",
         facility_iso="CA",
         facility_nameplate_capacity=2500,
-        facility_nameplate_capacity_unit_id=2,
+        facility_nameplate_capacity_unit="kg",
         proposed_fuel_code_effective_date=date(2027, 1, 1),
     )
 
@@ -321,7 +314,7 @@ async def test_update_step1_writes_fields_and_marks_update(service, repo, mock_u
     assert ci.facility_city == "Vancouver"
     assert ci.facility_country == "Canada"
     assert ci.facility_nameplate_capacity == 2500
-    assert ci.facility_nameplate_capacity_unit_id == 2
+    assert ci.facility_nameplate_capacity_unit == QuantityUnitsEnum.Kilograms
     assert ci.action_type == ActionTypeEnum.UPDATE
     assert ci.update_user == "ci_applicant_user"
     assert isinstance(result, CIApplicationSchema)

--- a/backend/lcfs/tests/ci_application/test_ci_application_validation.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_validation.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException, status
 
 from lcfs.db.models.ci_application import CIApplication
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.ci_application.validation import CIApplicationValidation
 
@@ -34,7 +35,7 @@ def _application(application_id=10, organization_id=1):
         status_id=1,
         facility_country="Argentina",
         facility_nameplate_capacity=1000,
-        facility_nameplate_capacity_unit_id=1,
+        facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
         group_uuid="abc",
         version=0,
     )

--- a/backend/lcfs/tests/ci_application/test_ci_application_views.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_views.py
@@ -17,7 +17,6 @@ from lcfs.web.api.ci_application.schema import (
     CIApplicationStatusSchema,
     CITableOptionsSchema,
     OrganizationInfoSchema,
-    UnitOfMeasureSchema,
 )
 from lcfs.web.api.base import PaginationResponseSchema
 
@@ -46,10 +45,7 @@ def _table_options() -> CITableOptionsSchema:
                 description="Recommended",
             ),
         ],
-        units_of_measure=[
-            UnitOfMeasureSchema(uom_id=1, name="Litres", description="Litres"),
-            UnitOfMeasureSchema(uom_id=2, name="Kilograms", description="Kilograms"),
-        ],
+        units_of_measure=["L", "kg"],
     )
 
 
@@ -73,10 +69,7 @@ def _ci_full_schema(ci_application_id: int = 10) -> CIApplicationSchema:
         facility_country="Argentina",
         facility_iso="AR",
         facility_nameplate_capacity=1000,
-        facility_nameplate_capacity_unit_id=1,
-        facility_nameplate_capacity_unit=UnitOfMeasureSchema(
-            uom_id=1, name="Litres", description="Litres"
-        ),
+        facility_nameplate_capacity_unit="L",
         proposed_fuel_code_effective_date=date(2026, 6, 1),
     )
 
@@ -93,7 +86,7 @@ def _ci_list_schema() -> CIApplicationsListSchema:
                 ),
                 facility_country="Argentina",
                 facility_nameplate_capacity=1000,
-                facility_nameplate_capacity_unit_id=1,
+                facility_nameplate_capacity_unit="L",
                 proposed_fuel_code_effective_date=date(2026, 6, 1),
                 update_date=datetime(2026, 5, 1, tzinfo=timezone.utc).isoformat(),
                 create_date=datetime(2026, 4, 1, tzinfo=timezone.utc).isoformat(),
@@ -123,7 +116,7 @@ def _step1_payload():
         "facilityCountry": "Argentina",
         "facilityIso": "AR",
         "facilityNameplateCapacity": 1000,
-        "facilityNameplateCapacityUnitId": 1,
+        "facilityNameplateCapacityUnit": "L",
         "proposedFuelCodeEffectiveDate": "2026-06-01",
     }
 

--- a/backend/lcfs/web/api/ci_application/repo.py
+++ b/backend/lcfs/web/api/ci_application/repo.py
@@ -36,7 +36,6 @@ from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
 from lcfs.db.models.fuel.FuelType import FuelType
 from lcfs.db.models.fuel.TransportMode import TransportMode
-from lcfs.db.models.fuel.UnitOfMeasure import UnitOfMeasure
 from lcfs.db.models.organization.Organization import Organization
 from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.db.models.user.Role import Role, RoleEnum
@@ -133,13 +132,6 @@ class CIApplicationRepository:
         return result.scalar_one_or_none()
 
     @repo_handler
-    async def get_units_of_measure(self) -> Sequence[UnitOfMeasure]:
-        result = await self.db.execute(
-            select(UnitOfMeasure).order_by(UnitOfMeasure.uom_id)
-        )
-        return result.scalars().all()
-
-    @repo_handler
     async def get_pathway_application_types(
         self,
     ) -> Sequence[PathwayApplicationType]:
@@ -203,7 +195,6 @@ class CIApplicationRepository:
                     Organization.org_address
                 ),
                 selectinload(CIApplication.ci_application_status),
-                selectinload(CIApplication.facility_nameplate_capacity_unit),
                 selectinload(CIApplication.assigned_analyst),
                 selectinload(CIApplication.verification_1_user),
                 selectinload(CIApplication.verification_2_user),

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -18,6 +18,7 @@ from pydantic import EmailStr, Field, field_validator, model_validator
 
 from lcfs.services.s3.schema import FileResponseSchema
 from lcfs.web.api.base import BaseSchema, PaginationResponseSchema
+from lcfs.web.api.fuel_type.schema import FuelTypeQuantityUnitsEnumSchema
 from lcfs.web.api.fuel_code.schema import (
     CoProcessedEnumSchema,
     FuelTypeQuantityUnitsEnumSchema,
@@ -51,12 +52,6 @@ class CIRiskAssessmentEnum(str, Enum):
 class CIApplicationStatusSchema(BaseSchema):
     ci_application_status_id: int
     status: CIApplicationStatusEnum
-    description: Optional[str] = None
-
-
-class UnitOfMeasureSchema(BaseSchema):
-    uom_id: int
-    name: str
     description: Optional[str] = None
 
 
@@ -153,7 +148,7 @@ class CITableOptionsSchema(BaseSchema):
     """Reference data needed to render the CI application forms."""
 
     statuses: List[CIApplicationStatusSchema]
-    units_of_measure: List[UnitOfMeasureSchema]
+    units_of_measure: List[str]
     pathway_application_types: List[PathwayApplicationTypeSchema] = []
     pathway_fuel_code_types: List[PathwayFuelCodeTypeSchema] = []
     fuel_types: List[FuelTypeOptionSchema] = []
@@ -180,7 +175,7 @@ class CIApplicationStep1Schema(BaseSchema):
     facility_country: str = Field(..., max_length=500)
     facility_iso: Optional[str] = Field(default=None, max_length=10)
     facility_nameplate_capacity: int = Field(..., gt=0)
-    facility_nameplate_capacity_unit_id: int
+    facility_nameplate_capacity_unit: FuelTypeQuantityUnitsEnumSchema
     proposed_fuel_code_effective_date: Optional[date] = None
 
 
@@ -347,7 +342,7 @@ class CIApplicationBaseSchema(BaseSchema):
     facility_province_state: Optional[str] = None
     facility_country: Optional[str] = None
     facility_nameplate_capacity: Optional[int] = None
-    facility_nameplate_capacity_unit_id: Optional[int] = None
+    facility_nameplate_capacity_unit: Optional[str] = None
     proposed_fuel_code_effective_date: Optional[date] = None
     preliminary_risk_assessment: Optional[CIRiskAssessmentEnum] = None
     priority_score: Optional[int] = None
@@ -374,8 +369,7 @@ class CIApplicationSchema(BaseSchema):
     facility_country: Optional[str] = None
     facility_iso: Optional[str] = None
     facility_nameplate_capacity: Optional[int] = None
-    facility_nameplate_capacity_unit_id: Optional[int] = None
-    facility_nameplate_capacity_unit: Optional[UnitOfMeasureSchema] = None
+    facility_nameplate_capacity_unit: Optional[str] = None
     proposed_fuel_code_effective_date: Optional[date] = None
 
     # Step 2

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -22,6 +22,7 @@ from lcfs.db.models.ci_application.CIApplication import (
     CI_DOC_CATEGORY_TECHNICAL_REPORT,
 )
 from lcfs.db.models.fuel.FuelCode import FuelCode
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
 from lcfs.services.s3.schema import FileResponseSchema
 from lcfs.web.api.base import (
     PaginationRequestSchema,
@@ -55,7 +56,6 @@ from lcfs.web.api.ci_application.schema import (
     PathwayFuelCodeTypeSchema,
     PathwayInputSchema,
     PathwaySchema,
-    UnitOfMeasureSchema,
 )
 from lcfs.web.api.role.schema import user_has_roles
 from lcfs.web.core.decorators import service_handler
@@ -203,9 +203,8 @@ def _to_full_schema(
         facility_country=ci.facility_country,
         facility_iso=ci.facility_iso,
         facility_nameplate_capacity=ci.facility_nameplate_capacity,
-        facility_nameplate_capacity_unit_id=ci.facility_nameplate_capacity_unit_id,
         facility_nameplate_capacity_unit=(
-            UnitOfMeasureSchema.model_validate(ci.facility_nameplate_capacity_unit)
+            ci.facility_nameplate_capacity_unit.value
             if ci.facility_nameplate_capacity_unit
             else None
         ),
@@ -318,7 +317,11 @@ def _to_list_item(
         facility_province_state=ci.facility_province_state,
         facility_country=ci.facility_country,
         facility_nameplate_capacity=ci.facility_nameplate_capacity,
-        facility_nameplate_capacity_unit_id=ci.facility_nameplate_capacity_unit_id,
+        facility_nameplate_capacity_unit=(
+            ci.facility_nameplate_capacity_unit.value
+            if ci.facility_nameplate_capacity_unit
+            else None
+        ),
         proposed_fuel_code_effective_date=ci.proposed_fuel_code_effective_date,
         preliminary_risk_assessment=getattr(ci, "preliminary_risk_assessment", None),
         update_date=ci.update_date.isoformat() if ci.update_date else None,
@@ -626,7 +629,6 @@ class CIApplicationServices:
     @service_handler
     async def get_table_options(self) -> CITableOptionsSchema:
         statuses = await self.repo.get_statuses()
-        units = await self.repo.get_units_of_measure()
         application_types = await self.repo.get_pathway_application_types()
         fuel_code_types = await self.repo.get_pathway_fuel_code_types()
         fuel_types = await self.repo.get_fuel_types()
@@ -634,7 +636,9 @@ class CIApplicationServices:
         fuel_codes = await self.repo.get_approved_fuel_codes()
         return CITableOptionsSchema(
             statuses=[CIApplicationStatusSchema.model_validate(s) for s in statuses],
-            units_of_measure=[UnitOfMeasureSchema.model_validate(u) for u in units],
+            # Facility nameplate capacity is a physical quantity — use the same
+            # units as fuel codes (L, kg, kWh, Gj, m³), not energy densities.
+            units_of_measure=[unit.value for unit in QuantityUnitsEnum],
             pathway_application_types=[
                 PathwayApplicationTypeSchema.model_validate(t)
                 for t in application_types
@@ -896,7 +900,9 @@ class CIApplicationServices:
             facility_country=data.facility_country,
             facility_iso=data.facility_iso,
             facility_nameplate_capacity=data.facility_nameplate_capacity,
-            facility_nameplate_capacity_unit_id=data.facility_nameplate_capacity_unit_id,
+            facility_nameplate_capacity_unit=QuantityUnitsEnum(
+                data.facility_nameplate_capacity_unit
+            ),
             proposed_fuel_code_effective_date=data.proposed_fuel_code_effective_date,
             group_uuid=str(uuid.uuid4()),
             version=0,
@@ -922,8 +928,8 @@ class CIApplicationServices:
         ci_application.facility_country = data.facility_country
         ci_application.facility_iso = data.facility_iso
         ci_application.facility_nameplate_capacity = data.facility_nameplate_capacity
-        ci_application.facility_nameplate_capacity_unit_id = (
-            data.facility_nameplate_capacity_unit_id
+        ci_application.facility_nameplate_capacity_unit = QuantityUnitsEnum(
+            data.facility_nameplate_capacity_unit
         )
         ci_application.proposed_fuel_code_effective_date = (
             data.proposed_fuel_code_effective_date

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -135,6 +135,7 @@
     "responseExpectations": "Applicants must respond to requests for additional information and/or corrections within 8 weeks. Failure to respond within this period may result in rejection of the application.",
     "commentsHeader": "Comments",
     "commentsToOrganizationHeader": "Comments to the organization",
+    "commentsToGovernmentHeader": "Comments to the Government of B.C.",
     "addCommentLabel": "Comments to government staff to support your application (optional):",
     "addComment": "Add comment",
     "noComments": "No comments yet.",

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -25,7 +25,7 @@
     "city": "City",
     "provinceState": "Province/State",
     "country": "Country",
-    "facilityNameplate": "Facility nameplate",
+    "facilityNameplate": "Facility nameplate capacity",
     "unitOfMeasure": "Unit of measure",
     "proposedFuelCodeEffective": "Proposed fuel code effective",
     "proposedFuelCodeEffectiveHelp": "(optional, if left blank, default is the date of application receipt by the Ministry)",
@@ -86,28 +86,9 @@
     },
     "otherPlaceholder": "Brief description of other supporting documentation included",
     "ghgeniusHeader": "GHGenius Modelling — Input & output tables",
-    "ghgeniusIntro": "Download the Excel template below and complete it with the required modelling input and output tables. When completed, upload the Excel spreadsheet.",
+    "ghgeniusIntro": "Complete the required modelling input and output tables in the GHGenius Excel template, then upload the completed spreadsheet.",
     "uploadGHGenius": "Upload GHGenius model",
-    "downloadTemplate": "Download GHGenius Excel template",
     "ghgeniusRequired": "GHGenius model upload is required.",
-    "modellingInstructions": {
-      "header": "Provide model inputs/outputs for each fuel pathway in the tables provided in the Excel template",
-      "inputsIntro": "For model inputs:",
-      "inputs": {
-        "region": "Ensure model region is stated for each model run",
-        "grouping": "Group inputs by the sheet they are located in (e.g. group together all inputs of the fuel production run entered in the Coprods sheet)",
-        "ordering": "Ensure that the inputs are ordered sequentially by their location in the respective sheet (e.g. cell AZ241 should be above cell AZ243)",
-        "descriptors": "Include GHGenius column and row descriptors in the description (e.g. instead of \"feedstock transport\" state \"corn oil rail distance\" which identifies the column \"corn oil\" and row \"rail\")"
-      },
-      "outputsIntro": "For model outputs:",
-      "outputs": {
-        "copyFromTab": "Where possible, copy results directly from the BC LCFS Tab in GHGenius",
-        "columnLabel": "Provide column label in the Results Location field for results pulled from GHGenius",
-        "outOfModel": "For results from out of model calculations state 'out of model calc.' in the Results Location field and ensure the calculations are included in the Technical Report",
-        "sampleTable": "A sample output table is provided in the Appendix of",
-        "rlcfLink": "RLCF-008 Carbon Intensity Applications"
-      }
-    },
     "saveAndProceed": "Save & proceed",
     "saveSuccess": "Documents saved.",
     "errors": {

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -505,7 +505,9 @@ const EditViewCIApplicationBase = () => {
                   color="primary"
                   component="div"
                 >
-                  {t('carbonIntensity:step5.commentsToOrganizationHeader')}
+                  {isGovernment
+                    ? t('carbonIntensity:step5.commentsToOrganizationHeader')
+                    : t('carbonIntensity:step5.commentsToGovernmentHeader')}
                 </BCTypography>
               </AccordionSummary>
               <AccordionDetails>

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -372,6 +372,7 @@ const EditViewCIApplicationBase = () => {
         onDelete={canDelete ? openDeleteConfirmation : null}
         isSaving={isSaving || isDeleting}
         readOnly={!isDraft}
+        showTitle={false}
       />
     ) : (
       <StepStub titleKey="carbonIntensity:steps.step3" />

--- a/frontend/src/views/CarbonIntensity/__tests__/ApplicationInformationStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/ApplicationInformationStep.test.jsx
@@ -25,10 +25,7 @@ const baseProps = {
     email: 'Zimmerman@fuelproducerltd.ar',
     phone: '+54 9 11 1234-5678'
   },
-  unitsOfMeasure: [
-    { uomId: 1, name: 'Litres' },
-    { uomId: 2, name: 'Kilograms' }
-  ]
+  unitsOfMeasure: ['L', 'kg']
 }
 
 describe('ApplicationInformationStep', () => {
@@ -51,7 +48,7 @@ describe('ApplicationInformationStep', () => {
     expect(document.getElementById('facilityCountry')).toBeInTheDocument()
     expect(document.getElementById('facilityNameplateCapacity')).toBeInTheDocument()
     expect(
-      document.getElementById('facilityNameplateCapacityUnitId')
+      document.getElementById('facilityNameplateCapacityUnit')
     ).toBeInTheDocument()
     expect(
       document.getElementById('proposedFuelCodeEffectiveDate')
@@ -133,7 +130,7 @@ describe('ApplicationInformationStep', () => {
     // MUI Select: open the listbox and click the desired option.
     const combobox = screen.getByRole('combobox')
     await user.click(combobox)
-    const option = await screen.findByRole('option', { name: 'Kilograms' })
+    const option = await screen.findByRole('option', { name: 'kg' })
     await user.click(option)
 
     fireEvent.change(document.getElementById('proposedFuelCodeEffectiveDate'), {
@@ -149,7 +146,7 @@ describe('ApplicationInformationStep', () => {
       facilityProvinceState: 'BC',
       facilityCountry: 'Canada',
       facilityNameplateCapacity: 2500,
-      facilityNameplateCapacityUnitId: 2,
+      facilityNameplateCapacityUnit: 'kg',
       proposedFuelCodeEffectiveDate: '2026-09-01'
     })
   })
@@ -161,7 +158,7 @@ describe('ApplicationInformationStep', () => {
       facilityProvinceState: 'Santa Fe',
       facilityCountry: 'Argentina',
       facilityNameplateCapacity: 1500,
-      facilityNameplateCapacityUnitId: 1,
+      facilityNameplateCapacityUnit: 'L',
       proposedFuelCodeEffectiveDate: '2026-06-01'
     }
     render(

--- a/frontend/src/views/CarbonIntensity/__tests__/CIApplicationProgress.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/CIApplicationProgress.test.jsx
@@ -97,6 +97,32 @@ describe('CIApplicationProgress', () => {
     vi.useRealTimers()
   })
 
+  it('keeps the 5-step wizard for BCeID users on submitted applications (ticket #4537)', () => {
+    mockHasAnyRole = vi.fn(() => false)
+    render(
+      <CIApplicationProgress
+        activeStep={0}
+        ciApplication={{
+          status: { status: 'Submitted' },
+          signatureUserDisplayName: 'Jane Submitter',
+          signatureDateTime: '2026-05-01T12:00:00Z',
+          proposedFuelCodeEffectiveDate: '2026-06-01'
+        }}
+      />,
+      { wrapper }
+    )
+
+    // The full 5-step wizard is shown, not the short government timeline.
+    expect(screen.getByText('carbonIntensity:steps.step1')).toBeInTheDocument()
+    expect(screen.getByText('carbonIntensity:steps.step5')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Proposed effective date')
+    ).not.toBeInTheDocument()
+    // Supplier steps 1-4 are marked complete; Government decision stays pending.
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.queryByText('5')).not.toBeInTheDocument()
+  })
+
   it('adds an hourglass supplier-wait step with days counted from request date', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-19T12:00:00Z'))

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -65,9 +65,11 @@ describe('DocumentsModellingStep', () => {
       screen.getByTestId('ci-step3-upload-supporting')
     ).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-upload-ghgenius')).toBeInTheDocument()
+    // The download-template button was removed (ticket #4534) — the template
+    // is now provided earlier in the process.
     expect(
-      screen.getByTestId('ci-step3-download-template')
-    ).toBeInTheDocument()
+      screen.queryByTestId('ci-step3-download-template')
+    ).not.toBeInTheDocument()
     expect(
       screen.getByTestId('ci-step3-other-description')
     ).toBeInTheDocument()

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -74,7 +74,7 @@ const mockDelete = vi.fn().mockResolvedValue(undefined)
 const mockOptions = {
   data: {
     statuses: [],
-    unitsOfMeasure: [{ uomId: 1, name: 'Litres' }]
+    unitsOfMeasure: ['L']
   },
   isLoading: false
 }
@@ -164,7 +164,7 @@ vi.mock(
             onSave({
               facilityCountry: 'Argentina',
               facilityNameplateCapacity: 1000,
-              facilityNameplateCapacityUnitId: 1
+              facilityNameplateCapacityUnit: 'L'
             })
           }
         >

--- a/frontend/src/views/CarbonIntensity/__tests__/SignAndSubmitStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/SignAndSubmitStep.test.jsx
@@ -42,14 +42,23 @@ describe('SignAndSubmitStep', () => {
     )
   })
 
-  it('blocks submission when not all declarations are checked', async () => {
+  it('disables submission until all required declarations are checked', () => {
     const onSave = vi.fn()
     render(<SignAndSubmitStep {...baseProps} onSave={onSave} />, { wrapper })
+
+    // Submit is gated on the three required declarations (ticket #4536).
+    expect(screen.getByTestId('ci-step4-submit-btn')).toBeDisabled()
     fireEvent.click(screen.getByTestId('ci-step4-submit-btn'))
-    await waitFor(() => {
-      expect(screen.getByTestId('ci-step4-decl-error')).toBeInTheDocument()
-    })
     expect(onSave).not.toHaveBeenCalled()
+
+    // Checking only some of the required declarations keeps it disabled.
+    fireEvent.click(screen.getByTestId('ci-step4-decl-1'))
+    fireEvent.click(screen.getByTestId('ci-step4-decl-2'))
+    expect(screen.getByTestId('ci-step4-submit-btn')).toBeDisabled()
+
+    // All three required declarations enable the button.
+    fireEvent.click(screen.getByTestId('ci-step4-decl-3'))
+    expect(screen.getByTestId('ci-step4-submit-btn')).toBeEnabled()
   })
 
   it('calls onSave with the correct payload when all declarations are checked', async () => {

--- a/frontend/src/views/CarbonIntensity/components/ApplicationInformationStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ApplicationInformationStep.jsx
@@ -45,9 +45,9 @@ const buildValidationSchema = (t) =>
       .required(t('carbonIntensity:step1.validation.capacityRequired'))
       .positive(t('carbonIntensity:step1.validation.capacityPositive'))
       .integer(t('carbonIntensity:step1.validation.capacityPositive')),
-    facilityNameplateCapacityUnitId: Yup.number()
-      .typeError(t('carbonIntensity:step1.validation.uomRequired'))
-      .required(t('carbonIntensity:step1.validation.uomRequired')),
+    facilityNameplateCapacityUnit: Yup.string().required(
+      t('carbonIntensity:step1.validation.uomRequired')
+    ),
     proposedFuelCodeEffectiveDate: Yup.string().nullable()
   })
 
@@ -56,8 +56,7 @@ const toFormValues = (data) => ({
   facilityProvinceState: data?.facilityProvinceState ?? '',
   facilityCountry: data?.facilityCountry ?? '',
   facilityNameplateCapacity: data?.facilityNameplateCapacity ?? '',
-  facilityNameplateCapacityUnitId:
-    data?.facilityNameplateCapacityUnitId ?? '',
+  facilityNameplateCapacityUnit: data?.facilityNameplateCapacityUnit ?? '',
   proposedFuelCodeEffectiveDate: data?.proposedFuelCodeEffectiveDate ?? ''
 })
 
@@ -66,9 +65,7 @@ const toApiPayload = (values) => ({
   facilityProvinceState: values.facilityProvinceState || null,
   facilityCountry: values.facilityCountry?.trim(),
   facilityNameplateCapacity: Number(values.facilityNameplateCapacity),
-  facilityNameplateCapacityUnitId: Number(
-    values.facilityNameplateCapacityUnitId
-  ),
+  facilityNameplateCapacityUnit: values.facilityNameplateCapacityUnit || null,
   proposedFuelCodeEffectiveDate: values.proposedFuelCodeEffectiveDate || null
 })
 
@@ -271,12 +268,12 @@ export const ApplicationInformationStep = forwardRef(
 
           <Grid2 size={{ xs: 12, md: 4 }}>
             <Controller
-              name="facilityNameplateCapacityUnitId"
+              name="facilityNameplateCapacityUnit"
               control={control}
               render={({ field, fieldState }) => (
                 <Box mb={2}>
                   <InputLabel
-                    htmlFor="facilityNameplateCapacityUnitId"
+                    htmlFor="facilityNameplateCapacityUnit"
                     sx={{ pb: 1 }}
                   >
                     {t('carbonIntensity:step1.unitOfMeasure')}
@@ -285,8 +282,8 @@ export const ApplicationInformationStep = forwardRef(
                   <TextField
                     {...field}
                     select
-                    id="facilityNameplateCapacityUnitId"
-                    data-test="facilityNameplateCapacityUnitId"
+                    id="facilityNameplateCapacityUnit"
+                    data-test="facilityNameplateCapacityUnit"
                     value={field.value ?? ''}
                     required
                     variant="outlined"
@@ -307,8 +304,8 @@ export const ApplicationInformationStep = forwardRef(
                       <em>{t('carbonIntensity:labels.selectPlaceholder')}</em>
                     </MenuItem>
                     {unitsOfMeasure.map((u) => (
-                      <MenuItem key={u.uomId} value={u.uomId}>
-                        {u.name}
+                      <MenuItem key={u} value={u}>
+                        {u}
                       </MenuItem>
                     ))}
                   </TextField>

--- a/frontend/src/views/CarbonIntensity/components/ApplicationSummary.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ApplicationSummary.jsx
@@ -98,7 +98,7 @@ export const ApplicationSummary = ({
   const capacity =
     ciApplication.facilityNameplateCapacity != null
       ? `${ciApplication.facilityNameplateCapacity.toLocaleString()} ${
-          ciApplication.facilityNameplateCapacityUnit?.name || ''
+          ciApplication.facilityNameplateCapacityUnit || ''
         }`.trim()
       : ''
 

--- a/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
+++ b/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
@@ -369,11 +369,34 @@ export const CIApplicationProgress = ({ activeStep = 0, ciApplication }) => {
   const { t } = useTranslation(['carbonIntensity'])
   const { hasAnyRole } = useCurrentUser()
 
-  if (
-    !ciApplication ||
-    (ciApplication?.status?.status === 'Draft' &&
-      !getSupplierRequestDate(ciApplication))
-  ) {
+  const showInternalSteps = Boolean(
+    hasAnyRole?.(
+      roles.government,
+      roles.analyst,
+      roles.compliance_manager,
+      roles.director
+    )
+  )
+
+  // BCeID/supplier users keep the 5-step wizard progress bar through the whole
+  // lifecycle (ticket #4537); only government users switch to the internal
+  // workflow timeline once the application leaves Draft.
+  const isDraftWizard =
+    ciApplication?.status?.status === 'Draft' &&
+    !getSupplierRequestDate(ciApplication)
+
+  if (!ciApplication || !showInternalSteps || isDraftWizard) {
+    // Once submitted, the supplier steps (1-4) are complete, so mark them done
+    // and leave Government decision pending. While drafting, follow the
+    // URL-driven active step.
+    const isSubmitted = Boolean(
+      ciApplication?.status?.status &&
+        ciApplication.status.status !== 'Draft'
+    )
+    const wizardActiveStep = isSubmitted
+      ? CI_APPLICATION_STEPS.length - 1
+      : activeStep
+
     return (
       <Stack direction="row" sx={{ mb: 3, mt: 2 }}>
         {CI_APPLICATION_STEPS.map((step, index) => (
@@ -383,8 +406,8 @@ export const CIApplicationProgress = ({ activeStep = 0, ciApplication }) => {
             step={{
               key: step.key,
               label: t(step.labelKey),
-              state: index < activeStep ? 'completed' : 'pending',
-              initials: index < activeStep ? String(index + 1) : ''
+              state: index < wizardActiveStep ? 'completed' : 'pending',
+              initials: index < wizardActiveStep ? String(index + 1) : ''
             }}
           />
         ))}
@@ -392,14 +415,6 @@ export const CIApplicationProgress = ({ activeStep = 0, ciApplication }) => {
     )
   }
 
-  const showInternalSteps = Boolean(
-    hasAnyRole?.(
-      roles.government,
-      roles.analyst,
-      roles.compliance_manager,
-      roles.director
-    )
-  )
   const workflowSteps = buildCIWorkflowSteps(ciApplication, {
     showInternalSteps
   })

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -13,8 +13,7 @@ import {
 } from '@mui/material'
 import {
   CloudUpload as CloudUploadIcon,
-  Delete as DeleteIcon,
-  FileDownload as FileDownloadIcon
+  Delete as DeleteIcon
 } from '@mui/icons-material'
 
 import BCAlert from '@/components/BCAlert'
@@ -25,13 +24,11 @@ import {
   COMPLIANCE_REPORT_FILE_TYPES,
   MAX_FILE_SIZE_BYTES
 } from '@/constants/common'
-import { apiRoutes } from '@/constants/routes'
 import {
   useDeleteDocument,
   useDocuments,
   useUploadDocument
 } from '@/hooks/useDocuments'
-import { useApiService } from '@/services/useApiService'
 import colors from '@/themes/base/colors'
 import { validateFile } from '@/utils/fileValidation'
 
@@ -61,7 +58,6 @@ export const DocumentsModellingStep = ({
 }) => {
   const { t } = useTranslation(['common', 'carbonIntensity'])
   const ciApplicationId = ciApplication?.ciApplicationId
-  const apiClient = useApiService()
 
   const supportingFileRef = useRef(null)
   const ghgeniusFileRef = useRef(null)
@@ -343,24 +339,6 @@ export const DocumentsModellingStep = ({
         >
           {t('carbonIntensity:step3.uploadGHGenius')}
         </BCButton>
-        <BCButton
-          type="button"
-          variant="outlined"
-          color="primary"
-          size="medium"
-          startIcon={
-            <FileDownloadIcon sx={{ fontSize: '1.5rem !important' }} />
-          }
-          onClick={async () => {
-            await apiClient.download({
-              url: apiRoutes.ciApplicationGHGeniusTemplate,
-              method: 'get'
-            })
-          }}
-          data-test="ci-step3-download-template"
-        >
-          {t('carbonIntensity:step3.downloadTemplate')}
-        </BCButton>
         <input
           ref={ghgeniusFileRef}
           type="file"
@@ -370,84 +348,6 @@ export const DocumentsModellingStep = ({
           data-test="ci-step3-ghgenius-input"
         />
       </Stack>
-
-      <BCTypography
-        variant="body2"
-        sx={{ fontWeight: 600, mb: 1 }}
-        data-test="ci-step3-modelling-instructions-header"
-      >
-        {t('carbonIntensity:step3.modellingInstructions.header')}
-      </BCTypography>
-      <BCTypography variant="body2" sx={{ mb: 0.5 }}>
-        {t('carbonIntensity:step3.modellingInstructions.inputsIntro')}
-      </BCTypography>
-      <Box component="ul" sx={{ pl: 3, mb: 1.5 }}>
-        <li>
-          <BCTypography variant="body2">
-            {t('carbonIntensity:step3.modellingInstructions.inputs.region')}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t('carbonIntensity:step3.modellingInstructions.inputs.grouping')}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t('carbonIntensity:step3.modellingInstructions.inputs.ordering')}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t(
-              'carbonIntensity:step3.modellingInstructions.inputs.descriptors'
-            )}
-          </BCTypography>
-        </li>
-      </Box>
-      <BCTypography variant="body2" sx={{ mb: 0.5 }}>
-        {t('carbonIntensity:step3.modellingInstructions.outputsIntro')}
-      </BCTypography>
-      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
-        <li>
-          <BCTypography variant="body2">
-            {t(
-              'carbonIntensity:step3.modellingInstructions.outputs.copyFromTab'
-            )}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t(
-              'carbonIntensity:step3.modellingInstructions.outputs.columnLabel'
-            )}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t(
-              'carbonIntensity:step3.modellingInstructions.outputs.outOfModel'
-            )}
-          </BCTypography>
-        </li>
-        <li>
-          <BCTypography variant="body2">
-            {t(
-              'carbonIntensity:step3.modellingInstructions.outputs.sampleTable'
-            )}{' '}
-            <Link
-              href="https://www2.gov.bc.ca/assets/gov/farming-natural-resources-and-industry/electricity-alternative-energy/transportation/renewable-low-carbon-fuels/rlcf-008.pdf"
-              target="_blank"
-              rel="noopener"
-              underline="always"
-            >
-              {t(
-                'carbonIntensity:step3.modellingInstructions.outputs.rlcfLink'
-              )}
-            </Link>
-          </BCTypography>
-        </li>
-      </Box>
 
       {!hasGHGeniusModel && (
         <BCTypography variant="body2" color="error" sx={{ mb: 2 }}>

--- a/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
@@ -74,11 +74,10 @@ export const ProposedFuelPathwaysStep = ({
 
   const onCellValueChanged = useCallback(
     (params) => {
-      setRowData((prev) =>
-        prev.map((row) =>
-          row.id === params.data.id ? { ...params.data } : row
-        )
-      )
+      // ag-grid owns the row data (rows are added/removed via transactions);
+      // mirroring edits back into React state re-syncs the grid to a stale
+      // rowData prop, which drops transaction-added rows. Only the per-row
+      // error state needs updating here.
       setErrors((prev) => {
         if (!prev[params.data.id]) return prev
         const applicationTypes = optionsData?.pathwayApplicationTypes || []
@@ -96,35 +95,21 @@ export const ProposedFuelPathwaysStep = ({
     [optionsData]
   )
 
-  const onAction = useCallback(async (action, params) => {
+  // ag-grid is the source of truth for rows; BCGridEditor applies the returned
+  // transaction and the grid is read back via collectGridRows() on save. State
+  // is NOT mirrored here — doing so adds each row twice (state + transaction).
+  const onAction = useCallback((action, params) => {
     switch (action) {
-      case 'add': {
-        const newRow = createEmptyRow()
-        // Mirror the grid transaction into React state — otherwise the next
-        // re-render makes ag-grid re-sync to the stale rowData prop and the
-        // newly-added row vanishes from the grid.
-        setRowData((prev) => [...prev, newRow])
-        return { add: [newRow] }
-      }
-      case 'duplicate': {
-        const original = params.data
-        const copy = { ...original, id: uuid(), pathwayId: null }
-        setRowData((prev) => [...prev, copy])
-        return { add: [copy] }
-      }
+      case 'add':
+        return { add: [createEmptyRow()] }
+      case 'duplicate':
+        return { add: [{ ...params.data, id: uuid(), pathwayId: null }] }
       case 'delete':
         params.api.applyTransaction({ remove: [params.data] })
-        setRowData((prev) => prev.filter((r) => r.id !== params.data.id))
         return null
       default:
         return null
     }
-  }, [])
-
-  const handleAddRow = useCallback(() => {
-    const newRow = createEmptyRow()
-    setRowData((prev) => [...prev, newRow])
-    gridRef.current?.api?.applyTransaction({ add: [newRow] })
   }, [])
 
   const collectGridRows = () => {
@@ -208,7 +193,6 @@ export const ProposedFuelPathwaysStep = ({
         onCellValueChanged={onCellValueChanged}
         onAction={onAction}
         showAddRowsButton={canEdit}
-        onAddRows={handleAddRow}
         context={{ errors }}
         showMandatoryColumns={canEdit}
         getRowId={(params) => params.data.id}

--- a/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
@@ -104,9 +104,16 @@ export const ProposedFuelPathwaysStep = ({
         return { add: [createEmptyRow()] }
       case 'duplicate':
         return { add: [{ ...params.data, id: uuid(), pathwayId: null }] }
-      case 'delete':
-        params.api.applyTransaction({ remove: [params.data] })
+      case 'delete': {
+        // Remove via the controlled rowData prop (read the live grid rows, then
+        // drop the deleted one) rather than a bare transaction. This keeps the
+        // grid, the rowData prop, and the autoHeight calc in sync — a
+        // transaction-only remove leaves the grid sized for the old row count.
+        const rows = []
+        params.api.forEachNode((node) => rows.push(node.data))
+        setRowData(rows.filter((r) => r.id !== params.data.id))
         return null
+      }
       default:
         return null
     }

--- a/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
@@ -6,7 +6,6 @@ import { v4 as uuid } from 'uuid'
 import BCButton from '@/components/BCButton'
 import BCTypography from '@/components/BCTypography'
 import { BCGridEditor } from '@/components/BCDataGrid/BCGridEditor'
-import colors from '@/themes/base/colors'
 
 import {
   apiToRow,
@@ -201,10 +200,6 @@ export const ProposedFuelPathwaysStep = ({
 
   return (
     <Box>
-      <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
-        {t('carbonIntensity:step2.title')}
-      </BCTypography>
-
       <BCGridEditor
         gridRef={gridRef}
         columnDefs={columnDefs}

--- a/frontend/src/views/CarbonIntensity/components/SignAndSubmitStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/SignAndSubmitStep.jsx
@@ -15,7 +15,6 @@ import BCAlert from '@/components/BCAlert'
 import BCButton from '@/components/BCButton'
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
-import colors from '@/themes/base/colors'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -109,10 +108,6 @@ export const SignAndSubmitStep = ({
 
   return (
     <Box>
-      <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
-        {t('carbonIntensity:step4.title')}
-      </BCTypography>
-
       <BCTypography
         variant="subtitle1"
         sx={{ fontWeight: 600, mb: 1 }}
@@ -305,7 +300,7 @@ export const SignAndSubmitStep = ({
           variant="contained"
           color="primary"
           onClick={handleSubmit}
-          disabled={readOnly || isSaving}
+          disabled={readOnly || isSaving || !(decl1 && decl2 && decl3)}
           data-test="ci-step4-submit-btn"
         >
           {t('carbonIntensity:step4.submit')}

--- a/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
+++ b/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
@@ -235,16 +235,14 @@ export const buildPathwayColDefs = ({ optionsData, canEdit }) => {
       field: 'proposedCi',
       headerName: i18n.t('carbonIntensity:step2.proposedCi'),
       headerComponent: canEdit ? RequiredHeader : undefined,
-      editable: lockedOnRenewal,
+      // Proposed CI must stay editable for both New and Renewal applications
+      // (ticket #4532) — it is never carried over from the existing fuel code.
+      editable: canEdit,
       cellEditor: 'agNumberCellEditor',
       cellEditorParams: { precision: 2, showStepperButtons: false },
       type: 'numericColumn',
       cellRenderer: renderNumberPlaceholder,
-      cellStyle: (params) => {
-        const base = cellErrorStyle(params)
-        if (isRenewal(params)) return { ...base, backgroundColor: '#f5f5f5' }
-        return base
-      },
+      cellStyle: cellErrorStyle,
       minWidth: 180
     },
     {


### PR DESCRIPTION
Refinements to the Carbon Intensity (CI) application wizard, covering four tickets.

## #4531 — Step 1 (Application information)
- Relabel the field to **Facility nameplate capacity** (matches its validation copy).
- **Unit of measure** now lists physical capacity units (**L, kg, kWh, Gj, m³**) instead of energy-density units (MJ/L, gCO²e/MJ…). Root cause: the CI application stored the nameplate-capacity unit as an FK to the `unit_of_measure` table — whose own model comment is *"Units used to measure energy densities"*. A nameplate capacity is a physical quantity; fuel codes (and the allocation-agreement / other-uses schedules) already model it with `QuantityUnitsEnum`. Switched `CIApplication.facility_nameplate_capacity_unit_id` (int FK) → `facility_nameplate_capacity_unit` (`Enum(QuantityUnitsEnum)`), mirroring `FuelCode`.
  - **Migration `f3a8c1d2e4b5`** adds the enum column (reusing the existing `quantityunitsenum` Postgres type) and drops the FK column. Existing values referenced energy-density units that can't map to a physical unit, so they are left NULL (the field is optional).

## #4532 — Step 2 (Proposed fuel pathways)
- Removed the duplicate in-body section heading (the accordion already renders it).
- **Proposed CI** is now editable for both New and Renewal applications (it was locked on renewal).
- Fixed **"Add row" inserting two rows** and the resulting duplicate-on-save: the grid was driven by both a controlled `rowData` prop and ag-grid transactions. Made ag-grid the single source of truth for adds (matching the allocation-agreement grid).
- Fixed the **empty height gap after deleting a row**: delete now updates the controlled `rowData` (read from the live grid) so the grid, the prop, and the `autoHeight` calc stay in agreement.

## #4534 — Step 3 (Documents & GHGenius modelling)
- Removed the duplicate in-body heading.
- Removed the **Download GHGenius Excel template** button and the modelling input/output instructions (provided earlier in the process). Kept the Upload button. Pruned the now-unused locale keys and imports.

## #4536 — Step 4 (Sign & submit)
- Removed the duplicate in-body heading.
- **Submit application** is now disabled until the three required declarations are checked (the optional consultant-consent checkbox does not gate submission).

## Testing
- Backend: all CI application tests updated and passing (service, views, repo, list, validation).
- Frontend: full CI application suite passing (142 tests); step 1–4 test expectations updated.
- Migration applied and verified against a local dev DB (column type is now `quantityunitsenum`).

## Notes for reviewers
- This PR carries a **DB migration**; run migrations on deploy. Existing CI applications' nameplate-capacity unit is reset to NULL (the prior values were the wrong lookup).

---

## #4537 — Submitted application view (BCeID)
- BCeID/supplier users now keep the **full 5-step wizard progress bar** after submission instead of the short government workflow timeline (supplier steps 1-4 marked complete, Government decision pending). Government users still get the internal workflow timeline.
- The step 5 comments heading is now role-aware: government sees "Comments to the organization", BCeID sees **"Comments to the Government of B.C."**
- Added a progress-bar test for the BCeID-submitted case.