### PR TITLE
Patch: Rename Methy to Fuelbert

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_review_service.py
+++ b/backend/lcfs/tests/compliance_report/test_review_service.py
@@ -136,3 +136,40 @@ def test_fse_chart_series_merges_kwh_usage_and_capacity_utilization():
         "Total FSE",
         "Level 2 FSE",
     }
+
+
+def test_supplemental_line_20_finding_uses_magnitude_gap_delta():
+    service = _service()
+    current_summary = SimpleNamespace(
+        low_carbon_fuel_target_summary=[SimpleNamespace(line=20, value=890)]
+    )
+    previous_summary = SimpleNamespace(
+        low_carbon_fuel_target_summary=[SimpleNamespace(line=20, value=-180)]
+    )
+
+    findings = service._supplemental_summary_findings(
+        current_summary,
+        previous_summary,
+    )
+
+    assert len(findings) == 1
+    metric = findings[0].evidence[0]
+    assert metric.value == 890
+    assert metric.comparison_value == -180
+    assert metric.delta == 710
+
+
+def test_comparison_point_can_use_magnitude_gap_delta_mode():
+    service = _service()
+
+    point = service._comparison_point(
+        "Line 20",
+        890,
+        -180,
+        units="compliance units",
+        delta_mode="magnitude_gap",
+    )
+
+    assert point.current_value == 890
+    assert point.comparison_value == -180
+    assert point.delta == 710

--- a/backend/lcfs/web/api/compliance_report/review_service.py
+++ b/backend/lcfs/web/api/compliance_report/review_service.py
@@ -1038,7 +1038,11 @@ class ComplianceReportReviewService:
         if current_line_20 == previous_line_20:
             return []
 
-        delta = (current_line_20 or 0) - (previous_line_20 or 0)
+        delta = self._magnitude_gap(current_line_20 or 0, previous_line_20 or 0)
+        percent_change = self._percent_change(
+            abs(current_line_20 or 0),
+            abs(previous_line_20 or 0),
+        )
         return [
             self._finding(
                 "Supplemental impacts",
@@ -1052,6 +1056,7 @@ class ComplianceReportReviewService:
                         current_line_20,
                         comparison_value=previous_line_20,
                         delta=delta,
+                        percent_change=percent_change,
                         units="compliance units",
                     )
                 ],
@@ -1168,6 +1173,7 @@ class ComplianceReportReviewService:
                             "Line 20",
                             current_line_20 or 0,
                             previous_line_20 or 0,
+                            delta_mode="magnitude_gap",
                             units="compliance units",
                         )
                     ],
@@ -1285,14 +1291,23 @@ class ComplianceReportReviewService:
         current_value: float,
         comparison_value: float,
         units: str,
+        delta_mode: str = "signed",
     ) -> ComplianceReportReviewComparisonPointSchema:
-        delta = current_value - comparison_value
+        if delta_mode == "magnitude_gap":
+            delta = self._magnitude_gap(current_value, comparison_value)
+            percent_change = self._percent_change(
+                abs(current_value),
+                abs(comparison_value),
+            )
+        else:
+            delta = current_value - comparison_value
+            percent_change = self._percent_change(current_value, comparison_value)
         return ComplianceReportReviewComparisonPointSchema(
             label=label,
             current_value=current_value,
             comparison_value=comparison_value,
             delta=delta,
-            percent_change=self._percent_change(current_value, comparison_value),
+            percent_change=percent_change,
             units=units,
         )
 
@@ -1520,6 +1535,9 @@ class ComplianceReportReviewService:
         if isinstance(value, Decimal):
             return float(value)
         return float(value)
+
+    def _magnitude_gap(self, current_value, comparison_value) -> float:
+        return abs(abs(self._number(current_value)) - abs(self._number(comparison_value)))
 
     def _to_int(self, value) -> int | None:
         try:

--- a/frontend/public/config/config.js
+++ b/frontend/public/config/config.js
@@ -1,5 +1,6 @@
 export const config = {
   api_base: 'http://localhost:8000/api',
+  analyst_review_assistant_name: 'Fuelbert',
   tfrs_base: 'http://localhost:3000',
   environment: 'development',
   keycloak: {

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -24,6 +24,7 @@ export interface KeycloakConfig {
 
 export interface LcfsWindowConfig {
   api_base?: string
+  analyst_review_assistant_name?: string
   tfrs_base: string
   environment: string
   keycloak: KeycloakConfig
@@ -92,10 +93,24 @@ export const isFeatureEnabled = (featureFlag: FeatureFlagValue): boolean => {
 
 export interface AppConfig {
   API_BASE: string
+  ANALYST_REVIEW_ASSISTANT_NAME: string
   TFRS_BASE: string
   ENVIRONMENT: string
   KEYCLOAK: Required<KeycloakConfig>
   feature_flags: Record<FeatureFlagValue, boolean>
+}
+
+const getAnalystReviewAssistantName = (): string => {
+  const viteEnv = (
+    import.meta as ImportMeta & {
+      env?: Record<string, string | undefined>
+    }
+  ).env
+  const assistantName =
+    window.lcfs_config.analyst_review_assistant_name ??
+    viteEnv?.VITE_ANALYST_REVIEW_ASSISTANT_NAME
+
+  return assistantName?.trim() || 'Fuelbert'
 }
 
 const getKeycloakConfig = (
@@ -112,6 +127,7 @@ const getKeycloakConfig = (
 
 export const CONFIG: AppConfig = {
   API_BASE: getApiBaseUrl(),
+  ANALYST_REVIEW_ASSISTANT_NAME: getAnalystReviewAssistantName(),
   TFRS_BASE: window.lcfs_config.tfrs_base,
   ENVIRONMENT: window.lcfs_config.environment,
   KEYCLOAK: getKeycloakConfig(window.lcfs_config.keycloak),

--- a/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/__tests__/RobotAvatar.test.tsx
+++ b/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/__tests__/RobotAvatar.test.tsx
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { RobotAvatar } from '../RobotAvatar'
 
 describe('RobotAvatar', () => {
-  it('renders the Methy robot gif in a square avatar frame', () => {
+  it('renders the assistant robot gif in a square avatar frame', () => {
     const { container } = render(
       <RobotAvatar
         robot={{
-          name: 'Methy',
+          name: 'Fuelbert',
           color: '#003366',
           background: '#fff'
         }}

--- a/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/__tests__/index.test.tsx
+++ b/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/__tests__/index.test.tsx
@@ -47,7 +47,7 @@ describe('AnalystReviewSummary', () => {
     mockUseGetComplianceReportReviewSummary.mockReset()
   })
 
-  it('shows Methy drafting state while loading', () => {
+  it('shows assistant drafting state while loading', () => {
     mockUseGetComplianceReportReviewSummary.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -69,7 +69,7 @@ describe('AnalystReviewSummary', () => {
     render(<AnalystReviewSummary complianceReportId={101} />)
 
     expect(
-      screen.getByText('Methy pre-screen is unavailable.')
+      screen.getByText('Fuelbert pre-screen is unavailable.')
     ).toBeInTheDocument()
   })
 
@@ -87,7 +87,9 @@ describe('AnalystReviewSummary', () => {
       screen.getAllByText('Which FSE rows are not validated?')
     ).toHaveLength(1)
 
-    await user.click(screen.getByRole('button', { name: /Methy pre-screen/i }))
+    await user.click(
+      screen.getByRole('button', { name: /Fuelbert pre-screen/i })
+    )
     await user.click(screen.getByRole('button', { name: /Electricity\/FSE/i }))
     await user.click(screen.getByRole('checkbox', { name: /addressed/i }))
 

--- a/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/constants.ts
+++ b/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/constants.ts
@@ -1,4 +1,5 @@
 import type { ChipProps } from '@mui/material'
+import { CONFIG } from '@/constants/config'
 import type { ReviewSectionStatus, ReviewSeverity, RobotVariant } from './types'
 
 export const severityColor: Record<ReviewSeverity, ChipProps['color']> = {
@@ -13,8 +14,22 @@ export const sectionColor: Record<ReviewSectionStatus, ChipProps['color']> = {
   clear: 'success'
 }
 
+export const analystReviewAssistantName = CONFIG.ANALYST_REVIEW_ASSISTANT_NAME
+
 export const robotVariants: RobotVariant[] = [
-  { name: 'Methy review', color: '#0f766e', background: '#ccfbf1' },
-  { name: 'Methy summary', color: '#1d4ed8', background: '#dbeafe' },
-  { name: 'Methy triage', color: '#7c3aed', background: '#ede9fe' }
+  {
+    name: `${analystReviewAssistantName} review`,
+    color: '#0f766e',
+    background: '#ccfbf1'
+  },
+  {
+    name: `${analystReviewAssistantName} summary`,
+    color: '#1d4ed8',
+    background: '#dbeafe'
+  },
+  {
+    name: `${analystReviewAssistantName} triage`,
+    color: '#7c3aed',
+    background: '#ede9fe'
+  }
 ]

--- a/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/index.tsx
+++ b/frontend/src/views/ComplianceReports/components/AnalystReviewSummary/index.tsx
@@ -13,7 +13,7 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
 import { useEffect, useMemo, useState } from 'react'
-import { robotVariants } from './constants'
+import { analystReviewAssistantName, robotVariants } from './constants'
 import { ReviewCharts } from './ReviewCharts'
 import { ReviewSections } from './ReviewSections'
 import { RobotAvatar } from './RobotAvatar'
@@ -129,7 +129,7 @@ export const AnalystReviewSummary = ({
   if (isError || !data) {
     return (
       <BCAlert severity="warning" noFade sx={{ mb: 2 }}>
-        Methy pre-screen is unavailable.
+        {analystReviewAssistantName} pre-screen is unavailable.
       </BCAlert>
     )
   }
@@ -180,7 +180,7 @@ export const AnalystReviewSummary = ({
               <BCBox>
                 <Stack direction="row" spacing={0.75} alignItems="center">
                   <BCTypography variant="h6" color="primary">
-                    Methy pre-screen
+                    {analystReviewAssistantName} pre-screen
                   </BCTypography>
                   <Chip
                     size="small"


### PR DESCRIPTION
- Change Methy to Fuelbert, also can be re-configurered to a different name using environment variable.
- Fix a minor issue with compliance units delta calculation to identify the real gap rather than just difference.