### PR TITLE
Honour per-year supplemental config for 2023 and prior reports (#4691)

### DIFF
--- a/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
+++ b/frontend/src/views/ComplianceReports/components/AssessmentCard.jsx
@@ -139,25 +139,39 @@ export const AssessmentCard = ({
     return parseInt(derivedCompliancePeriod, 10)
   }, [derivedCompliancePeriod])
 
+  // Per-year IDIR configuration (Report openings) for this report's year, if the
+  // year is one the administrator can configure at all.
+  const yearConfig = useMemo(() => {
+    if (
+      !Array.isArray(reportOpenings) ||
+      Number.isNaN(compliancePeriodNumber)
+    ) {
+      return null
+    }
+    return (
+      reportOpenings.find(
+        (opening) => opening.complianceYear === compliancePeriodNumber
+      ) ?? null
+    )
+  }, [reportOpenings, compliancePeriodNumber])
+
+  // The per-year IDIR configuration is authoritative wherever it exists, so an
+  // administrator enabling "Create supplemental" for 2023 or earlier makes the
+  // button available for that year (#4691). The legacy lock flag predates that
+  // toggle and would otherwise override it; it now only guards years with no
+  // configuration row (compliance periods outside the configurable range), which
+  // an administrator has no way to open up.
   const isLegacySupplementalRestricted =
     !isGovernmentUser &&
     isFeatureEnabled(FEATURE_FLAGS.LEGACY_SUPPLEMENTAL_LOCK) &&
     !Number.isNaN(compliancePeriodNumber) &&
-    compliancePeriodNumber <= 2023
+    compliancePeriodNumber <= 2023 &&
+    !yearConfig
 
   // Show/hide Create Supplemental button for BCeID by IDIR config per year.
-  const isCreateSupplementalAllowedForYear = useMemo(() => {
-    if (!Array.isArray(reportOpenings)) {
-      return true
-    }
-    const yearConfig = reportOpenings.find(
-      (opening) => opening.complianceYear === compliancePeriodNumber
-    )
-    if (!yearConfig) {
-      return true
-    }
-    return yearConfig.createSupplementalEnabled !== false
-  }, [reportOpenings, compliancePeriodNumber])
+  const isCreateSupplementalAllowedForYear = yearConfig
+    ? yearConfig.createSupplementalEnabled !== false
+    : true
 
   return (
     <BCWidgetCard

--- a/frontend/src/views/ComplianceReports/components/__tests__/AssessmentCard.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/AssessmentCard.test.jsx
@@ -776,6 +776,93 @@ describe('AssessmentCard', () => {
         expect(screen.getByTestId('create-supplemental')).toBeInTheDocument()
       })
 
+      // #4691 — the legacy lock feature flag is enabled in these tests
+      // (isFeatureEnabled is mocked to true), mirroring the deployed
+      // environment where the bug was reported.
+      it('shows supplemental button for a 2023 report when an admin enabled the year', () => {
+        mockShowRoleContent = true
+        vi.mocked(useReportOpenings).mockReturnValue({
+          data: [{ complianceYear: 2023, createSupplementalEnabled: true }]
+        })
+        render(
+          <AssessmentCard
+            {...defaultProps}
+            currentStatus={COMPLIANCE_REPORT_STATUSES.ASSESSED}
+            compliancePeriodYear="2023"
+          />,
+          { wrapper }
+        )
+        expect(screen.getByTestId('create-supplemental')).toBeInTheDocument()
+      })
+
+      it('hides supplemental button for a 2023 report when an admin disabled the year', () => {
+        mockShowRoleContent = true
+        vi.mocked(useReportOpenings).mockReturnValue({
+          data: [{ complianceYear: 2023, createSupplementalEnabled: false }]
+        })
+        render(
+          <AssessmentCard
+            {...defaultProps}
+            currentStatus={COMPLIANCE_REPORT_STATUSES.ASSESSED}
+            compliancePeriodYear="2023"
+          />,
+          { wrapper }
+        )
+        expect(
+          screen.queryByTestId('create-supplemental')
+        ).not.toBeInTheDocument()
+      })
+
+      it('keeps the legacy lock for a pre-2019 year that has no configurable row', () => {
+        // Report openings are only configurable for 2019-2030, so an older year
+        // can never be enabled by an admin and stays locked.
+        mockShowRoleContent = true
+        vi.mocked(useReportOpenings).mockReturnValue({
+          data: [{ complianceYear: 2023, createSupplementalEnabled: true }]
+        })
+        render(
+          <AssessmentCard
+            {...defaultProps}
+            currentStatus={COMPLIANCE_REPORT_STATUSES.ASSESSED}
+            compliancePeriodYear="2017"
+          />,
+          { wrapper }
+        )
+        expect(
+          screen.queryByTestId('create-supplemental')
+        ).not.toBeInTheDocument()
+      })
+
+      it('keeps the legacy lock for a 2023 report while the config is still loading', () => {
+        mockShowRoleContent = true
+        vi.mocked(useReportOpenings).mockReturnValue({ data: undefined })
+        render(
+          <AssessmentCard
+            {...defaultProps}
+            currentStatus={COMPLIANCE_REPORT_STATUSES.ASSESSED}
+            compliancePeriodYear="2023"
+          />,
+          { wrapper }
+        )
+        expect(
+          screen.queryByTestId('create-supplemental')
+        ).not.toBeInTheDocument()
+      })
+
+      it('still shows supplemental button for 2025 while the config is loading', () => {
+        mockShowRoleContent = true
+        vi.mocked(useReportOpenings).mockReturnValue({ data: undefined })
+        render(
+          <AssessmentCard
+            {...defaultProps}
+            currentStatus={COMPLIANCE_REPORT_STATUSES.ASSESSED}
+            compliancePeriodYear="2025"
+          />,
+          { wrapper }
+        )
+        expect(screen.getByTestId('create-supplemental')).toBeInTheDocument()
+      })
+
       it('shows download button for non-draft status', () => {
         render(<AssessmentCard {...defaultProps} />, { wrapper })
         expect(screen.getByTestId('download-report')).toBeInTheDocument()


### PR DESCRIPTION
Closes #4691.

The **Create supplemental report** button never appeared for assessed 2023-and-earlier reports, even after an administrator enabled supplemental reporting for those years.

## Root cause
Two gates governed the same decision, and the blunt one won:

- `legacySupplementalLock` (feature flag, Dec 2025) hides the button for any year `<= 2023`.
- `create_supplemental_enabled` (per-year **Report openings** toggle, May 2026) is the DB-backed, admin-controlled setting.

They were evaluated independently, and the hard-coded year cutoff took precedence — so no amount of administrative configuration could reveal the button for 2023 and prior. That is exactly the reported symptom.

## Fix
Make the per-year configuration authoritative wherever it exists, and keep the legacy lock only for years that have **no** configuration row.

This is the right precedence because the per-year toggle is the newer, purpose-built mechanism, and it already defaults past years to disabled (`create_supplemental_enabled = year >= current_year`), reproducing the lock's intent per-year while letting an admin override it.

Report openings are configurable for **2019–2030** only (`configured_years()`), while compliance periods span 2010–2032. Retiring the lock outright would newly expose the button for pre-2019 legacy reports that an administrator has no way to close again — so the lock is retained for exactly those years.

### Behaviour by year
| Year | Config | Before | After |
|---|---|---|---|
| 2023 | enabled by admin | hidden | **shown** (the fix) |
| 2023 | disabled | hidden | hidden |
| 2024 / 2025 | enabled/disabled | governed by config | unchanged |
| pre-2019 | not configurable | hidden | hidden (lock retained) |

This holds regardless of the deployed value of the legacy lock flag, which lives outside this repo.

The backend (`create_supplemental_report`) already permits creating a supplemental for these years — it validates only ownership and latest-in-group — so no server-side change is required. IDIR-side creation was never affected (the gate is BCeID-only).

## Acceptance criteria
- Button displayed for assessed 2023-and-prior when enabled for those years ✓
- Users can initiate creation from Report History ✓ (backend already allows it)
- Eligibility rules consistent across supported reporting years ✓
- Visibility reflects administrative configuration ✓
- No regression for 2024/2025 ✓
- Users without permission still restricted ✓ (unchanged `Role`/status/reassessment gates)

## Tests
5 new cases in `AssessmentCard.test.jsx` (the suite mocks the lock flag as **enabled**, mirroring the affected environment): 2023 enabled → shown; 2023 disabled → hidden; pre-2019 → still locked; plus two loading-state cases confirming no button flicker for 2023 and no delay for 2025. Full ComplianceReports suite passes (657 tests).

## Note on verification
Verified via the test suite rather than a live browser: the bug does not reproduce locally (`legacySupplementalLock` is `false` in the local config), and reproducing it needs the deployed flag plus BCeID auth and an assessed 2023 report.

## Possible follow-ups (not included)
- `ViewLegacyComplianceReport.jsx` is orphaned and imports a deleted component; it would throw if rendered.
- `isLegacyCompliancePeriod()` in `constants/common.ts` is unused, and `AssessmentCard` duplicates it with a hard-coded literal.