### PR TITLE
Fix: Require new CI value for pathway renewal - 4668

### DIFF
--- a/frontend/src/views/CarbonIntensity/__tests__/step2Schema.test.js
+++ b/frontend/src/views/CarbonIntensity/__tests__/step2Schema.test.js
@@ -163,3 +163,42 @@ describe('buildPathwayColDefs — fuel code iteration empty state', () => {
     expect(fuelCodeCol([]).tooltipValueGetter(newRow)).toBeNull()
   })
 })
+
+describe('buildPathwayColDefs — Renewal CI carry-over prevention', () => {
+  const fuelCodes = [
+    {
+      fuelCodeId: 42,
+      fuelCode: 'C-BCLCF100.4',
+      carbonIntensity: 23.23,
+      fuelTypeId: 1,
+      feedstock: 'Corn',
+      feedstockLocation: 'Ontario'
+    }
+  ]
+
+  const colDefs = buildPathwayColDefs({
+    optionsData: { pathwayApplicationTypes: APPLICATION_TYPES, fuelCodes },
+    canEdit: true
+  })
+  const applicationTypeCol = colDefs.find((c) => c.field === 'applicationTypeId')
+  const fuelCodeCol = colDefs.find((c) => c.field === 'fuelCodeId')
+
+  it('blanks proposedCi when the applicant selects Renewal', () => {
+    const data = { applicationTypeId: 1, proposedCi: 5.61 }
+    applicationTypeCol.valueSetter({ data, newValue: 'Renewal' })
+    expect(data.proposedCi).toBeNull()
+  })
+
+  it('leaves proposedCi untouched when switching between non-Renewal types', () => {
+    const data = { applicationTypeId: 1, proposedCi: 5.61 }
+    applicationTypeCol.valueSetter({ data, newValue: 'New' })
+    expect(data.proposedCi).toBe(5.61)
+  })
+
+  it('does not populate proposedCi from the selected fuel code iteration', () => {
+    const data = { applicationTypeId: 2, proposedCi: null }
+    fuelCodeCol.valueSetter({ data, newValue: 'C-BCLCF100.4' })
+    expect(data.fuelCodeId).toBe(42)
+    expect(data.proposedCi).toBeNull()
+  })
+})

--- a/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
+++ b/frontend/src/views/CarbonIntensity/components/_step2Schema.jsx
@@ -54,11 +54,7 @@ const applyFuelCodeAutofill = (rowData, fuelCode) => {
     fuelCodeId: fuelCode.fuelCodeId,
     fuelTypeId: fuelCode.fuelTypeId ?? rowData.fuelTypeId,
     feedstock: fuelCode.feedstock ?? rowData.feedstock,
-    feedstockRegion: fuelCode.feedstockLocation ?? rowData.feedstockRegion,
-    proposedCi:
-      fuelCode.carbonIntensity != null
-        ? Number(fuelCode.carbonIntensity)
-        : rowData.proposedCi
+    feedstockRegion: fuelCode.feedstockLocation ?? rowData.feedstockRegion
   }
 }
 
@@ -115,9 +111,9 @@ export const buildPathwayColDefs = ({ optionsData, canEdit }) => {
         const match = applicationTypes.find((t) => t.type === params.newValue)
         if (!match) return false
         params.data.applicationTypeId = match.pathwayApplicationTypeId
-        // Switching back to "New" must clear any renewal-specific fuel code
-        // reference; otherwise validation will reject the row server-side.
-        if (match.type !== APPLICATION_TYPE_RENEWAL) {
+        if (match.type === APPLICATION_TYPE_RENEWAL) {
+          params.data.proposedCi = null
+        } else {
           params.data.fuelCodeId = null
         }
         return true


### PR DESCRIPTION
This PR requires applicants to enter a new CI value when renewing a pathway.
- Clears previously populated CI values
- Applies only to pathway renewals
- Keeps the CI field mandatory
- Enforces existing CI validation rules

Closes #4668