### PR TITLE
Gate Fuel codes dashboard card behind ciApplications flag (#4579)

### DIFF
--- a/frontend/src/views/Dashboard/components/cards/bceid/OrgFuelCodeCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/bceid/OrgFuelCodeCard.jsx
@@ -10,13 +10,18 @@ import { roles } from '@/constants/roles'
 import { ROUTES } from '@/routes/routes'
 import { useOrgFuelCodeCounts } from '@/hooks/useDashboard'
 
-const CountDisplay = ({ count }) => (
+// When `hidden`, the number is rendered invisibly but still occupies layout,
+// so plain links (with no count) share the same indent and row height as the
+// counted links above them.
+const CountDisplay = ({ count, hidden = false }) => (
   <BCTypography
     component="span"
     variant="h3"
+    aria-hidden={hidden || undefined}
     sx={{
       color: 'success.main',
-      marginX: 3
+      marginX: 3,
+      ...(hidden && { visibility: 'hidden' })
     }}
   >
     {count}
@@ -44,7 +49,12 @@ const OrgFuelCodeCard = () => {
     return count > 0 ? (
       <ListItemButton component="a" onClick={onClick}>
         <CountDisplay count={count} />
-        <BCTypography variant="body2" color="link" sx={linkSx} onClick={onClick}>
+        <BCTypography
+          variant="body2"
+          color="link"
+          sx={linkSx}
+          onClick={onClick}
+        >
           {text}
         </BCTypography>
       </ListItemButton>
@@ -52,7 +62,8 @@ const OrgFuelCodeCard = () => {
   }
 
   const renderPlainLink = (text, onClick) => (
-    <ListItemButton component="a" sx={{ pl: '4.2rem' }} onClick={onClick}>
+    <ListItemButton component="a" onClick={onClick}>
+      <CountDisplay count={0} hidden />
       <BCTypography variant="body2" color="link" sx={linkSx} onClick={onClick}>
         {text}
       </BCTypography>

--- a/frontend/src/views/Dashboard/components/cards/bceid/OrgFuelCodeCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/bceid/OrgFuelCodeCard.jsx
@@ -6,7 +6,9 @@ import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
 import BCTypography from '@/components/BCTypography'
 import Loading from '@/components/Loading'
 import withRole from '@/utils/withRole'
+import { withFeatureFlag } from '@/utils/withFeatureFlag'
 import { roles } from '@/constants/roles'
+import { FEATURE_FLAGS } from '@/constants/config'
 import { ROUTES } from '@/routes/routes'
 import { useOrgFuelCodeCounts } from '@/hooks/useDashboard'
 
@@ -125,4 +127,13 @@ const OrgFuelCodeCard = () => {
 const AllowedRoles = [roles.ci_applicant]
 const OrgFuelCodeCardWithRole = withRole(OrgFuelCodeCard, AllowedRoles)
 
-export default OrgFuelCodeCardWithRole
+// Gate the card behind the CI applications feature flag (off in prod) so it
+// only appears where the feature is enabled — mirroring the flag gating on the
+// CI application routes. No redirect: this is a dashboard card, not a route, so
+// it simply renders nothing when the flag is off.
+const OrgFuelCodeCardGated = withFeatureFlag(
+  OrgFuelCodeCardWithRole,
+  FEATURE_FLAGS.CI_APPLICATIONS
+)
+
+export default OrgFuelCodeCardGated

--- a/frontend/src/views/Dashboard/components/cards/bceid/__tests__/OrgFuelCodeCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/bceid/__tests__/OrgFuelCodeCard.test.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterAll } from 'vitest'
 import OrgFuelCodeCard from '../OrgFuelCodeCard'
 import { useOrgFuelCodeCounts } from '@/hooks/useDashboard'
 import { wrapper } from '@/tests/utils/wrapper'
 import { useNavigate } from 'react-router-dom'
 import { ROUTES } from '@/routes/routes'
+import { CONFIG } from '@/constants/config'
 
 // Mock dependencies
 vi.mock('@/hooks/useDashboard')
@@ -63,10 +64,33 @@ vi.mock('@mui/material', () => ({
 
 describe('OrgFuelCodeCard Component', () => {
   const mockNavigate = vi.fn()
+  const originalCiApplicationsFlag = CONFIG.feature_flags.ciApplications
 
   beforeEach(() => {
     vi.resetAllMocks()
     useNavigate.mockReturnValue(mockNavigate)
+    // The card is gated behind the CI applications feature flag; enable it so
+    // the content tests below exercise the rendered card. The gating itself is
+    // covered by the "Feature flag gating" block.
+    CONFIG.feature_flags.ciApplications = true
+  })
+
+  afterAll(() => {
+    CONFIG.feature_flags.ciApplications = originalCiApplicationsFlag
+  })
+
+  describe('Feature flag gating', () => {
+    it('renders nothing when the CI applications feature flag is off', () => {
+      CONFIG.feature_flags.ciApplications = false
+      useOrgFuelCodeCounts.mockReturnValue({
+        data: { draft: 1, submitted: 0 },
+        isLoading: false
+      })
+
+      render(<OrgFuelCodeCard />, { wrapper })
+
+      expect(screen.queryByText('Fuel codes')).not.toBeInTheDocument()
+    })
   })
 
   describe('Loading state', () => {
@@ -137,23 +161,21 @@ describe('OrgFuelCodeCard Component', () => {
   })
 
   describe('Empty state', () => {
-    it.each([
-      { draft: 0, submitted: 0 },
-      undefined,
-      null,
-      {}
-    ])('shows the no-applications message when there is nothing in progress (%o)', (data) => {
-      useOrgFuelCodeCounts.mockReturnValue({ data, isLoading: false })
+    it.each([{ draft: 0, submitted: 0 }, undefined, null, {}])(
+      'shows the no-applications message when there is nothing in progress (%o)',
+      (data) => {
+        useOrgFuelCodeCounts.mockReturnValue({ data, isLoading: false })
 
-      render(<OrgFuelCodeCard />, { wrapper })
+        render(<OrgFuelCodeCard />, { wrapper })
 
-      expect(
-        screen.getByText(
-          /There are no carbon intensity applications in progress./
-        )
-      ).toBeInTheDocument()
-      expect(screen.queryByText(/There are:/)).not.toBeInTheDocument()
-    })
+        expect(
+          screen.getByText(
+            /There are no carbon intensity applications in progress./
+          )
+        ).toBeInTheDocument()
+        expect(screen.queryByText(/There are:/)).not.toBeInTheDocument()
+      }
+    )
   })
 
   describe('Action links (always present)', () => {
@@ -166,7 +188,9 @@ describe('OrgFuelCodeCard Component', () => {
 
     it('navigates to the CI applications list via "View all"', () => {
       render(<OrgFuelCodeCard />, { wrapper })
-      fireEvent.click(screen.getByText(/View all carbon intensity applications/))
+      fireEvent.click(
+        screen.getByText(/View all carbon intensity applications/)
+      )
       expect(mockNavigate).toHaveBeenCalledWith(ROUTES.CI_APPLICATIONS.LIST)
     })
 


### PR DESCRIPTION
## Summary

Follow-up to the merged #4579 Fuel codes dashboard card (PR #4618). Two changes:

1. **Feature-flag gating (primary).** The card was gated by the `ci_applicant` role only, so it rendered for CI-applicant users even where the CI applications feature is turned off — including prod. It's now wrapped in `withFeatureFlag(FEATURE_FLAGS.CI_APPLICATIONS)` (no redirect — it simply renders nothing when the flag is off), matching how the CI application routes are already gated. This keeps it off prod until the feature is released, while still visible on test where the flag is on.

2. **Layout fix (review nit).** The "View all" / "Start a new" links faked their indent with a fixed `pl` and had no leading element, so they sat at a different indent and row height than the counted rows above. They now render the same `CountDisplay` element, invisibly (`visibility: hidden` + `aria-hidden`), so indent and line spacing match by construction.

## Testing
- `vitest` on `OrgFuelCodeCard` — 12 passed, including a new test asserting the card renders nothing when `ciApplications` is off.
- Not browser-verified: the card sits behind a `ci_applicant` Keycloak login + the flag, so it isn't reachable in a quick preview. The flag-off/on behaviour is covered by unit tests.
