### PR TITLE
Fix: Update draft application delete message - 4671

### DIFF
--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -32,6 +32,7 @@
     "saveAndProceed": "Save & proceed",
     "deleteDraft": "Delete draft application",
     "saveSuccess": "Application information saved.",
+    "deleteSuccess": "Draft application deleted.",
     "deleteConfirmTitle": "Delete draft application?",
     "deleteConfirmText": "This will permanently remove the draft. This action cannot be undone.",
     "validation": {

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -288,7 +288,7 @@ const EditViewCIApplicationBase = () => {
       await deleteDraft(ciApplicationId)
       navigate(ROUTES.CI_APPLICATIONS.LIST, {
         state: {
-          message: t('carbonIntensity:step1.deleteConfirmTitle'),
+          message: t('carbonIntensity:step1.deleteSuccess'),
           severity: 'success'
         }
       })

--- a/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/EditViewCIApplication.test.jsx
@@ -344,7 +344,12 @@ describe('EditViewCIApplication', () => {
     await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('10'))
     expect(mockNavigate).toHaveBeenCalledWith(
       ROUTES.CI_APPLICATIONS.LIST,
-      expect.any(Object)
+      {
+        state: {
+          message: 'carbonIntensity:step1.deleteSuccess',
+          severity: 'success'
+        }
+      }
     )
   })
 


### PR DESCRIPTION
This PR updates the confirmation message shown after deleting a draft CI application.

- Displays “Draft application deleted.”

Closes #4671