### PR TITLE
fix(credit-ledger): stop double timezone conversion on ledger timestamps

### DIFF
--- a/backend/lcfs/db/sql/materialized_views.sql
+++ b/backend/lcfs/db/sql/materialized_views.sql
@@ -76,8 +76,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
             ) AS recorded_date,
             NULL AS approved_date,
             (t.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
-            (t.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (t.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            t.update_date AS update_date,
+            t.create_date AS create_date
         FROM transfer t
         JOIN organization org_from
             ON t.from_organization_id = org_from.organization_id
@@ -116,8 +116,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
                 LIMIT 1
             ) AS approved_date,
             (ia.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
-            (ia.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (ia.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            ia.update_date AS update_date,
+            ia.create_date AS create_date
         FROM initiative_agreement ia
         JOIN organization org
             ON ia.to_organization_id = org.organization_id
@@ -152,8 +152,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
                 LIMIT 1
             ) AS approved_date,
             (aa.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
-            (aa.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (aa.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            aa.update_date AS update_date,
+            aa.create_date AS create_date
         FROM admin_adjustment aa
         JOIN organization org
             ON aa.to_organization_id = org.organization_id
@@ -182,8 +182,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
             (ag.recorded_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS recorded_date,
             NULL AS approved_date,
             (ag.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
-            (ag.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (ag.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            ag.update_date AS update_date,
+            ag.create_date AS create_date
         FROM aggregator_issuance ag
         JOIN organization org
             ON ag.to_organization_id = org.organization_id
@@ -211,8 +211,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
             NULL AS recorded_date,
             NULL AS approved_date,
             NULL AS transaction_effective_date,
-            (cr.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (cr.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            cr.update_date AS update_date,
+            cr.create_date AS create_date
         FROM compliance_report cr
         JOIN organization org
             ON cr.organization_id = org.organization_id
@@ -247,8 +247,8 @@ CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
             NULL AS recorded_date,
             NULL AS approved_date,
             (COALESCE(t.effective_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
-            (COALESCE(t.update_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
-            (t.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+            COALESCE(t.update_date, t.create_date) AS update_date,
+            t.create_date AS create_date
         FROM "transaction" t
         JOIN organization org
             ON t.organization_id = org.organization_id


### PR DESCRIPTION
## Problem

The org **Credit ledger** displays transaction dates in UTC wall-clock time but labels them PDT. For example, a transfer recorded at `2026-06-25 22:08 UTC` shows as **10:08 PM PDT** in the ledger, while the transfer detail page correctly shows **3:08 PM PDT** (the true Pacific time).

## Root cause

`mv_transaction_aggregate` built its `update_date` / `create_date` columns with:

```sql
(t.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')
```

For a UTC `timestamptz`, the first `AT TIME ZONE 'UTC'` strips the zone to the naive UTC wall-clock, and the second re-stamps that same wall-clock as Pacific — shifting the instant by the Pacific offset. The net effect is that the frontend formatter (which already converts to `America/Vancouver`) renders the original **UTC clock time** relabelled as PDT.

`mv_credit_ledger` inherits these columns from the aggregate, so the ledger shows the wrong time. The transfer detail endpoint sends the raw UTC `timestamptz` and converts in the frontend, which is why it displays correctly.

## Fix

Emit the raw UTC `timestamptz` for the `update_date` / `create_date` **display** columns across all transaction-type branches of `mv_transaction_aggregate`, and let the existing frontend formatter handle the Pacific conversion — consistent with the transfer detail path. No frontend change required.

The `::date` / `EXTRACT(YEAR …)` columns (`transaction_effective_date`, `recorded_date`, `compliance_period`) use the same idiom but are intentionally **left unchanged** here, since altering them affects compliance-period bucketing and warrants separate, dedicated testing.

## Deployment note

This edits the materialized-view source SQL only. The views must be dropped and recreated for the change to take effect in each environment; that recreation is being handled per-environment rather than via an Alembic migration in this PR.

## Verification

After recreating the views, ledger timestamps convert correctly to Pacific and match the transfer detail page:

```sql
SELECT transaction_id, update_date,
       update_date AT TIME ZONE 'America/Vancouver' AS vancouver_local
FROM mv_credit_ledger
WHERE transaction_id = 5507;
-- update_date = 2026-06-25 22:08…+00, vancouver_local = 2026-06-25 15:08…
```