### PR TITLE
Fix: Improve pathway export column widths - 4661

### DIFF
--- a/frontend/src/views/CarbonIntensity/__tests__/pathwayExport.test.js
+++ b/frontend/src/views/CarbonIntensity/__tests__/pathwayExport.test.js
@@ -54,7 +54,7 @@ describe('pathwayExport', () => {
           ['New', 'Canola'],
           ['Renewal', 'Soy']
         ],
-        '!cols': [{ wch: 18 }, { wch: 14 }]
+        '!cols': [{ wch: 20 }, { wch: 14 }]
       }),
       'Pathways'
     )
@@ -62,6 +62,25 @@ describe('pathwayExport', () => {
       { sheets: [] },
       'ci_application_pathways_10.xlsx',
       { bookType: 'xlsx' }
+    )
+  })
+
+  it('uses the grid minimum width when it is wider than the content', () => {
+    exportRowsToXlsx({
+      rows: [{ feedstock: 'Soy' }],
+      columnDefs: [
+        { field: 'feedstock', headerName: 'Feedstock', minWidth: 220 }
+      ],
+      fileName: 'pathways.xlsx',
+      sheetName: 'Pathways'
+    })
+
+    expect(XLSX.utils.book_append_sheet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        '!cols': [{ wch: 31 }]
+      }),
+      'Pathways'
     )
   })
 

--- a/frontend/src/views/CarbonIntensity/components/pathwayExport.js
+++ b/frontend/src/views/CarbonIntensity/components/pathwayExport.js
@@ -7,10 +7,28 @@ const getExportCellValue = (row, colDef) => {
   return row?.[colDef.field] ?? ''
 }
 
-const columnWidthFor = (values) =>
+const MAX_COLUMN_WIDTH = 80
+const MIN_COLUMN_WIDTH = 14
+const COLUMN_PADDING = 4
+const EXCEL_CHARACTER_WIDTH_IN_PIXELS = 7
+const EXCEL_CELL_PADDING_IN_PIXELS = 5
+
+const minWidthFor = (colDef) =>
+  colDef.minWidth
+    ? Math.ceil(
+        (colDef.minWidth - EXCEL_CELL_PADDING_IN_PIXELS) /
+          EXCEL_CHARACTER_WIDTH_IN_PIXELS
+      )
+    : 0
+
+const columnWidthFor = (values, colDef) =>
   Math.min(
-    Math.max(...values.map((value) => String(value ?? '').length), 12) + 2,
-    80
+    Math.max(
+      ...values.map((value) => String(value ?? '').length + COLUMN_PADDING),
+      MIN_COLUMN_WIDTH,
+      minWidthFor(colDef)
+    ),
+    MAX_COLUMN_WIDTH
   )
 
 export const exportRowsToXlsx = ({ rows, columnDefs, fileName, sheetName }) => {
@@ -26,7 +44,10 @@ export const exportRowsToXlsx = ({ rows, columnDefs, fileName, sheetName }) => {
   const worksheet = XLSX.utils.aoa_to_sheet([headers, ...dataRows])
 
   worksheet['!cols'] = headers.map((header, index) => ({
-    wch: columnWidthFor([header, ...dataRows.map((row) => row[index])])
+    wch: columnWidthFor(
+      [header, ...dataRows.map((row) => row[index])],
+      exportColumns[index]
+    )
   }))
 
   const workbook = XLSX.utils.book_new()


### PR DESCRIPTION
This PR improves default column widths in pathway Excel exports.

- Show column headers without resizing
- Minimize manual column adjustments

Closes #4661