### PR TITLE
Fix: Allow Editing Empty Rows in FSE Export - 4557

### DIFF
--- a/backend/lcfs/web/api/compliance_report/sheet_exporters/fse.py
+++ b/backend/lcfs/web/api/compliance_report/sheet_exporters/fse.py
@@ -17,7 +17,6 @@ class FSESheetExporter(TabularSheetExporter):
     annual_columns = FSE_EXPORT_COLUMNS
     quarterly_columns = FSE_EXPORT_COLUMNS
     min_compliance_year = 2024
-    locked_columns = {1}
 
     def __init__(
         self,


### PR DESCRIPTION
This PR updates FSE export protection rules to support user calculations in editable cells.
- Unprotect empty FSE rows
- Allow edits in added rows

Closes #4557