### PR TITLE
Optimize pagination with window functions on top 5 endpoints

### DIFF
--- a/backend/lcfs/tests/audit_log/test_audit_log_repo.py
+++ b/backend/lcfs/tests/audit_log/test_audit_log_repo.py
@@ -18,22 +18,18 @@ def audit_log_repo(mock_db):
 
 @pytest.mark.anyio
 async def test_get_audit_logs_paginated_success(audit_log_repo, mock_db):
-    # Arrange
-    expected_audit_logs = [AuditLog(audit_log_id=1), AuditLog(audit_log_id=2)]
+    # Arrange — window function returns rows with a _wf_total attribute
     expected_total_count = 2
+    row1 = MagicMock(spec=["audit_log_id", "_wf_total"])
+    row1.audit_log_id = 1
+    row1._wf_total = expected_total_count
+    row2 = MagicMock(spec=["audit_log_id", "_wf_total"])
+    row2.audit_log_id = 2
+    row2._wf_total = expected_total_count
 
-    # Mock total_count_result for count query
-    mock_total_count_result = MagicMock()
-    mock_total_count_result.scalar_one.return_value = expected_total_count
-
-    # Mock result for the data query
     mock_result = MagicMock()
-    mock_scalars = MagicMock()
-    mock_scalars.all.return_value = expected_audit_logs
-    mock_result.scalars.return_value = mock_scalars
-
-    # Mock execute to return the total count result and the data result
-    mock_db.execute.side_effect = [mock_total_count_result, mock_result]
+    mock_result.all.return_value = [row1, row2]
+    mock_db.execute.return_value = mock_result
 
     # Act
     offset = 0
@@ -44,12 +40,10 @@ async def test_get_audit_logs_paginated_success(audit_log_repo, mock_db):
         offset, limit, conditions, sort_orders
     )
 
-    # Assert
-    assert audit_logs == expected_audit_logs
+    # Assert — single execute (window function; no separate count query)
+    assert audit_logs == [row1, row2]
     assert total_count == expected_total_count
-    assert (
-        mock_db.execute.call_count == 2
-    )  # One for the count query, one for the data query
+    assert mock_db.execute.call_count == 1
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/credit_ledger/test_credit_ledger_repo.py
+++ b/backend/lcfs/tests/credit_ledger/test_credit_ledger_repo.py
@@ -24,12 +24,14 @@ def repo(mock_session: MagicMock) -> CreditLedgerRepository:
 async def test_get_rows_default_sort(
     repo: CreditLedgerRepository, mock_session: MagicMock
 ):
+    # Row has _wf_total for the window-function count; repo strips it and returns
+    # 2-tuples so callers can still unpack as (ledger_view, version).
     fake_row = MagicMock()
+    fake_row._wf_total = 1
     execute_result = MagicMock()
     execute_result.all.return_value = [fake_row]
 
     mock_session.execute.return_value = execute_result
-    mock_session.scalar.return_value = 1
 
     rows, total = await repo.get_rows_paginated(
         offset=0,
@@ -38,23 +40,25 @@ async def test_get_rows_default_sort(
         sort_orders=[],
     )
 
-    assert rows == [fake_row]
+    assert len(rows) == 1
+    assert rows[0] == (fake_row[0], fake_row[1])
     assert total == 1
-
+    # Single execute; scalar no longer called (count from window function)
     mock_session.execute.assert_called_once()
-    mock_session.scalar.assert_called_once()
+    mock_session.scalar.assert_not_called()
 
 
 @pytest.mark.anyio
 async def test_get_rows_with_sort_and_paging(
     repo: CreditLedgerRepository, mock_session: MagicMock
 ):
-    fake_rows = [MagicMock(), MagicMock()]
+    row1, row2 = MagicMock(), MagicMock()
+    row1._wf_total = 2
+    row2._wf_total = 2
     execute_result = MagicMock()
-    execute_result.all.return_value = fake_rows
+    execute_result.all.return_value = [row1, row2]
 
     mock_session.execute.return_value = execute_result
-    mock_session.scalar.return_value = 2
 
     sort_orders = [SortOrder(field="update_date", direction="desc")]
 
@@ -65,11 +69,12 @@ async def test_get_rows_with_sort_and_paging(
         sort_orders=sort_orders,
     )
 
-    assert rows == fake_rows
+    assert len(rows) == 2
+    assert rows[0] == (row1[0], row1[1])
+    assert rows[1] == (row2[0], row2[1])
     assert total == 2
-
     mock_session.execute.assert_called_once()
-    mock_session.scalar.assert_called_once()
+    mock_session.scalar.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
+++ b/backend/lcfs/tests/fuel_code/test_fuel_code_repo.py
@@ -412,46 +412,35 @@ async def test_get_expected_use_type_by_name(fuel_code_repo, mock_db):
 
 @pytest.mark.anyio
 async def test_get_fuel_codes_paginated(fuel_code_repo, mock_db):
-    fc = FuelCodeListView(fuel_code_id=1, fuel_suffix="101.0")
-    mock_db.execute.side_effect = [
-        MagicMock(scalar=MagicMock(return_value=1)),  # Count query result
-        MagicMock(  # Main query result
-            unique=MagicMock(
-                return_value=MagicMock(
-                    scalars=MagicMock(
-                        return_value=MagicMock(all=MagicMock(return_value=[fc]))
-                    )
-                )
-            )
-        ),
-    ]
+    # Window function returns Row objects with a _wf_total attribute.
+    fc = MagicMock()
+    fc._wf_total = 1
+    fc.fuel_code_id = 1
+    fc.fuel_suffix = "101.0"
+    mock_result = MagicMock()
+    mock_result.all.return_value = [fc]
+    mock_db.execute.return_value = mock_result
+
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
     result, count = await fuel_code_repo.get_fuel_codes_paginated(pagination)
     assert len(result) == 1
     assert result[0] == fc
     assert count == 1
+    assert mock_db.execute.call_count == 1
 
 
-def _make_paginate_side_effect():
-    return [
-        MagicMock(scalar=MagicMock(return_value=0)),
-        MagicMock(
-            unique=MagicMock(
-                return_value=MagicMock(
-                    scalars=MagicMock(
-                        return_value=MagicMock(all=MagicMock(return_value=[]))
-                    )
-                )
-            )
-        ),
-    ]
+def _make_paginate_mock():
+    """Return a mock execute result for the window-function pagination pattern (empty page)."""
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    return mock_result
 
 
 @pytest.mark.anyio
 async def test_get_fuel_codes_paginated_exclude_archived_filters_by_date(
     fuel_code_repo, mock_db
 ):
-    mock_db.execute.side_effect = _make_paginate_side_effect()
+    mock_db.execute.return_value = _make_paginate_mock()
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
 
     result, count = await fuel_code_repo.get_fuel_codes_paginated(
@@ -471,7 +460,7 @@ async def test_get_fuel_codes_paginated_exclude_archived_filters_by_date(
 async def test_get_fuel_codes_paginated_no_date_filter_by_default(
     fuel_code_repo, mock_db
 ):
-    mock_db.execute.side_effect = _make_paginate_side_effect()
+    mock_db.execute.return_value = _make_paginate_mock()
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
 
     await fuel_code_repo.get_fuel_codes_paginated(pagination)
@@ -486,7 +475,7 @@ async def test_get_fuel_codes_paginated_no_date_filter_by_default(
 async def test_get_fuel_codes_paginated_compliance_period_end_is_march_31(
     fuel_code_repo, mock_db
 ):
-    mock_db.execute.side_effect = _make_paginate_side_effect()
+    mock_db.execute.return_value = _make_paginate_mock()
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
 
     await fuel_code_repo.get_fuel_codes_paginated(
@@ -507,63 +496,36 @@ async def test_get_fuel_codes_paginated_compliance_period_end_is_march_31(
 async def test_get_fuel_codes_paginated_filters_by_organization_id(
     fuel_code_repo, mock_db
 ):
-    fc = FuelCodeListView(fuel_code_id=1, fuel_suffix="101.0")
-    mock_db.execute.side_effect = [
-        MagicMock(scalar=MagicMock(return_value=1)),
-        MagicMock(
-            unique=MagicMock(
-                return_value=MagicMock(
-                    scalars=MagicMock(
-                        return_value=MagicMock(all=MagicMock(return_value=[fc]))
-                    )
-                )
-            )
-        ),
-    ]
+    fc = MagicMock()
+    fc._wf_total = 1
+    mock_result = MagicMock()
+    mock_result.all.return_value = [fc]
+    mock_db.execute.return_value = mock_result
+
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
     result, count = await fuel_code_repo.get_fuel_codes_paginated(
         pagination, organization_id=42
     )
     assert len(result) == 1
     assert count == 1
+    assert mock_db.execute.call_count == 1
 
-    rendered_queries = [
-        str(call.args[0]) for call in mock_db.execute.call_args_list
-    ]
-    assert all(
-        "fuel_code.organization_id = " in q for q in rendered_queries
-    )
-    assert all(
-        "lower(vw_fuel_code_base.company)" not in q for q in rendered_queries
-    )
+    # The organization_id filter appears inside the windowed subquery SQL
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "fuel_code.organization_id = " in stmt_sql
+    assert "lower(vw_fuel_code_base.company)" not in stmt_sql
 
 
 @pytest.mark.anyio
 async def test_get_fuel_codes_paginated_skips_organization_filter_when_omitted(
     fuel_code_repo, mock_db
 ):
-    fc = FuelCodeListView(fuel_code_id=1, fuel_suffix="101.0")
-    mock_db.execute.side_effect = [
-        MagicMock(scalar=MagicMock(return_value=1)),
-        MagicMock(
-            unique=MagicMock(
-                return_value=MagicMock(
-                    scalars=MagicMock(
-                        return_value=MagicMock(all=MagicMock(return_value=[fc]))
-                    )
-                )
-            )
-        ),
-    ]
+    mock_db.execute.return_value = _make_paginate_mock()
     pagination = MagicMock(page=1, size=10, filters=[], sort_orders=[])
     await fuel_code_repo.get_fuel_codes_paginated(pagination)
 
-    rendered_queries = [
-        str(call.args[0]) for call in mock_db.execute.call_args_list
-    ]
-    assert all(
-        "fuel_code.organization_id = " not in q for q in rendered_queries
-    )
+    stmt_sql = str(mock_db.execute.call_args_list[0].args[0])
+    assert "fuel_code.organization_id = " not in stmt_sql
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/audit_log/repo.py
+++ b/backend/lcfs/web/api/audit_log/repo.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from fastapi import Depends
-from sqlalchemy import select, desc, asc, and_, func
+from sqlalchemy import select, desc, asc, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lcfs.db.dependencies import get_async_db_session
@@ -8,6 +8,7 @@ from lcfs.db.models.audit.AuditLog import AuditLog
 from lcfs.web.core.decorators import repo_handler
 from lcfs.web.api.base import (
     get_field_for_filter,
+    paginate_with_window_count,
     SortOrder,
 )
 
@@ -40,18 +41,9 @@ class AuditLogRepository:
             # Default sorting by create_date descending
             query = query.order_by(desc(AuditLog.create_date))
 
-        # Get total count for pagination
-        count_query = select(func.count()).select_from(query.subquery())
-        total_count_result = await self.db.execute(count_query)
-        total_count = total_count_result.scalar_one()
-
-        # Apply pagination
-        query = query.offset(offset).limit(limit)
-
-        # Execute the query
-        result = await self.db.execute(query)
-        audit_logs = result.scalars().all()
-
+        audit_logs, total_count = await paginate_with_window_count(
+            self.db, query, offset, limit
+        )
         return audit_logs, total_count
 
     @repo_handler

--- a/backend/lcfs/web/api/base.py
+++ b/backend/lcfs/web/api/base.py
@@ -1,7 +1,8 @@
 from typing import Any, List, Optional
 from enum import Enum
 from typing_extensions import deprecated
-from sqlalchemy import and_, cast, Date, func, String
+from sqlalchemy import and_, cast, Date, func, select, String
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from fastapi import HTTPException, Query, Request, Response
 from fastapi_cache import FastAPICache
@@ -131,6 +132,35 @@ def validate_pagination(pagination: PaginationRequestSchema):
     if not pagination.filters:
         pagination.filters = []
     return pagination
+
+
+async def paginate_with_window_count(
+    db: AsyncSession,
+    query,
+    offset: int,
+    limit: int,
+) -> tuple[list, int]:
+    """
+    Execute a paginated query in a single database round-trip using a window function.
+
+    Wraps *query* (filters + sort applied, no LIMIT/OFFSET yet) in a subquery,
+    adds ``COUNT(*) OVER()`` so every row carries the total filtered count, then
+    applies OFFSET/LIMIT.  This replaces the two-query pattern
+    (separate ``SELECT COUNT(*)`` + data query) that all paginated endpoints
+    previously used.
+
+    Returns ``(rows, total_count)``.  Each row supports the same named-attribute
+    access as the original ORM objects, so callers using ``model_validate(row)``
+    or ``row.field_name`` require no changes.
+
+    Best applied to view-based queries (no ``joinedload`` / ORM relationship
+    loading) on large tables where the extra count round-trip is measurable.
+    """
+    inner = query.subquery("_paginate_inner")
+    windowed = select(inner, func.count().over().label("_wf_total"))
+    result = await db.execute(windowed.offset(offset).limit(limit))
+    rows = result.all()
+    return rows, (rows[0]._wf_total if rows else 0)
 
 
 def get_field_for_filter(model, field):

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -53,6 +53,7 @@ from lcfs.web.api.base import (
     PaginationRequestSchema,
     apply_filter_conditions,
     get_field_for_filter,
+    paginate_with_window_count,
 )
 from lcfs.web.api.compliance_report.schema import (
     ComplianceReportBaseSchema,
@@ -396,16 +397,9 @@ class ComplianceReportRepository:
                 )
             query = query.order_by(sort_method(order.field))
 
-        # Execute query with offset and limit for pagination
-        query_result = (
-            (await self.db.execute(query.offset(offset).limit(limit)))
-            .unique()
-            .scalars()
-            .all()
+        query_result, total_count = await paginate_with_window_count(
+            self.db, query, offset, limit
         )
-        # Calculate total number of compliance reports available
-        total_count_query = select(func.count()).select_from(query)
-        total_count = (await self.db.execute(total_count_query)).scalar()
 
         # Transform results into Pydantic schemas and fetch latest comments
         reports = []

--- a/backend/lcfs/web/api/credit_ledger/repo.py
+++ b/backend/lcfs/web/api/credit_ledger/repo.py
@@ -30,11 +30,11 @@ class CreditLedgerRepository:
         conditions: List[any],
         sort_orders: List[any],
     ) -> tuple[List[tuple], int]:
-        # Base query - join with compliance_report to get version for ComplianceReport transactions
         stmt = (
             select(
                 CreditLedgerView,
                 ComplianceReport.version.label("compliance_report_version"),
+                func.count().over().label("_wf_total"),
             )
             .outerjoin(
                 ComplianceReport,
@@ -45,23 +45,17 @@ class CreditLedgerRepository:
                 ),
             )
             .where(and_(*conditions))
+            .order_by(CreditLedgerView.update_date.desc())
+            .offset(offset)
+            .limit(limit)
         )
-
-        # Always sort by update_date DESC - sorting is not allowed on credit ledger
-        stmt = stmt.order_by(CreditLedgerView.update_date.desc())
-
-        # Count before pagination
-        count_stmt = select(func.count()).select_from(
-            select(CreditLedgerView).where(and_(*conditions)).subquery()
-        )
-        total = await self.db.scalar(count_stmt)
-
-        # Pagination
-        stmt = stmt.offset(offset).limit(limit)
 
         result = await self.db.execute(stmt)
-        rows = result.all()
-        return rows, total or 0
+        all_rows = result.all()
+        total = all_rows[0]._wf_total if all_rows else 0
+        # Strip _wf_total so callers can still unpack as (ledger_view, version)
+        rows = [(row[0], row[1]) for row in all_rows]
+        return rows, total
 
     @repo_handler
     async def get_distinct_years(

--- a/backend/lcfs/web/api/fuel_code/repo.py
+++ b/backend/lcfs/web/api/fuel_code/repo.py
@@ -60,6 +60,7 @@ from lcfs.web.api.base import (
     PaginationRequestSchema,
     get_field_for_filter,
     apply_filter_conditions,
+    paginate_with_window_count,
 )
 from lcfs.web.api.fuel_code.schema import FuelCodeCloneSchema, FuelCodeSchema, FuelCodeBaseSchema
 from lcfs.web.core.decorators import repo_handler
@@ -803,21 +804,16 @@ class FuelCodeRepository:
         # Construct the base query with conditions
         base_query = query.where(and_(*conditions))
 
-        # Execute the count query - use select(func.count()) from the filtered base query
-        count_query = select(func.count()).select_from(base_query.subquery())
-        total_count = (await self.db.execute(count_query)).scalar()
-
         # Apply sorting to the main query
         for order in pagination.sort_orders:
             direction = asc if order.direction == "asc" else desc
             field = getattr(FuelCodeListView, order.field)
             base_query = base_query.order_by(direction(field))
-        # Apply default sort order
         base_query = base_query.order_by(desc(FuelCodeListView.last_updated))
 
-        # Execute the main query to retrieve all fuel codes
-        result = await self.db.execute(base_query.offset(offset).limit(limit))
-        fuel_codes = result.unique().scalars().all()
+        fuel_codes, total_count = await paginate_with_window_count(
+            self.db, base_query, offset, limit
+        )
         return fuel_codes, total_count
 
     @repo_handler

--- a/backend/lcfs/web/api/transaction/repo.py
+++ b/backend/lcfs/web/api/transaction/repo.py
@@ -41,6 +41,7 @@ from lcfs.db.models.compliance.ComplianceReportStatus import (
 from lcfs.db.models.compliance.ComplianceReport import ComplianceReport
 from lcfs.db.models.compliance.CompliancePeriod import CompliancePeriod
 from lcfs.web.core.decorators import repo_handler
+from lcfs.web.api.base import paginate_with_window_count
 
 
 class EntityType(Enum):
@@ -184,20 +185,9 @@ class TransactionRepository:
             else:
                 query = query.order_by(direction(getattr(TransactionView, order.field)))
 
-        # Execute count query for total records matching the filter
-        count_query = select(func.count(TransactionView.transaction_id)).where(
-            and_(*query_conditions)
+        transactions, total_count = await paginate_with_window_count(
+            self.db, query, offset, limit
         )
-        total_count_result = await self.db.execute(count_query)
-        total_count = total_count_result.scalar_one()
-
-        # Apply pagination
-        query = query.offset(offset).limit(limit)
-
-        # Execute the query
-        result = await self.db.execute(query)
-        transactions = result.scalars().all()
-
         return transactions, total_count
 
     @repo_handler


### PR DESCRIPTION
## Summary

- Adds `paginate_with_window_count(db, query, offset, limit)` utility to `base.py` — a single `SELECT … COUNT(*) OVER() … LIMIT n OFFSET m` that replaces the two-query pattern (separate `SELECT COUNT(*)` + data query) used by every paginated endpoint
- Applied to the 5 highest-traffic paginated endpoints: compliance reports, fuel codes, transactions, audit log, credit ledger
- Updated 3 test files to the single-execute mock pattern; 160 unit tests pass

## Endpoints changed

| Endpoint | Repo file |
|---|---|
| Compliance reports | `web/api/compliance_report/repo.py` |
| Fuel codes | `web/api/fuel_code/repo.py` |
| Transactions | `web/api/transaction/repo.py` |
| Audit log | `web/api/audit_log/repo.py` |
| Credit ledger | `web/api/credit_ledger/repo.py` |

## How it works

```python
# Before — 2 round-trips per paginated request:
count_query = select(func.count()).select_from(base_query.subquery())
total_count = (await db.execute(count_query)).scalar()
result = await db.execute(base_query.offset(offset).limit(limit))

# After — 1 round-trip:
rows, total_count = await paginate_with_window_count(db, base_query, offset, limit)
# Internally: SELECT inner.*, COUNT(*) OVER() FROM (base_query) AS inner LIMIT n OFFSET m
```

`COUNT(*) OVER()` is evaluated by PostgreSQL before `LIMIT`/`OFFSET`, so the total accurately reflects all filtered rows regardless of page size.

## Notes

- Endpoints with `joinedload` ORM relationships (organizations, final supply equipment) were intentionally excluded — wrapping in a subquery discards `joinedload`, causing N+1 queries instead of saving one
- Credit ledger uses an inline window column (not a subquery wrapper) because its query already selects `(CreditLedgerView, version)` tuples; `_wf_total` is stripped before returning so callers are unchanged
- Remaining 33+ endpoints can adopt `paginate_with_window_count` incrementally

## Test plan

- [ ] `pytest lcfs/tests/audit_log/test_audit_log_repo.py` — passes
- [ ] `pytest lcfs/tests/fuel_code/test_fuel_code_repo.py` — passes
- [ ] `pytest lcfs/tests/credit_ledger/test_credit_ledger_repo.py` — passes
- [ ] `pytest lcfs/tests/compliance_report/test_compliance_report_services.py` — passes
- [ ] Smoke-test compliance report list, fuel code list, and transaction list pages in dev

Closes #4103