### PR TITLE
fix(supply-history): stop organization fuel supply filters from returning 500 (#4601)

### DIFF
--- a/backend/lcfs/tests/fuel_supply/test_fuel_supplies_repo.py
+++ b/backend/lcfs/tests/fuel_supply/test_fuel_supplies_repo.py
@@ -716,3 +716,43 @@ async def test_get_effective_fuel_supplies_empty_result(
 
     # Verify mock was called
     assert mock_db_session.execute.call_count > 0
+
+
+@pytest.mark.anyio
+async def test_get_organization_fuel_supply_analytics_filters_no_duplicate_join(
+    dbsession,
+):
+    """Regression (#4601): filtering the org fuel-supply analytics query must
+    not emit a duplicate, unaliased join.
+
+    The base query already outerjoins fuel_type / fuel_category /
+    provision_of_the_act / fuel_code; re-joining them in the filter loop made
+    Postgres raise ``DuplicateAliasError: table name ... specified more than
+    once`` (a 500 on the Supply History tab). Runs against the real test DB so
+    the SQL is actually prepared and executed.
+    """
+    from lcfs.web.api.base import FilterModel
+
+    repo = FuelSupplyRepository(db=dbsession)
+
+    for field in ("fuelType", "fuelCategory", "provisionOfTheAct", "fuelCode"):
+        filters = [
+            FilterModel(
+                field=field, filter="x", type="contains", filter_type="text"
+            )
+        ]
+
+        # Analytics (charts) path.
+        result = await repo.get_organization_fuel_supply_analytics(1, filters)
+        assert isinstance(result, dict)
+        assert "total_volume" in result
+
+        # Paginated (table) path — same filter columns.
+        pagination = PaginationRequestSchema(
+            page=1, size=10, filters=filters, sort_orders=[]
+        )
+        rows, total = await repo.get_organization_fuel_supply_paginated(
+            1, pagination
+        )
+        assert isinstance(rows, list)
+        assert isinstance(total, int)

--- a/backend/lcfs/web/api/fuel_supply/repo.py
+++ b/backend/lcfs/web/api/fuel_supply/repo.py
@@ -1,7 +1,7 @@
 import structlog
 from datetime import datetime
 from fastapi import Depends
-from sqlalchemy import and_, or_, select, delete, func
+from sqlalchemy import and_, or_, select, delete, func, cast, String
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload, aliased
 from typing import List, Optional, Sequence, Any
@@ -758,16 +758,28 @@ class FuelSupplyRepository:
                         FuelType.fuel_type.ilike(f"%{filter_value}%")
                     )
                 elif field == "fuel_category":
+                    # category is a Postgres enum; cast to text so ILIKE works
+                    # (otherwise the pattern is cast to the enum type and fails).
                     query = query.where(
-                        FuelCategory.category.ilike(f"%{filter_value}%")
+                        cast(FuelCategory.category, String).ilike(
+                            f"%{filter_value}%"
+                        )
                     )
                 elif field == "provision_of_the_act":
                     query = query.where(
                         ProvisionOfTheAct.name.ilike(f"%{filter_value}%")
                     )
                 elif field == "fuel_code":
-                    query = query.where(
-                        FuelCode.fuel_code.ilike(f"%{filter_value}%")
+                    # FuelCode.fuel_code is a Python property (prefix + suffix),
+                    # not a column, so it can't be used in SQL. Join the prefix
+                    # table and match the concatenated value instead.
+                    query = query.join(
+                        FuelCodePrefix,
+                        FuelCode.prefix_id == FuelCodePrefix.fuel_code_prefix_id,
+                    ).where(
+                        func.concat(
+                            FuelCodePrefix.prefix, FuelCode.fuel_suffix
+                        ).ilike(f"%{filter_value}%")
                     )
 
         # Get total count before pagination
@@ -871,25 +883,43 @@ class FuelSupplyRepository:
                 if not filter_value:
                     continue
 
+                # The base query already outerjoins each of these tables, so the
+                # filters only add a WHERE clause. Re-joining (e.g.
+                # ``query.join(FuelType)``) emits a second, unaliased join of the
+                # same table — SQLAlchemy infers it off the most recent entity
+                # (fuel_code) — which Postgres rejects with
+                # "table name ... specified more than once" (issue #4601).
                 if field == "compliance_period":
                     query = query.where(
                         CompliancePeriod.description.ilike(f"%{filter_value}%")
                     )
                 elif field == "fuel_type":
-                    query = query.join(FuelType).where(
+                    query = query.where(
                         FuelType.fuel_type.ilike(f"%{filter_value}%")
                     )
                 elif field == "fuel_category":
-                    query = query.join(FuelCategory).where(
-                        FuelCategory.category.ilike(f"%{filter_value}%")
+                    # category is a Postgres enum; cast to text so ILIKE works
+                    # (otherwise the pattern is cast to the enum type and fails).
+                    query = query.where(
+                        cast(FuelCategory.category, String).ilike(
+                            f"%{filter_value}%"
+                        )
                     )
                 elif field == "provision_of_the_act":
-                    query = query.join(ProvisionOfTheAct).where(
+                    query = query.where(
                         ProvisionOfTheAct.name.ilike(f"%{filter_value}%")
                     )
                 elif field == "fuel_code":
-                    query = query.join(FuelCode).where(
-                        FuelCode.fuel_code.ilike(f"%{filter_value}%")
+                    # FuelCode.fuel_code is a Python property (prefix + suffix),
+                    # not a column, so it can't be used in SQL. Join the prefix
+                    # table and match the concatenated value instead.
+                    query = query.join(
+                        FuelCodePrefix,
+                        FuelCode.prefix_id == FuelCodePrefix.fuel_code_prefix_id,
+                    ).where(
+                        func.concat(
+                            FuelCodePrefix.prefix, FuelCode.fuel_suffix
+                        ).ilike(f"%{filter_value}%")
                     )
 
         # Execute query


### PR DESCRIPTION
## Summary

Fixes [#4601](https://github.com/bcgov/lcfs/issues/4601): applying **any** filter on the Organization Dashboard → **Supply History** tab returned a 500.

The endpoint runs two queries (analytics charts + paginated table). "Any filter → 500" turned out to be **three** distinct bugs in those queries:

1. **Duplicate join (the reported `DuplicateAliasError`).** The analytics query re-`join()`ed `fuel_type` / `fuel_category` / `provision_of_the_act` / `fuel_code` in the filter loop, on top of the base `outerjoin`s. SQLAlchemy inferred the second join off `fuel_code`, so Postgres rejected it with *"table name `fuel_type` specified more than once."* This fired for every filter field. Fixed by filtering with `WHERE` only (the base query already joins those tables — the table query was already doing this correctly).

2. **`ILIKE` on an enum.** `fuel_category.category` is a Postgres enum, so `ILIKE` cast the pattern to the enum type and failed. Fixed by casting the column to text first.

3. **Filtering a Python property.** `FuelCode.fuel_code` is a `@property` (`prefix + suffix`), not a column, so `.ilike()` on it isn't valid SQL. Fixed by joining the prefix table and matching `concat(prefix, fuel_suffix)`.

Bugs 2 and 3 also affected the paginated table query (they were masked by bug 1 dying first).

## Tests

The existing org fuel-supply tests mocked the DB session, so they could never catch a SQL-construction error — which is how this shipped. Adds a repo-level regression test that runs all four filter fields through **both** the analytics and paginated queries against the real test DB. Full `fuel_supply` suite passes (67).

## Out of scope

Sorting the table by the `fuel_code` column hits the same property issue, but the default sort is by year and filtering doesn't trigger a `fuel_code` sort, so it's unrelated to this ticket. Flagged for a possible follow-up.