### PR TITLE
Fix: Allow fuel code generation for medium risk - 4659

### DIFF
--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -926,17 +926,18 @@ async def test_update_step3_rejects_when_ghgenius_missing(service, repo, mock_us
 
 
 @pytest.mark.anyio
-async def test_generate_fuel_codes_requires_verification_2_for_moderate_risk(
+async def test_generate_fuel_codes_allows_moderate_after_verification_1(
     service, repo, mock_user
 ):
     mock_user.role_names = {RoleEnum.ANALYST}
     ci = _submitted_ci_for_generation("Medium")
+    _stub_generation_dependencies(service, repo, ci)
 
-    with pytest.raises(HTTPException) as exc:
-        await service.generate_fuel_codes(ci, mock_user)
+    result = await service.generate_fuel_codes(ci, mock_user)
 
-    assert exc.value.status_code == 400
-    assert "Required verification" in exc.value.detail
+    assert isinstance(result, CIApplicationSchema)
+    assert len(ci.generated_fuel_code_associations) == 1
+    repo.update.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -702,10 +702,7 @@ class CIApplicationServices:
         self._require_submitted_workflow(ci_application)
         risk = ci_application.preliminary_risk_assessment
         verification_2_risk = ci_application.verification_2_risk_assessment or risk
-        requires_verification_2 = risk in {
-            CIRiskAssessmentEnum.Medium.value,
-            CIRiskAssessmentEnum.High.value,
-        }
+        requires_verification_2 = risk == CIRiskAssessmentEnum.High.value
         can_generate_after_verification_1 = (
             ci_application.verification_1_date and not requires_verification_2
         )
@@ -1224,13 +1221,10 @@ class CIApplicationServices:
     ) -> CIApplicationSchema:
         self._require_submitted_workflow(ci_application)
         self._validate_priority_score(priority_score)
-        if ci_application.preliminary_risk_assessment not in {
-            CIRiskAssessmentEnum.Medium.value,
-            CIRiskAssessmentEnum.High.value,
-        }:
+        if ci_application.preliminary_risk_assessment != CIRiskAssessmentEnum.High.value:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Verification 2 is only required for Medium or High risk applications.",
+                detail="Verification 2 is only required for High risk applications.",
             )
         if not ci_application.verification_1_date:
             raise HTTPException(
@@ -1278,10 +1272,7 @@ class CIApplicationServices:
             )
         self._require_submitted_workflow(ci_application)
         risk = ci_application.preliminary_risk_assessment
-        requires_verification_2 = risk in {
-            CIRiskAssessmentEnum.Medium.value,
-            CIRiskAssessmentEnum.High.value,
-        }
+        requires_verification_2 = risk == CIRiskAssessmentEnum.High.value
         if not ci_application.verification_1_date or (
             requires_verification_2 and not ci_application.verification_2_date
         ):

--- a/frontend/src/views/CarbonIntensity/__tests__/CIApplicationProgress.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/CIApplicationProgress.test.jsx
@@ -69,6 +69,22 @@ describe('CIApplicationProgress', () => {
     ])
   })
 
+  it('builds moderate risk workflow without verification 2', () => {
+    const steps = buildCIWorkflowSteps({
+      status: { status: 'Submitted' },
+      signatureUser: 'Jane Submitter',
+      signatureDateTime: '2026-05-01T12:00:00Z',
+      preliminaryRiskAssessment: 'Medium',
+      verification1Date: '2026-05-02T12:00:00Z',
+      proposedFuelCodeEffectiveDate: '2026-06-01'
+    })
+    expect(steps.map((step) => step.key)).toEqual([
+      'submitted',
+      'verification1',
+      'target'
+    ])
+  })
+
   it('renders submitted workflow details and target countdown', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-19T12:00:00Z'))
@@ -78,7 +94,7 @@ describe('CIApplicationProgress', () => {
           status: { status: 'Submitted' },
           signatureUserDisplayName: 'Jane Submitter',
           signatureDateTime: '2026-05-01T12:00:00Z',
-          preliminaryRiskAssessment: 'Medium',
+          preliminaryRiskAssessment: 'High',
           assignedAnalyst: {
             initials: 'AA',
             fullName: 'Alex Analyst'
@@ -243,7 +259,7 @@ describe('CIApplicationProgress', () => {
       status: { status: 'Submitted' },
       signatureUserDisplayName: 'Jane Submitter',
       signatureDateTime: '2026-05-01T12:00:00Z',
-      preliminaryRiskAssessment: 'Medium',
+      preliminaryRiskAssessment: 'High',
       verification1Date: '2026-05-02T12:00:00Z',
       verification1User: {
         initials: 'GW',

--- a/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
@@ -299,13 +299,51 @@ describe('GovernmentDecisionStep', () => {
     ).toBeInTheDocument()
   })
 
-  it('waits for Verification 2 before showing Generate fuel codes for moderate risk', () => {
+  it('shows Generate fuel codes after Verification 1 for moderate risk', () => {
+    mockUserRoles = [{ name: roles.analyst }]
+    render(
+      <GovernmentDecisionStep
+        ciApplication={{
+          ...baseCi,
+          preliminaryRiskAssessment: 'Medium',
+          verification1Date: '2026-05-19T12:00:00Z'
+        }}
+        isGovernment={true}
+      />,
+      { wrapper }
+    )
+
+    expect(screen.getByTestId('ci-generate-fuel-codes-btn')).toBeInTheDocument()
+    expect(
+      screen.getByText('carbonIntensity:step5.generateFuelCodes')
+    ).toBeInTheDocument()
+  })
+
+  it('does not show Generate fuel codes before Verification 1 is complete', () => {
+    mockUserRoles = [{ name: roles.analyst }]
+    render(
+      <GovernmentDecisionStep
+        ciApplication={{
+          ...baseCi,
+          preliminaryRiskAssessment: 'Medium'
+        }}
+        isGovernment={true}
+      />,
+      { wrapper }
+    )
+
+    expect(
+      screen.queryByTestId('ci-generate-fuel-codes-btn')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows Generate fuel codes when switched from high to moderate risk on Verification 2', () => {
     mockUserRoles = [{ name: roles.analyst }]
     const { rerender } = render(
       <GovernmentDecisionStep
         ciApplication={{
           ...baseCi,
-          preliminaryRiskAssessment: 'Medium',
+          preliminaryRiskAssessment: 'High',
           verification1Date: '2026-05-19T12:00:00Z'
         }}
         isGovernment={true}
@@ -321,7 +359,7 @@ describe('GovernmentDecisionStep', () => {
       <GovernmentDecisionStep
         ciApplication={{
           ...baseCi,
-          preliminaryRiskAssessment: 'Medium',
+          preliminaryRiskAssessment: 'High',
           verification1Date: '2026-05-19T12:00:00Z',
           verification2Date: '2026-05-20T12:00:00Z',
           verification2RiskAssessment: 'Medium'

--- a/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
+++ b/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
@@ -67,7 +67,7 @@ export const buildCIWorkflowSteps = (
   const isApproved = status === 'Completed'
   const isWithdrawn = status === 'Withdrawn'
   const risk = ciApplication.preliminaryRiskAssessment
-  const showVerification2 = risk === 'Medium' || risk === 'High'
+  const showVerification2 = risk === 'High'
   const recommendationComplete = Boolean(ciApplication.recommendationDate)
   const targetDate = ciApplication.proposedFuelCodeEffectiveDate
   const supplierRequestDate = getSupplierRequestDate(ciApplication)

--- a/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
+++ b/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
@@ -178,8 +178,7 @@ export const GovernmentDecisionStep = ({
   const verification2Risk = normalizeRisk(
     ciApplication?.verification2RiskAssessment
   )
-  const requiresVerification2 =
-    preliminaryRisk === 'Medium' || preliminaryRisk === 'High'
+  const requiresVerification2 = preliminaryRisk === 'High'
   const fuelPathwayCount = ciApplication?.pathways?.length || 0
   const generatedFuelCodesCount = ciApplication?.generatedFuelCodes?.length || 0
   const generatedFuelCodesReady =


### PR DESCRIPTION
This PR allows eligible medium risk applications to generate fuel codes.

- Allows Low and Medium risk assessments
- Requires completed Verification 1
- Restricts High risk assessments
- Updates visibility after risk changes

Closes #4659