### PR TITLE
Fix credit ledger transaction time: recreate mv_transaction_aggregate with raw UTC (#4634)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-07-16-12-00_d4e5f6a7b8c9.py
+++ b/backend/lcfs/db/migrations/versions/2026-07-16-12-00_d4e5f6a7b8c9.py
@@ -837,9 +837,22 @@ CREATE UNIQUE INDEX mv_credit_ledger_tx_org_idx ON mv_credit_ledger (transaction
 """
 
 
+def _exec_script(ddl: str) -> None:
+    """Execute a multi-statement DDL script one statement at a time.
+
+    The migrations run over asyncpg, which rejects multiple commands in a
+    single prepared statement, so each statement is sent on its own (matching
+    the helper in 2026-06-04-12-00_d2e4f6a8b0c1.py).
+    """
+    for statement in ddl.split(";"):
+        statement = statement.strip()
+        if statement:
+            op.execute(statement + ";")
+
+
 def upgrade() -> None:
-    op.execute(UPGRADE_SQL)
+    _exec_script(UPGRADE_SQL)
 
 
 def downgrade() -> None:
-    op.execute(DOWNGRADE_SQL)
+    _exec_script(DOWNGRADE_SQL)

--- a/backend/lcfs/db/migrations/versions/2026-07-16-12-00_d4e5f6a7b8c9.py
+++ b/backend/lcfs/db/migrations/versions/2026-07-16-12-00_d4e5f6a7b8c9.py
@@ -1,0 +1,845 @@
+"""Fix credit ledger timezone: emit raw UTC timestamps in mv_transaction_aggregate
+
+The credit ledger showed transfer timestamps offset by the Pacific-UTC gap
+(e.g. an 11:00 AM PST transfer rendered as 6:00 PM). mv_transaction_aggregate
+built update_date/create_date with
+`AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'`, shifting the instant,
+and the frontend then converted the already-shifted value to Pacific a second
+time. Commit c4e994b81 corrected db/sql/materialized_views.sql, but that file
+is only a reference copy; nothing executes it, so no environment picked up the
+change. This migration recreates mv_transaction_aggregate (and its dependent
+mv_credit_ledger) with the corrected definition so the fix actually reaches the
+database. Display columns now emit the raw UTC timestamptz and the frontend
+performs the single Pacific conversion. The ::date / compliance-period
+extractions are intentionally unchanged.
+
+Revision ID: d4e5f6a7b8c9
+Revises: b7c8d9e0f1a2
+Create Date: 2026-07-16 12:00:00.000000
+"""
+
+from alembic import op
+
+revision = "d4e5f6a7b8c9"
+down_revision = "b7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+UPGRADE_SQL = r"""
+DROP MATERIALIZED VIEW IF EXISTS mv_credit_ledger CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_transaction_aggregate CASCADE;
+
+CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
+    WITH all_transactions AS (
+        ------------------------------------------------------------------------
+        -- Transfers
+        ------------------------------------------------------------------------
+        SELECT
+            t.transfer_id AS transaction_id,
+            'Transfer' AS transaction_type,
+            NULL AS description,
+            org_from.organization_id AS from_organization_id,
+            org_from.name AS from_organization,
+            org_to.organization_id AS to_organization_id,
+            org_to.name AS to_organization,
+            t.quantity,
+            t.price_per_unit,
+            ts.status::text AS status,
+            CASE
+                WHEN ts.status = 'Recorded' THEN
+                    EXTRACT(YEAR FROM (
+                        COALESCE(t.transaction_effective_date, (
+                            SELECT th.create_date
+                            FROM transfer_history th
+                            WHERE th.transfer_id = t.transfer_id
+                            AND th.transfer_status_id = 6  -- Recorded
+                            LIMIT 1
+                        )) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'
+                    ))::text
+                ELSE 'N/A'
+            END AS compliance_period,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'FROM_ORG'
+                LIMIT 1
+            ) AS from_org_comment,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'TO_ORG'
+                LIMIT 1
+            ) AS to_org_comment,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'GOVERNMENT'
+                LIMIT 1
+            ) AS government_comment,
+            tc.category,
+            (
+                SELECT (th.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM transfer_history th
+                WHERE th.transfer_id = t.transfer_id
+                AND th.transfer_status_id = 6  -- Recorded
+                LIMIT 1
+            ) AS recorded_date,
+            NULL AS approved_date,
+            (t.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            t.update_date AS update_date,
+            t.create_date AS create_date
+        FROM transfer t
+        JOIN organization org_from
+            ON t.from_organization_id = org_from.organization_id
+        JOIN organization org_to
+            ON t.to_organization_id = org_to.organization_id
+        JOIN transfer_status ts
+            ON t.current_status_id = ts.transfer_status_id
+        LEFT JOIN transfer_category tc
+            ON t.transfer_category_id = tc.transfer_category_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Initiative Agreements
+        ------------------------------------------------------------------------
+        SELECT
+            ia.initiative_agreement_id AS transaction_id,
+            'InitiativeAgreement' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            ia.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            ias.status::text AS status,
+            EXTRACT(YEAR FROM (ia.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            null as from_org_comment,
+            null as to_org_comment,
+            ia.gov_comment AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            (
+                SELECT (iah.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM initiative_agreement_history iah
+                WHERE iah.initiative_agreement_id = ia.initiative_agreement_id
+                AND iah.initiative_agreement_status_id = 3 -- Approved
+                LIMIT 1
+            ) AS approved_date,
+            (ia.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            ia.update_date AS update_date,
+            ia.create_date AS create_date
+        FROM initiative_agreement ia
+        JOIN organization org
+            ON ia.to_organization_id = org.organization_id
+        JOIN initiative_agreement_status ias
+            ON ia.current_status_id = ias.initiative_agreement_status_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Admin Adjustments
+        ------------------------------------------------------------------------
+        SELECT
+            aa.admin_adjustment_id AS transaction_id,
+            'AdminAdjustment' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            aa.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            aas.status::text AS status,
+            EXTRACT(YEAR FROM (aa.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            null as from_org_comment,
+            null as to_org_comment,
+            aa.gov_comment AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            (
+                SELECT (aah.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM admin_adjustment_history aah
+                WHERE aah.admin_adjustment_id = aa.admin_adjustment_id
+                AND aah.admin_adjustment_status_id = 3 -- Approved
+                LIMIT 1
+            ) AS approved_date,
+            (aa.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            aa.update_date AS update_date,
+            aa.create_date AS create_date
+        FROM admin_adjustment aa
+        JOIN organization org
+            ON aa.to_organization_id = org.organization_id
+        JOIN admin_adjustment_status aas
+            ON aa.current_status_id = aas.admin_adjustment_status_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Aggregator Issuances
+        ------------------------------------------------------------------------
+        SELECT
+            ag.aggregator_issuance_id AS transaction_id,
+            'AggregatorIssuance' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            ag.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            'Recorded' AS status,
+            EXTRACT(YEAR FROM (ag.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            NULL AS from_org_comment,
+            NULL AS to_org_comment,
+            ag.gov_comment AS government_comment,
+            NULL AS category,
+            (ag.recorded_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS recorded_date,
+            NULL AS approved_date,
+            (ag.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            ag.update_date AS update_date,
+            ag.create_date AS create_date
+        FROM aggregator_issuance ag
+        JOIN organization org
+            ON ag.to_organization_id = org.organization_id
+        WHERE COALESCE(ag.effective_status, TRUE) = TRUE
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Compliance Reports
+        ------------------------------------------------------------------------
+        SELECT
+            cr.compliance_report_id AS transaction_id,
+            'ComplianceReport' AS transaction_type,
+            cr.nickname AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            tr.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            crs.status::text AS status,
+            cp.description AS compliance_period,
+            NULL as from_org_comment,
+            NULL as to_org_comment,
+            NULL AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            NULL AS approved_date,
+            NULL AS transaction_effective_date,
+            cr.update_date AS update_date,
+            cr.create_date AS create_date
+        FROM compliance_report cr
+        JOIN organization org
+            ON cr.organization_id = org.organization_id
+        JOIN compliance_report_status crs
+            ON cr.current_status_id = crs.compliance_report_status_id
+        JOIN compliance_period cp
+            ON cr.compliance_period_id = cp.compliance_period_id
+        JOIN "transaction" tr
+            ON cr.transaction_id = tr.transaction_id
+        AND cr.transaction_id IS NOT NULL
+        WHERE crs.status IN ('Assessed', 'Reassessed')
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Standalone Transactions (legacy / unassociated)
+        ------------------------------------------------------------------------
+        SELECT
+            t.transaction_id,
+            'StandaloneTransaction' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            t.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            CASE WHEN COALESCE(t.effective_status, TRUE) THEN 'Recorded' ELSE 'Inactive' END AS status,
+            EXTRACT(YEAR FROM (COALESCE(t.effective_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            NULL AS from_org_comment,
+            NULL AS to_org_comment,
+            NULL AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            NULL AS approved_date,
+            (COALESCE(t.effective_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            COALESCE(t.update_date, t.create_date) AS update_date,
+            t.create_date AS create_date
+        FROM "transaction" t
+        JOIN organization org
+            ON t.organization_id = org.organization_id
+        LEFT JOIN compliance_report cr
+            ON cr.transaction_id = t.transaction_id
+        LEFT JOIN admin_adjustment aa
+            ON aa.transaction_id = t.transaction_id
+        LEFT JOIN initiative_agreement ia
+            ON ia.transaction_id = t.transaction_id
+        LEFT JOIN transfer tf_from
+            ON tf_from.from_transaction_id = t.transaction_id
+        LEFT JOIN transfer tf_to
+            ON tf_to.to_transaction_id = t.transaction_id
+        LEFT JOIN aggregator_issuance ag
+            ON ag.transaction_id = t.transaction_id
+        WHERE cr.transaction_id IS NULL
+          AND aa.transaction_id IS NULL
+          AND ia.transaction_id IS NULL
+          AND tf_from.from_transaction_id IS NULL
+          AND tf_to.to_transaction_id IS NULL
+          AND ag.transaction_id IS NULL
+          AND COALESCE(t.effective_status, TRUE) = TRUE
+    )
+    , deduped AS (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY transaction_id, transaction_type
+                ORDER BY update_date DESC NULLS LAST, create_date DESC NULLS LAST
+            ) AS rn
+        FROM all_transactions
+    )
+    SELECT * FROM deduped WHERE rn = 1;
+
+CREATE UNIQUE INDEX mv_transaction_aggregate_unique_idx
+    ON mv_transaction_aggregate (transaction_id, transaction_type);
+
+-- ==========================================
+-- mv_credit_ledger
+-- Source: 2025-12-02-12-00_b71c1d2e3f45.py
+-- Depends on: mv_transaction_aggregate
+-- ==========================================
+CREATE MATERIALIZED VIEW mv_credit_ledger AS
+WITH base AS (
+    -- Transfers: from_org loses units
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.from_organization_id                       AS organization_id,
+        -ABS(t.quantity)                             AS compliance_units,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'Transfer'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Transfers: to_org gains units
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id,
+        ABS(t.quantity),
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'Transfer'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Admin Adjustments
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'AdminAdjustment'
+    AND    t.status           = 'Approved'
+
+    UNION ALL
+
+    -- Initiative Agreements
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'InitiativeAgreement'
+    AND    t.status           = 'Approved'
+
+    UNION ALL
+
+    -- Compliance Reports
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'ComplianceReport'
+    AND    t.status           = 'Assessed'
+
+    UNION ALL
+
+    -- Standalone Transactions
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'StandaloneTransaction'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Aggregator Issuances
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'AggregatorIssuance'
+    AND    t.status           = 'Recorded'
+)
+
+SELECT
+    transaction_id,
+    transaction_type,
+    compliance_period,
+    organization_id,
+    compliance_units,
+    SUM(compliance_units) OVER (
+        PARTITION BY organization_id
+        ORDER BY update_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS available_balance,
+    create_date,
+    update_date
+FROM base;
+
+CREATE INDEX mv_credit_ledger_org_year_idx ON mv_credit_ledger (organization_id, compliance_period);
+CREATE INDEX mv_credit_ledger_org_date_idx ON mv_credit_ledger (organization_id, update_date DESC);
+CREATE UNIQUE INDEX mv_credit_ledger_tx_org_idx ON mv_credit_ledger (transaction_id, transaction_type, organization_id);
+"""
+
+DOWNGRADE_SQL = r"""
+DROP MATERIALIZED VIEW IF EXISTS mv_credit_ledger CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_transaction_aggregate CASCADE;
+
+CREATE MATERIALIZED VIEW mv_transaction_aggregate AS
+    WITH all_transactions AS (
+        ------------------------------------------------------------------------
+        -- Transfers
+        ------------------------------------------------------------------------
+        SELECT
+            t.transfer_id AS transaction_id,
+            'Transfer' AS transaction_type,
+            NULL AS description,
+            org_from.organization_id AS from_organization_id,
+            org_from.name AS from_organization,
+            org_to.organization_id AS to_organization_id,
+            org_to.name AS to_organization,
+            t.quantity,
+            t.price_per_unit,
+            ts.status::text AS status,
+            CASE
+                WHEN ts.status = 'Recorded' THEN
+                    EXTRACT(YEAR FROM (
+                        COALESCE(t.transaction_effective_date, (
+                            SELECT th.create_date
+                            FROM transfer_history th
+                            WHERE th.transfer_id = t.transfer_id
+                            AND th.transfer_status_id = 6  -- Recorded
+                            LIMIT 1
+                        )) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'
+                    ))::text
+                ELSE 'N/A'
+            END AS compliance_period,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'FROM_ORG'
+                LIMIT 1
+            ) AS from_org_comment,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'TO_ORG'
+                LIMIT 1
+            ) AS to_org_comment,
+            (
+                SELECT tc.comment
+                FROM transfer_comment tc
+                WHERE tc.transfer_id = t.transfer_id
+                AND tc.comment_source = 'GOVERNMENT'
+                LIMIT 1
+            ) AS government_comment,
+            tc.category,
+            (
+                SELECT (th.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM transfer_history th
+                WHERE th.transfer_id = t.transfer_id
+                AND th.transfer_status_id = 6  -- Recorded
+                LIMIT 1
+            ) AS recorded_date,
+            NULL AS approved_date,
+            (t.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            (t.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (t.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM transfer t
+        JOIN organization org_from
+            ON t.from_organization_id = org_from.organization_id
+        JOIN organization org_to
+            ON t.to_organization_id = org_to.organization_id
+        JOIN transfer_status ts
+            ON t.current_status_id = ts.transfer_status_id
+        LEFT JOIN transfer_category tc
+            ON t.transfer_category_id = tc.transfer_category_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Initiative Agreements
+        ------------------------------------------------------------------------
+        SELECT
+            ia.initiative_agreement_id AS transaction_id,
+            'InitiativeAgreement' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            ia.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            ias.status::text AS status,
+            EXTRACT(YEAR FROM (ia.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            null as from_org_comment,
+            null as to_org_comment,
+            ia.gov_comment AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            (
+                SELECT (iah.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM initiative_agreement_history iah
+                WHERE iah.initiative_agreement_id = ia.initiative_agreement_id
+                AND iah.initiative_agreement_status_id = 3 -- Approved
+                LIMIT 1
+            ) AS approved_date,
+            (ia.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            (ia.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (ia.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM initiative_agreement ia
+        JOIN organization org
+            ON ia.to_organization_id = org.organization_id
+        JOIN initiative_agreement_status ias
+            ON ia.current_status_id = ias.initiative_agreement_status_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Admin Adjustments
+        ------------------------------------------------------------------------
+        SELECT
+            aa.admin_adjustment_id AS transaction_id,
+            'AdminAdjustment' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            aa.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            aas.status::text AS status,
+            EXTRACT(YEAR FROM (aa.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            null as from_org_comment,
+            null as to_org_comment,
+            aa.gov_comment AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            (
+                SELECT (aah.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date
+                FROM admin_adjustment_history aah
+                WHERE aah.admin_adjustment_id = aa.admin_adjustment_id
+                AND aah.admin_adjustment_status_id = 3 -- Approved
+                LIMIT 1
+            ) AS approved_date,
+            (aa.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            (aa.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (aa.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM admin_adjustment aa
+        JOIN organization org
+            ON aa.to_organization_id = org.organization_id
+        JOIN admin_adjustment_status aas
+            ON aa.current_status_id = aas.admin_adjustment_status_id
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Aggregator Issuances
+        ------------------------------------------------------------------------
+        SELECT
+            ag.aggregator_issuance_id AS transaction_id,
+            'AggregatorIssuance' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            ag.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            'Recorded' AS status,
+            EXTRACT(YEAR FROM (ag.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            NULL AS from_org_comment,
+            NULL AS to_org_comment,
+            ag.gov_comment AS government_comment,
+            NULL AS category,
+            (ag.recorded_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS recorded_date,
+            NULL AS approved_date,
+            (ag.transaction_effective_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            (ag.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (ag.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM aggregator_issuance ag
+        JOIN organization org
+            ON ag.to_organization_id = org.organization_id
+        WHERE COALESCE(ag.effective_status, TRUE) = TRUE
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Compliance Reports
+        ------------------------------------------------------------------------
+        SELECT
+            cr.compliance_report_id AS transaction_id,
+            'ComplianceReport' AS transaction_type,
+            cr.nickname AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            tr.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            crs.status::text AS status,
+            cp.description AS compliance_period,
+            NULL as from_org_comment,
+            NULL as to_org_comment,
+            NULL AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            NULL AS approved_date,
+            NULL AS transaction_effective_date,
+            (cr.update_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (cr.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM compliance_report cr
+        JOIN organization org
+            ON cr.organization_id = org.organization_id
+        JOIN compliance_report_status crs
+            ON cr.current_status_id = crs.compliance_report_status_id
+        JOIN compliance_period cp
+            ON cr.compliance_period_id = cp.compliance_period_id
+        JOIN "transaction" tr
+            ON cr.transaction_id = tr.transaction_id
+        AND cr.transaction_id IS NOT NULL
+        WHERE crs.status IN ('Assessed', 'Reassessed')
+        UNION ALL
+        ------------------------------------------------------------------------
+        -- Standalone Transactions (legacy / unassociated)
+        ------------------------------------------------------------------------
+        SELECT
+            t.transaction_id,
+            'StandaloneTransaction' AS transaction_type,
+            NULL AS description,
+            NULL AS from_organization_id,
+            NULL AS from_organization,
+            org.organization_id AS to_organization_id,
+            org.name AS to_organization,
+            t.compliance_units AS quantity,
+            NULL AS price_per_unit,
+            CASE WHEN COALESCE(t.effective_status, TRUE) THEN 'Recorded' ELSE 'Inactive' END AS status,
+            EXTRACT(YEAR FROM (COALESCE(t.effective_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::text AS compliance_period,
+            NULL AS from_org_comment,
+            NULL AS to_org_comment,
+            NULL AS government_comment,
+            NULL AS category,
+            NULL AS recorded_date,
+            NULL AS approved_date,
+            (COALESCE(t.effective_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver')::date AS transaction_effective_date,
+            (COALESCE(t.update_date, t.create_date) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS update_date,
+            (t.create_date AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver') AS create_date
+        FROM "transaction" t
+        JOIN organization org
+            ON t.organization_id = org.organization_id
+        LEFT JOIN compliance_report cr
+            ON cr.transaction_id = t.transaction_id
+        LEFT JOIN admin_adjustment aa
+            ON aa.transaction_id = t.transaction_id
+        LEFT JOIN initiative_agreement ia
+            ON ia.transaction_id = t.transaction_id
+        LEFT JOIN transfer tf_from
+            ON tf_from.from_transaction_id = t.transaction_id
+        LEFT JOIN transfer tf_to
+            ON tf_to.to_transaction_id = t.transaction_id
+        LEFT JOIN aggregator_issuance ag
+            ON ag.transaction_id = t.transaction_id
+        WHERE cr.transaction_id IS NULL
+          AND aa.transaction_id IS NULL
+          AND ia.transaction_id IS NULL
+          AND tf_from.from_transaction_id IS NULL
+          AND tf_to.to_transaction_id IS NULL
+          AND ag.transaction_id IS NULL
+          AND COALESCE(t.effective_status, TRUE) = TRUE
+    )
+    , deduped AS (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY transaction_id, transaction_type
+                ORDER BY update_date DESC NULLS LAST, create_date DESC NULLS LAST
+            ) AS rn
+        FROM all_transactions
+    )
+    SELECT * FROM deduped WHERE rn = 1;
+
+CREATE UNIQUE INDEX mv_transaction_aggregate_unique_idx
+    ON mv_transaction_aggregate (transaction_id, transaction_type);
+
+-- ==========================================
+-- mv_credit_ledger
+-- Source: 2025-12-02-12-00_b71c1d2e3f45.py
+-- Depends on: mv_transaction_aggregate
+-- ==========================================
+CREATE MATERIALIZED VIEW mv_credit_ledger AS
+WITH base AS (
+    -- Transfers: from_org loses units
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.from_organization_id                       AS organization_id,
+        -ABS(t.quantity)                             AS compliance_units,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'Transfer'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Transfers: to_org gains units
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id,
+        ABS(t.quantity),
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'Transfer'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Admin Adjustments
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'AdminAdjustment'
+    AND    t.status           = 'Approved'
+
+    UNION ALL
+
+    -- Initiative Agreements
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'InitiativeAgreement'
+    AND    t.status           = 'Approved'
+
+    UNION ALL
+
+    -- Compliance Reports
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'ComplianceReport'
+    AND    t.status           = 'Assessed'
+
+    UNION ALL
+
+    -- Standalone Transactions
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'StandaloneTransaction'
+    AND    t.status           = 'Recorded'
+
+    UNION ALL
+
+    -- Aggregator Issuances
+    SELECT
+        t.transaction_id,
+        t.transaction_type,
+        t.compliance_period,
+        t.to_organization_id                       AS organization_id,
+        t.quantity,
+        t.create_date,
+        t.update_date
+    FROM   mv_transaction_aggregate t
+    WHERE  t.transaction_type = 'AggregatorIssuance'
+    AND    t.status           = 'Recorded'
+)
+
+SELECT
+    transaction_id,
+    transaction_type,
+    compliance_period,
+    organization_id,
+    compliance_units,
+    SUM(compliance_units) OVER (
+        PARTITION BY organization_id
+        ORDER BY update_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS available_balance,
+    create_date,
+    update_date
+FROM base;
+
+CREATE INDEX mv_credit_ledger_org_year_idx ON mv_credit_ledger (organization_id, compliance_period);
+CREATE INDEX mv_credit_ledger_org_date_idx ON mv_credit_ledger (organization_id, update_date DESC);
+CREATE UNIQUE INDEX mv_credit_ledger_tx_org_idx ON mv_credit_ledger (transaction_id, transaction_type, organization_id);
+"""
+
+
+def upgrade() -> None:
+    op.execute(UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    op.execute(DOWNGRADE_SQL)


### PR DESCRIPTION
Closes #4634.

The Organization Credit Ledger displayed transfer timestamps offset by the Pacific–UTC gap. Transfers **#5517 / #5514**, recorded ~11:08 AM PDT, showed as 6:08 PM PDT.

## Why the earlier fix (#4600 / PR #4614) didn't take
Commit `c4e994b81` corrected `backend/lcfs/db/sql/materialized_views.sql` — but **nothing executes that file**. `prestart.sh` runs `manage_views.py`, which recreates only the `vw_*` views from `metabase.sql`; the `mv_*` materialized views are defined **solely by Alembic migrations**. The file's own header says as much. So no environment ever picked up the corrected definition, and a plain `REFRESH MATERIALIZED VIEW` just recomputes rows from the old, still-double-converting definition.

Confirmed live: `pg_get_viewdef('mv_transaction_aggregate')` still contains `AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'` on `update_date`/`create_date`.

## Root cause
`mv_transaction_aggregate` builds the display columns with `AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'`, which strips the zone and shifts the instant ~7h forward. The frontend (`timezoneFormatter`) then converts the already-shifted value to Pacific a second time.

| transfer #5517 | value |
|---|---|
| True instant | `2026-07-03 18:08 UTC` = **11:08 AM PDT** |
| MV stored (double-converted) | `2026-07-04 01:08 UTC` |
| Frontend renders | **6:08 PM PDT** ✗ |

This also explains why only the *time* looked wrong in #4634: the shift landed on the same Pacific calendar day, so the date appeared correct.

## Fix
Migration `2026-07-16-12-00_d4e5f6a7b8c9.py` recreates `mv_transaction_aggregate` (and its dependent `mv_credit_ledger`, which the ledger endpoint actually reads) with the corrected definition: display timestamps emit the **raw UTC `timestamptz`** and the frontend performs the single Pacific conversion. The `::date` / compliance-period extractions keep their Pacific conversion, so the #4600 date fix is preserved.

The new definition is lifted from `materialized_views.sql`; a diff against the live definition confirms the **only** change is the six `update_date`/`create_date` expression pairs — nothing else.

## Verification (against a live DB)
- `upgrade` → view has **0** timezone conversions on the timestamp columns; MV now emits the true instant (e.g. `2018-08-14 19:41` instead of the shifted `2018-08-15 02:41`).
- `::date` columns → **9** conversions preserved (date behavior unchanged).
- `downgrade` → old definition restored (reversible).
- `alembic heads` → single clean head chained off the current head.
- All 4 indexes (incl. the unique indexes used for concurrent refresh) recreated.

## Notes for reviewers
- **No frontend change needed** — `timezoneFormatter` already converts UTC→Pacific correctly; it just needs the DB to stop pre-shifting. Buyer and seller read the same underlying instant, so both now show the same correct time.
- **Cross-consumer:** the main Transactions grid (`TransactionView`) also maps to `mv_transaction_aggregate`. It formats `updateDate` with a UTC-date formatter, so this change moves it toward the true instant's date as well (e.g. `2018-08-15` → `2018-08-14`), consistent with #4614's intent. No regression.
- Recreating `mv_transaction_aggregate` cascades only to `mv_credit_ledger` (verified via `pg_depend`); both are recreated in the migration.

## Follow-up (not in this PR)
`materialized_views.sql` is a reference copy that no code path executes yet drifts from the migration-defined truth — it silently caused this bug to look "fixed." Worth either wiring it into a migration-backed recreate step or clearly quarantining it. Happy to file an issue.