### PR TITLE
Skip data-entry validation when deleting Fuels for other use rows (#4689)

### DIFF
--- a/backend/lcfs/tests/other_uses/test_other_uses_validation.py
+++ b/backend/lcfs/tests/other_uses/test_other_uses_validation.py
@@ -1,16 +1,19 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 
 from lcfs.web.api.other_uses.schema import OtherUsesCreateSchema, OtherUsesSchema
 from lcfs.web.api.other_uses.validation import OtherUsesValidation
 
+
 @pytest.fixture
 def other_uses_validation():
     request = MagicMock(spec=Request)
     validation = OtherUsesValidation(request=request)
     return validation
+
 
 @pytest.mark.anyio
 async def test_validate_compliance_report_id_success(other_uses_validation):
@@ -31,7 +34,10 @@ async def test_validate_compliance_report_id_success(other_uses_validation):
         )
     ]
 
-    await validation.validate_compliance_report_id(compliance_report_id, other_uses_data)
+    await validation.validate_compliance_report_id(
+        compliance_report_id, other_uses_data
+    )
+
 
 @pytest.mark.anyio
 async def test_validate_compliance_report_id_failure(other_uses_validation):
@@ -53,7 +59,9 @@ async def test_validate_compliance_report_id_failure(other_uses_validation):
     ]
 
     with pytest.raises(HTTPException) as exc_info:
-        await validation.validate_compliance_report_id(compliance_report_id, other_uses_data)
+        await validation.validate_compliance_report_id(
+            compliance_report_id, other_uses_data
+        )
 
     assert exc_info.value.status_code == 400
     assert "Mismatch compliance_report_id" in str(exc_info.value.detail)
@@ -95,6 +103,70 @@ def test_non_other_expected_use_allows_blank_rationale():
     )
 
     assert schema.expected_use == "Transportation"
+
+
+def test_delete_skips_other_expected_use_rationale_rule():
+    # Deleting re-submits the stored row with `deleted: true`. A row saved
+    # before the rationale rule existed has expected_use "Other" with no
+    # rationale, and must still be removable (#4689).
+    schema = OtherUsesCreateSchema(
+        compliance_report_id=1,
+        quantity_supplied=1000,
+        fuel_type="Gasoline",
+        fuel_category="Petroleum-based",
+        expected_use="Other",
+        rationale=None,
+        units="L",
+        provision_of_the_act="Provision A",
+        deleted=True,
+        group_uuid="test-group-uuid",
+        is_canada_produced=True,
+        is_q1_supplied=False,
+    )
+
+    assert schema.deleted is True
+    assert schema.rationale is None
+
+
+def test_delete_skips_fuel_code_required_rule():
+    schema = OtherUsesCreateSchema(
+        compliance_report_id=1,
+        quantity_supplied=1000,
+        fuel_type="Gasoline",
+        fuel_category="Petroleum-based",
+        expected_use="Transportation",
+        units="L",
+        provision_of_the_act="Fuel code - section 19 (b) (i)",
+        fuel_code=None,
+        deleted=True,
+        group_uuid="test-group-uuid",
+        is_canada_produced=True,
+        is_q1_supplied=False,
+    )
+
+    assert schema.deleted is True
+    assert schema.fuel_code is None
+
+
+def test_non_delete_still_requires_rationale_for_other():
+    # Saving a row (deleted explicitly false) keeps the data-entry rule.
+    with pytest.raises(RequestValidationError) as exc:
+        OtherUsesCreateSchema(
+            compliance_report_id=1,
+            quantity_supplied=1000,
+            fuel_type="Gasoline",
+            fuel_category="Petroleum-based",
+            expected_use="Other",
+            rationale=None,
+            units="L",
+            provision_of_the_act="Provision A",
+            deleted=False,
+            is_canada_produced=True,
+            is_q1_supplied=False,
+        )
+
+    errors = exc.value.errors()
+    assert errors[0]["loc"] == ("rationale",)
 
 
 def test_response_schema_allows_legacy_other_without_rationale():

--- a/backend/lcfs/web/api/other_uses/schema.py
+++ b/backend/lcfs/web/api/other_uses/schema.py
@@ -1,20 +1,27 @@
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import Field, field_validator, model_validator
 
 from lcfs.web.api.base import (
     BaseSchema,
-    FilterModel,
-    SortOrder,
-    PaginationResponseSchema,
     ComplianceReportRequestSchema,
+    FilterModel,
+    PaginationResponseSchema,
+    SortOrder,
 )
 from lcfs.web.api.fuel_type.schema import FuelTypeQuantityUnitsEnumSchema
 from lcfs.web.utils.schema_validators import (
     fuel_code_required_label,
     other_expected_use_required,
 )
+
+
+def _is_delete(values) -> bool:
+    """True when the payload is removing a row rather than saving one."""
+    if hasattr(values, "get"):
+        return bool(values.get("deleted"))
+    return bool(getattr(values, "deleted", False))
 
 
 class FuelCodeStatusEnumSchema(str, Enum):
@@ -119,6 +126,15 @@ class OtherUsesCreateSchema(BaseSchema):
     @model_validator(mode="before")
     @classmethod
     def check_fuel_code_required(cls, values):
+        # Deleting a row re-submits the stored values with `deleted: true`, but
+        # delete_other_use only reads group_uuid, other_uses_id and
+        # compliance_report_id and copies every other field from the record it
+        # already has. These rules therefore only apply to data being saved:
+        # enforcing them on a delete blocks removing rows whose rationale is
+        # empty, which is possible for rows saved before the rule existed
+        # (#4689).
+        if _is_delete(values):
+            return values
         values = fuel_code_required_label(values)
         return other_expected_use_required(values)
 


### PR DESCRIPTION
Closes #4689.

BCeID users could not delete rows from **Fuels for other use** in a draft supplemental report. The delete failed with:

> Unable to delete/undo row: required when Expected use is Other.

## Root cause
Deleting a row re-submits the stored row with `deleted: true` to `POST /other-uses/save`, whose body is typed as `OtherUsesCreateSchema`. That schema's `model_validator(mode="before")` runs **while FastAPI parses the request** — so it rejects the payload before the endpoint ever reaches its `if request_data.deleted:` branch (`views.py:151`).

Any row with expected use `Other` and no rationale was therefore impossible to delete. That state is reachable for rows saved before the rationale rule existed — and `OtherUsesSchema` already tolerates exactly those rows on read (see the pre-existing `test_response_schema_allows_legacy_other_without_rationale`), so the data model expects them to exist.

This matches the issue's own diagnosis: *"validation intended for data entry is preventing row deletion."*

## Fix
Skip the field-level rules when the payload is a delete.

Those rules only apply to data being *saved*. `delete_other_use` (`services.py:290-321`) reads only `group_uuid`, `other_uses_id` and `compliance_report_id`, and copies **every other field from the record it already has** — so the submitted field values are discarded regardless. Validating them gates the delete on data that is never used.

Saving is unchanged: the rules still apply to any non-delete payload.

## Acceptance criteria
- Users can delete rows in Fuels for other use of a draft supplemental report ✓
- Deleting bypasses validation rules only applicable to saving ✓
- No warning message when deleting a valid row ✓
- Row removed successfully ✓ (the existing delete path now runs)
- Calculations/validation still work after deletion ✓ (delete path itself untouched)
- Adding/editing rows unaffected ✓ (rules still enforced on save)

## Scope
Backend-only. The frontend already sends the delete correctly and does not block it client-side — `isOtherExpectedUseMissing` only runs in `onCellEditingStopped` (the save path), not in `onAction`. The 400 surfaced from the server.

The skip is deliberately scoped to `OtherUsesCreateSchema` rather than the shared validators in `schema_validators.py`, so `allocation_agreement` (the other consumer of `fuel_code_required_label`) is untouched.

## Tests
3 new cases in `test_other_uses_validation.py`:
- delete with `Other` + no rationale → accepted (fails without this fix)
- delete with a fuel-code-requiring provision + no fuel code → accepted
- save with `deleted=False` + `Other` + no rationale → still rejected (regression guard)

19 tests pass in `lcfs/tests/other_uses/`. The 8 `test_other_uses_view.py` tests error at **fixture setup** on a pre-existing seeding `ForeignKeyViolationError` unrelated to this change — untouched modules (e.g. `lcfs/tests/fuel_export/`) show the identical failure on develop.

## Note on verification
Verified via the test suite; reproducing the original symptom end-to-end needs the deployed environment plus BCeID auth and a draft supplemental containing a legacy `Other` row with no rationale.

## Formatting
`black` + `isort` (the documented backend convention) were run on the two touched files, which reorders a few pre-existing import lines. Functional change is confined to the validator.