### PR TITLE
feat: add Credit Trader organization type (#4547)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-06-16-00-00_d9c8b7a6e5f4.py
+++ b/backend/lcfs/db/migrations/versions/2026-06-16-00-00_d9c8b7a6e5f4.py
@@ -1,0 +1,37 @@
+"""Add Credit Trader organization type
+
+Adds a 'credit_trader' organization type (#4547) for organizations that trade
+compliance units but have no compliance obligation.
+
+Additive only: compliance reporting is gated by user role (SUPPLIER), not by
+organization type, so this new type does not create any compliance obligation
+and does not affect existing organization types.
+
+Revision ID: d9c8b7a6e5f4
+Revises: e5f7a9b1c3d4
+Create Date: 2026-06-16 00:00:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d9c8b7a6e5f4"
+down_revision = "e5f7a9b1c3d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO organization_type
+            (organization_type_id, org_type, description, is_bceid_user, display_order)
+        VALUES
+            (6, 'credit_trader', 'Credit Trader', true, 6)
+        ON CONFLICT (organization_type_id) DO NOTHING;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM organization_type WHERE org_type = 'credit_trader';")

--- a/frontend/src/utils/__tests__/organizationTypes.test.js
+++ b/frontend/src/utils/__tests__/organizationTypes.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ORG_TYPE_LABELS,
+  getOrgTypeDisplayLabel
+} from '@/utils/organizationTypes'
+
+describe('organizationTypes', () => {
+  it('maps the Credit Trader org type to its label (#4547)', () => {
+    expect(ORG_TYPE_LABELS.credit_trader).toBe('Credit Trader')
+    expect(getOrgTypeDisplayLabel('credit_trader')).toBe('Credit Trader')
+    expect(getOrgTypeDisplayLabel({ orgType: 'credit_trader' })).toBe(
+      'Credit Trader'
+    )
+  })
+
+  it('still maps the existing org types', () => {
+    expect(getOrgTypeDisplayLabel('fuel_supplier')).toBe('Supplier')
+    expect(getOrgTypeDisplayLabel('initiative_agreement_holder')).toBe(
+      'IA Holder'
+    )
+  })
+
+  it('falls back to a humanized key for unknown types', () => {
+    expect(getOrgTypeDisplayLabel('some_new_type')).toBe('some new type')
+    expect(getOrgTypeDisplayLabel('')).toBe('')
+  })
+})

--- a/frontend/src/utils/organizationTypes.js
+++ b/frontend/src/utils/organizationTypes.js
@@ -3,7 +3,8 @@ export const ORG_TYPE_LABELS = {
   aggregator: 'Aggregator',
   fuel_producer: 'Producer',
   exempted_supplier: 'Exempted',
-  initiative_agreement_holder: 'IA Holder'
+  initiative_agreement_holder: 'IA Holder',
+  credit_trader: 'Credit Trader'
 }
 
 const normalizeOrgTypeKey = (orgType) => {


### PR DESCRIPTION
Adds a **Credit Trader** organization type for organizations that trade compliance units but have no compliance obligation. Closes #4547.

## Changes
- **Migration `d9c8b7a6e5f4`** — seeds `organization_type` id 6 (`credit_trader` / "Credit Trader", `is_bceid_user = true`, `display_order = 6`), matching the existing seed pattern, with `ON CONFLICT DO NOTHING` and a downgrade that removes it.
- **Frontend label** — `credit_trader: 'Credit Trader'` in `organizationTypes.js`, so the type renders cleanly in the IDIR add-organization dropdown and on the org profile. The type flows through the existing `/organizations/types/` API and create-organization endpoint with no other code change.
- Added a unit test for the label util.

## Acceptance criteria
- [x] "Credit Trader" appears in the organization type list (via the existing `/organizations/types/` endpoint once the migration runs)
- [x] Selection is saved (`organization_type_id`) and displayed via the label mapping
- [x] Does **not** trigger compliance reporting requirements — compliance reporting is gated by the `SUPPLIER` user role, not by organization type, so the new type creates no obligation
- [x] Does not impact existing organization types (additive insert only)

## Notes for reviewers
- **`is_bceid_user = true`**: credit traders are treated as BCeID/portal orgs (like fuel supplier / aggregator), which makes addresses required on creation. Flip to `false` if these should be createable with minimal info — easy one-line change.
- **"Credit Trader" is a working label** per the ticket; it's just the migration `description` + the `ORG_TYPE_LABELS` entry, trivial to rename.
- **Alembic heads:** this migration descends from develop head `e5f7a9b1c3d4`; PR #4551 (CI application) also branches from there. Merging both will produce two heads, needing an `alembic merge` migration.