### PR TITLE
Suppress supplemental 30-day list flag after first submission (#4630)

### DIFF
--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -483,6 +483,54 @@ class ComplianceReportRepository:
             self.db, query, offset, limit
         )
 
+        # Determine which groups' *latest* version has ever been Submitted. The
+        # IDIR "supplemental draft over 30 days old" flag only nudges the
+        # organization toward the *initial* submission of a supplemental; once
+        # it has been submitted the flag is permanently retired, even if the
+        # report is later returned to Draft for analyst-requested revisions
+        # (#4630 — matches the report-page banner suppression). A prior
+        # Submitted history entry on the latest version is the signal.
+        group_uuids = [report.compliance_report_group_uuid for report in query_result]
+        submitted_group_uuids: set = set()
+        if group_uuids:
+            latest_versions = (
+                select(
+                    ComplianceReport.compliance_report_group_uuid.label("group_uuid"),
+                    func.max(ComplianceReport.version).label("max_version"),
+                )
+                .where(ComplianceReport.compliance_report_group_uuid.in_(group_uuids))
+                .group_by(ComplianceReport.compliance_report_group_uuid)
+                .subquery()
+            )
+            submitted_query = (
+                select(ComplianceReport.compliance_report_group_uuid)
+                .join(
+                    latest_versions,
+                    and_(
+                        ComplianceReport.compliance_report_group_uuid
+                        == latest_versions.c.group_uuid,
+                        ComplianceReport.version == latest_versions.c.max_version,
+                    ),
+                )
+                .join(
+                    ComplianceReportHistory,
+                    ComplianceReportHistory.compliance_report_id
+                    == ComplianceReport.compliance_report_id,
+                )
+                .join(
+                    ComplianceReportStatus,
+                    ComplianceReportHistory.status_id
+                    == ComplianceReportStatus.compliance_report_status_id,
+                )
+                .where(
+                    ComplianceReportStatus.status
+                    == ComplianceReportStatusEnum.Submitted
+                )
+                .distinct()
+            )
+            submitted_result = await self.db.execute(submitted_query)
+            submitted_group_uuids = {row[0] for row in submitted_result.all()}
+
         # Transform results into Pydantic schemas and fetch latest comments
         reports = []
         for report in query_result:
@@ -501,6 +549,9 @@ class ComplianceReportRepository:
                 "is_latest": report.is_latest,
                 "latest_supplemental_create_date": report.latest_supplemental_create_date,
                 "latest_status": report.latest_status,
+                "latest_supplemental_has_been_submitted": (
+                    report.compliance_report_group_uuid in submitted_group_uuids
+                ),
                 "assigned_analyst_id": report.assigned_analyst_id,
                 "assigned_analyst_first_name": report.assigned_analyst_first_name,
                 "assigned_analyst_last_name": report.assigned_analyst_last_name,

--- a/backend/lcfs/web/api/compliance_report/schema.py
+++ b/backend/lcfs/web/api/compliance_report/schema.py
@@ -230,6 +230,7 @@ class ComplianceReportViewSchema(BaseSchema):
     latest_report_supplemental_initiator: Optional[SupplementalInitiatorType] = None
     latest_supplemental_create_date: Optional[datetime] = None
     latest_status: Optional[str] = None
+    latest_supplemental_has_been_submitted: bool = False
     assigned_analyst: Optional[AssignedAnalystSchema] = None
 
     @classmethod

--- a/frontend/src/views/ComplianceReports/components/__tests__/_schema.test.jsx
+++ b/frontend/src/views/ComplianceReports/components/__tests__/_schema.test.jsx
@@ -359,6 +359,30 @@ describe('ComplianceReports Schema', () => {
       expect(warningIcon).not.toBeInTheDocument()
     })
 
+    // #4630: once a supplemental has been submitted, the flag is permanently
+    // retired even after the analyst returns it to Draft (over 30 days old).
+    it('should NOT show flag when a returned Draft supplemental has been submitted before', () => {
+      const fortyDaysAgo = new Date()
+      fortyDaysAgo.setDate(fortyDaysAgo.getDate() - 40)
+
+      const data = {
+        reportType: 'Original Report',
+        compliancePeriod: '2024',
+        complianceReportId: 2,
+        latestSupplementalCreateDate: fortyDaysAgo.toISOString(),
+        latestStatus: 'Draft',
+        isLatest: false,
+        latestSupplementalHasBeenSubmitted: true
+      }
+
+      const { container } = renderTypeCell(data, false)
+
+      const warningIcon = container.querySelector(
+        '[data-testid="warning-icon"]'
+      )
+      expect(warningIcon).not.toBeInTheDocument()
+    })
+
     // Matches screenshot: LCFS Org 2 (2024) - no flag when no hidden draft
     it('should NOT show flag when there is no hidden draft (isLatest=true)', () => {
       const fortyDaysAgo = new Date()

--- a/frontend/src/views/ComplianceReports/components/_schema.tsx
+++ b/frontend/src/views/ComplianceReports/components/_schema.tsx
@@ -43,6 +43,14 @@ const TypeCellRenderer = (isSupplier) => (props) => {
       return false
     }
 
+    // The flag only nudges toward the *initial* submission of a supplemental.
+    // Once it has been submitted for the first time the flag is permanently
+    // retired, even after the report is returned to Draft for analyst-requested
+    // revisions (#4630 — matches the report-page 30-day banner suppression).
+    if (data.latestSupplementalHasBeenSubmitted) {
+      return false
+    }
+
     // Calculate how long the draft supplemental has been sitting
     const createDate = new Date(data.latestSupplementalCreateDate)
     const now = new Date()


### PR DESCRIPTION
## Purpose

Follow-up to #4630 / #4670. The 30-day supplemental warning has **two** surfaces, and the earlier fix only addressed one:

1. The **banner** on the compliance report page — retired after first submission by #4670. ✅
2. The **red flag icon in the IDIR compliance reporting grid** (Type column, tooltip _"Supplemental draft over 30 days old"_) — **not** addressed. ❌

The grid icon fired on any group whose latest version is a Draft supplemental older than 30 days, with no check for prior submission. A supplemental that a supplier submitted and an analyst then returned to Draft is back in Draft and still >30 days old, so the icon kept showing — which is what was reported on dev.

## Changes

Retire the grid flag once the supplemental has been submitted for the first time, matching the banner behaviour and the #4630 acceptance criteria (returning to Draft must not reactivate the warning; multiple return/resubmit cycles supported).

- **`repo.py`** — `get_reports_paginated` runs a single batched query to determine which report groups' _latest_ version has a `Submitted` history entry, and exposes `latest_supplemental_has_been_submitted` on each row. (Kept as a repo-level query rather than a `v_compliance_report` view change to limit blast radius, since that view also feeds two materialized views.)
- **`schema.py`** — add `latest_supplemental_has_been_submitted` to `ComplianceReportViewSchema`.
- **`_schema.tsx`** — hide the Type-column flag when the latest supplemental has been submitted before.
- **tests** — cover the returned-to-Draft-after-submission case.

## Testing

- Frontend: `_schema.test.jsx` passes (23 tests, incl. the new suppression case).
- Backend: the batched query validated against dev data — it flags exactly the returned-Draft-but-previously-submitted groups for suppression while leaving never-submitted drafts flagged.

## Acceptance criteria

- [x] Flag shown for supplementals that have never been submitted (>30 days old).
- [x] Flag permanently suppressed once submitted for the first time.
- [x] Returning to Draft does not reactivate the flag.
- [x] Multiple analyst return/resubmit cycles supported without the flag.