### PR TITLE
Feat: Add Credit Market login feature flag - 4704

### DIFF
--- a/frontend/public/config/config.js
+++ b/frontend/public/config/config.js
@@ -24,7 +24,8 @@ export const config = {
     manageFse: true,
     legacySupplementalLock: false,
     deterministicReportSummary: true,
-    internalCommentSearch: true
+    internalCommentSearch: true,
+    creditMarketLoginPage: false
   }
 }
 

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -12,6 +12,7 @@ export interface FeatureFlagsConfig {
   ciApplications?: boolean
   internalCommentSearch?: boolean
   deterministicReportSummary?: boolean
+  creditMarketLoginPage?: boolean
 }
 
 export interface KeycloakConfig {
@@ -81,7 +82,8 @@ export const FEATURE_FLAGS = {
   LEGACY_SUPPLEMENTAL_LOCK: 'legacySupplementalLock',
   CI_APPLICATIONS: 'ciApplications',
   INTERNAL_COMMENT_SEARCH: 'internalCommentSearch',
-  DETERMINISTIC_REPORT_SUMMARY: 'deterministicReportSummary'
+  DETERMINISTIC_REPORT_SUMMARY: 'deterministicReportSummary',
+  CREDIT_MARKET_LOGIN_PAGE: 'creditMarketLoginPage'
 } as const
 
 export type FeatureFlagValue =
@@ -160,6 +162,8 @@ export const CONFIG: AppConfig = {
       window.lcfs_config.feature_flags.internalCommentSearch ?? false,
     deterministicReportSummary:
       window.lcfs_config.feature_flags.deterministicReportSummary ??
-      !isProductionEnvironment
+      !isProductionEnvironment,
+    creditMarketLoginPage:
+      window.lcfs_config.feature_flags.creditMarketLoginPage ?? false
   }
 }

--- a/frontend/src/layouts/MainLayout/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout/MainLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Outlet, useLocation, useMatches, useNavigate } from 'react-router-dom'
 import { ROUTES } from '@/routes/routes'
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
 import { Container, Stack } from '@mui/material'
 import BCTypography from '@/components/BCTypography'
 import Footer from '@/components/Footer'
@@ -65,10 +66,12 @@ export const MainLayout = () => {
     refreshToken(true)
   }, [location.pathname])
 
-  // Logged-out visitors to the app root land on the public dashboard;
-  // deep links to other protected routes still go to the login screen.
+  // Route root visitors to the public dashboard when enabled, else to login.
+  const showCreditMarketLoginPage = isFeatureEnabled(
+    FEATURE_FLAGS.CREDIT_MARKET_LOGIN_PAGE
+  )
   const unauthRedirect =
-    location.pathname === ROUTES.DASHBOARD
+    location.pathname === ROUTES.DASHBOARD && showCreditMarketLoginPage
       ? ROUTES.PUBLIC_DASHBOARD
       : ROUTES.AUTH.LOGIN
 

--- a/frontend/src/layouts/MainLayout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/layouts/MainLayout/__tests__/MainLayout.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { useLocation } from 'react-router-dom'
+import { MainLayout } from '../MainLayout'
+import { isFeatureEnabled } from '@/constants/config'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('@/constants/config', async () => {
+  const actual = await vi.importActual<typeof import('@/constants/config')>(
+    '@/constants/config'
+  )
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn()
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useLocation: vi.fn(),
+    useMatches: () => [{ handle: {} }],
+    useNavigate: () => vi.fn()
+  }
+})
+
+vi.mock('@/components/RequireAuth', () => ({
+  RequireAuth: ({ redirectTo }: { redirectTo: string }) => (
+    <div data-test="require-auth" data-redirect-to={redirectTo} />
+  )
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ refreshToken: vi.fn() })
+}))
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ data: null })
+}))
+
+vi.mock('@/contexts/AuthorizationContext', () => ({
+  useAuthorization: () => ({ forbidden: false })
+}))
+
+vi.mock('@/stores/useLoadingStore', () => ({
+  useLoadingStore: (selector: (state: { loading: boolean }) => unknown) =>
+    selector({ loading: false })
+}))
+
+vi.mock('./components/Navbar', () => ({
+  Navbar: () => <div data-test="navbar" />
+}))
+
+vi.mock('@/components/Footer', () => ({
+  default: () => <div data-test="footer" />
+}))
+
+vi.mock('@/layouts/MainLayout/components/Crumb', () => ({
+  default: () => <div data-test="crumb" />
+}))
+
+vi.mock('@/components/DisclaimerBanner', () => ({
+  default: () => <div data-test="disclaimer-banner" />
+}))
+
+const mockedUseLocation = useLocation as unknown as Mock
+const mockedIsFeatureEnabled = isFeatureEnabled as unknown as Mock
+
+describe('MainLayout unauthenticated redirect target', () => {
+  beforeEach(() => {
+    mockedUseLocation.mockReset()
+    mockedIsFeatureEnabled.mockReset()
+  })
+
+  it('redirects root visitors to the Credit Market public dashboard when the feature flag is enabled', () => {
+    mockedUseLocation.mockReturnValue({ pathname: '/' })
+    mockedIsFeatureEnabled.mockReturnValue(true)
+
+    render(<MainLayout />, { wrapper })
+
+    expect(screen.getByTestId('require-auth')).toHaveAttribute(
+      'data-redirect-to',
+      '/public'
+    )
+  })
+
+  it('redirects root visitors to the standard login page when the feature flag is disabled', () => {
+    mockedUseLocation.mockReturnValue({ pathname: '/' })
+    mockedIsFeatureEnabled.mockReturnValue(false)
+
+    render(<MainLayout />, { wrapper })
+
+    expect(screen.getByTestId('require-auth')).toHaveAttribute(
+      'data-redirect-to',
+      '/login'
+    )
+  })
+
+  it('always redirects deep links to the standard login page regardless of the feature flag', () => {
+    mockedUseLocation.mockReturnValue({ pathname: '/organizations' })
+    mockedIsFeatureEnabled.mockReturnValue(true)
+
+    render(<MainLayout />, { wrapper })
+
+    expect(screen.getByTestId('require-auth')).toHaveAttribute(
+      'data-redirect-to',
+      '/login'
+    )
+  })
+})

--- a/frontend/src/layouts/PublicPageLayout/PublicPageLayout.tsx
+++ b/frontend/src/layouts/PublicPageLayout/PublicPageLayout.tsx
@@ -6,6 +6,7 @@ import Footer from '@/components/Footer'
 import { PublicHeader } from './components/PublicHeader'
 import { PublicBreadcrumb } from './components/PublicBreadcrumb'
 import ROUTES from '@/routes/routes'
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
 
 type RouteHandle = {
   title?: string
@@ -45,10 +46,17 @@ export const PublicPageLayout = () => {
         <Stack spacing={2} sx={{ flexGrow: 1 }}>
           {!hideBreadcrumb && (
             <BCBox size={12}>
-              <PublicBreadcrumb
-                rootLabel="Home"
-                rootPath={ROUTES.PUBLIC_DASHBOARD}
-              />
+              {isFeatureEnabled(FEATURE_FLAGS.CREDIT_MARKET_LOGIN_PAGE) ? (
+                <PublicBreadcrumb
+                  rootLabel="Home"
+                  rootPath={ROUTES.PUBLIC_DASHBOARD}
+                />
+              ) : (
+                <PublicBreadcrumb
+                  rootLabel="Login"
+                  rootPath={ROUTES.AUTH.LOGIN}
+                />
+              )}
             </BCBox>
           )}
           <BCBox

--- a/frontend/src/routes/routeConfig/publicPageRoutes.tsx
+++ b/frontend/src/routes/routeConfig/publicPageRoutes.tsx
@@ -1,18 +1,24 @@
 import ROUTES from '../routes'
 import { CalculatorMenu } from '@/views/ComplianceReports/CalculatorMenu'
 import FormView from '@/views/Forms/FormView'
-import PublicDashboard from '@/views/PublicDashboard/PublicDashboard'
+import PublicDashboardRoute from '@/views/PublicDashboard/PublicDashboardRoute'
 import { PublicMarketData } from '@/views/PublicMarketData'
 import { FuelCodeBulletinsBase } from '@/views/FuelCodeBulletins/FuelCodeBulletins'
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
 import { AppRouteObject } from '../types'
+
+const creditMarketPageEnabled = isFeatureEnabled(FEATURE_FLAGS.CREDIT_MARKET_LOGIN_PAGE)
 
 export const publicPageRoutes: AppRouteObject[] = [
   {
     name: 'Public dashboard',
     key: 'public-dashboard',
     path: ROUTES.PUBLIC_DASHBOARD,
-    element: <PublicDashboard />,
-    handle: { title: 'LCFS program information', hideBreadcrumb: true }
+    element: <PublicDashboardRoute />,
+    handle: {
+      title: 'LCFS program information',
+      hideBreadcrumb: creditMarketPageEnabled
+    }
   },
   {
     name: 'Credit market data',

--- a/frontend/src/views/PublicDashboard/LegacyPublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard/LegacyPublicDashboard.tsx
@@ -1,0 +1,69 @@
+import { Box, List, ListItemButton } from '@mui/material'
+import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
+import BCTypography from '@/components/BCTypography'
+import { ROUTES } from '@/routes/routes'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+const publicLinks = [
+  {
+    labelKey: 'publicDashboard.links.calculator',
+    path: ROUTES.CREDIT_CALCULATOR
+  },
+  {
+    labelKey: 'publicDashboard.links.calculationData',
+    path: ROUTES.CALCULATION_DATA
+  },
+  {
+    labelKey: 'publicDashboard.links.approvedCarbonIntensities',
+    path: ROUTES.APPROVED_CARBON_INTENSITIES
+  }
+]
+
+export const LegacyPublicDashboard = () => {
+  const { t } = useTranslation()
+
+  return (
+    <Box
+      data-test="legacy-public-dashboard"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="60vh"
+    >
+      <BCWidgetCard
+        color="nav"
+        title={t('publicDashboard.cardTitle')}
+        data-test="public-dashboard-card"
+        sx={{ width: 550, mb: 0, pb: 12 }}
+        content={
+          <List component="div" sx={{ maxWidth: '100%', py: 1, pr: 0 }}>
+            {publicLinks.map(({ labelKey, path }) => (
+              <ListItemButton
+                component={Link}
+                to={path}
+                key={labelKey}
+                alignItems="flex-start"
+                data-test={`public-link-${path.replace(/^\//, '')}`}
+              >
+                <BCTypography
+                  variant="subtitle2"
+                  component="p"
+                  color="link"
+                  sx={{
+                    textDecoration: 'underline',
+                    '&:hover': { color: 'info.main' }
+                  }}
+                >
+                  {t(labelKey)}
+                </BCTypography>
+              </ListItemButton>
+            ))}
+          </List>
+        }
+      />
+    </Box>
+  )
+}
+
+export default LegacyPublicDashboard

--- a/frontend/src/views/PublicDashboard/PublicDashboardRoute.tsx
+++ b/frontend/src/views/PublicDashboard/PublicDashboardRoute.tsx
@@ -1,0 +1,12 @@
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
+import { PublicDashboard } from './PublicDashboard'
+import { LegacyPublicDashboard } from './LegacyPublicDashboard'
+
+export const PublicDashboardRoute = () =>
+  isFeatureEnabled(FEATURE_FLAGS.CREDIT_MARKET_LOGIN_PAGE) ? (
+    <PublicDashboard />
+  ) : (
+    <LegacyPublicDashboard />
+  )
+
+export default PublicDashboardRoute

--- a/frontend/src/views/PublicDashboard/__tests__/LegacyPublicDashboard.test.tsx
+++ b/frontend/src/views/PublicDashboard/__tests__/LegacyPublicDashboard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { wrapper } from '@/tests/utils/wrapper'
+import { LegacyPublicDashboard } from '../LegacyPublicDashboard'
+
+describe('LegacyPublicDashboard', () => {
+  it('renders the public tools nav card', () => {
+    render(<LegacyPublicDashboard />, { wrapper })
+
+    expect(screen.getByTestId('legacy-public-dashboard')).toBeInTheDocument()
+    expect(screen.getByTestId('public-dashboard-card')).toBeInTheDocument()
+  })
+
+  it('links to the compliance unit calculator, calculation data, and approved carbon intensities pages', () => {
+    render(<LegacyPublicDashboard />, { wrapper })
+
+    expect(
+      screen.getByTestId('public-link-credit-calculator')
+    ).toHaveAttribute('href', '/credit-calculator')
+    expect(
+      screen.getByTestId('public-link-calculation-data')
+    ).toHaveAttribute('href', '/calculation-data')
+    expect(
+      screen.getByTestId('public-link-approved-carbon-intensities')
+    ).toHaveAttribute('href', '/approved-carbon-intensities')
+  })
+})

--- a/frontend/src/views/PublicDashboard/__tests__/PublicDashboardRoute.test.tsx
+++ b/frontend/src/views/PublicDashboard/__tests__/PublicDashboardRoute.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest'
+import { PublicDashboardRoute } from '../PublicDashboardRoute'
+import { isFeatureEnabled } from '@/constants/config'
+
+vi.mock('@/constants/config', async () => {
+  const actual = await vi.importActual<typeof import('@/constants/config')>(
+    '@/constants/config'
+  )
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn()
+  }
+})
+
+vi.mock('../PublicDashboard', () => ({
+  PublicDashboard: () => <div data-test="new-public-dashboard" />
+}))
+
+vi.mock('../LegacyPublicDashboard', () => ({
+  LegacyPublicDashboard: () => <div data-test="legacy-public-dashboard" />
+}))
+
+const mockedIsFeatureEnabled = isFeatureEnabled as unknown as Mock
+
+describe('PublicDashboardRoute', () => {
+  beforeEach(() => {
+    mockedIsFeatureEnabled.mockReset()
+  })
+
+  it('renders the new Credit Market public dashboard when the flag is enabled', () => {
+    mockedIsFeatureEnabled.mockReturnValue(true)
+
+    render(<PublicDashboardRoute />)
+
+    expect(screen.getByTestId('new-public-dashboard')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('legacy-public-dashboard')
+    ).not.toBeInTheDocument()
+  })
+
+  it('falls back to the legacy public dashboard when the flag is disabled', () => {
+    mockedIsFeatureEnabled.mockReturnValue(false)
+
+    render(<PublicDashboardRoute />)
+
+    expect(screen.getByTestId('legacy-public-dashboard')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('new-public-dashboard')
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This PR adds a feature flag for the Credit Market login page.

- Allow switching between login page layouts
- Preserve login behaviour across both layouts

A related DevOps PR has also been created in the respective repository to add the required environment variable configuration for this feature flag.

Closes #4704
