### PR TITLE
Fix: Show description in submitted applications - 4649

### DIFF
--- a/frontend/src/views/CarbonIntensity/__tests__/ApplicationSummary.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/ApplicationSummary.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { wrapper } from '@/tests/utils/wrapper'
+import { ApplicationSummary } from '@/views/CarbonIntensity/components/ApplicationSummary'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+vi.mock('@/hooks/useDocuments', () => ({
+  useDownloadDocument: () => vi.fn()
+}))
+
+vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
+  BCGridViewer: () => <div data-test="grid-stub" />
+}))
+
+vi.mock('@/views/CarbonIntensity/components/_step2Schema', () => ({
+  ciApplicationPathwayChangelogColDefs: () => [],
+  ciApplicationPathwaySummaryColDefs: () => []
+}))
+
+const baseApplication = {
+  ciApplicationId: 99,
+  documents: [],
+  organization: {},
+  pathways: []
+}
+
+describe('ApplicationSummary', () => {
+  afterEach(cleanup)
+
+  it('displays the pathway description above the pathway content', () => {
+    render(
+      <ApplicationSummary
+        ciApplication={{
+          ...baseApplication,
+          pathwayDescription: 'Uses carbon capture and sequestration.'
+        }}
+      />,
+      { wrapper }
+    )
+
+    const description = screen.getByTestId('ci-summary-pathway-description')
+    expect(description).toHaveTextContent(
+      'carbonIntensity:step2.descriptionLabel'
+    )
+    expect(description).toHaveTextContent(
+      'Uses carbon capture and sequestration.'
+    )
+    const pathwaysHeader = screen.getByText(
+      'carbonIntensity:summary.pathwaysHeader'
+    )
+    expect(
+      description.compareDocumentPosition(pathwaysHeader) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it.each([null, '', '   '])(
+    'does not display the pathway description when its value is %p',
+    (pathwayDescription) => {
+      render(
+        <ApplicationSummary
+          ciApplication={{ ...baseApplication, pathwayDescription }}
+        />,
+        { wrapper }
+      )
+
+      expect(
+        screen.queryByTestId('ci-summary-pathway-description')
+      ).not.toBeInTheDocument()
+    }
+  )
+})

--- a/frontend/src/views/CarbonIntensity/components/ApplicationSummary.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ApplicationSummary.jsx
@@ -282,6 +282,7 @@ export const ApplicationSummary = ({
 
   const documents = ciApplication.documents || []
   const pathways = ciApplication.pathways || []
+  const pathwayDescription = ciApplication.pathwayDescription?.trim()
   const pathwayChangeLogs = [
     ...(ciApplication.pathwayChangeLogs ||
       ciApplication.pathway_change_logs ||
@@ -709,6 +710,26 @@ export const ApplicationSummary = ({
       </BCBox>
 
       <Divider sx={{ mb: 2 }} />
+
+      {!isEditingPathways && pathwayDescription && (
+        <>
+          <BCBox
+            data-test="ci-summary-pathway-description"
+            sx={{ width: '100%', mb: 2 }}
+          >
+            <BCTypography
+              variant="subtitle1"
+              sx={{ fontWeight: 700, color: colors.primary.main, mb: 1 }}
+            >
+              {t('carbonIntensity:step2.descriptionLabel')}
+            </BCTypography>
+            <BCTypography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+              {pathwayDescription}
+            </BCTypography>
+          </BCBox>
+          <Divider sx={{ mb: 2 }} />
+        </>
+      )}
 
       {/* Pathways */}
       <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 1 }}>


### PR DESCRIPTION
This PR displays unique pathway characteristics in submitted applications.
- Displays description above pathway tables
- Hides the section when empty

Closes #4649