### PR TITLE
Simplify CI application Step 3 document upload (#4669)

### DIFF
--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -13,13 +13,12 @@ from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models.ci_application import CIApplication, CIApplicationStatus
 from lcfs.db.models.fuel.FuelCodePrefix import FuelCodePrefix
 from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatus, FuelCodeStatusEnum
-from lcfs.db.models.fuel.FuelType import FuelType
-from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
+from lcfs.db.models.fuel.FuelType import FuelType, QuantityUnitsEnum
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.ci_application.schema import (
-    CIApplicationsListSchema,
     CIApplicationSchema,
+    CIApplicationsListSchema,
     CIApplicationStatusEnum,
     CIApplicationStep1Schema,
     CIApplicationStep2Schema,
@@ -34,7 +33,6 @@ from lcfs.web.api.ci_application.services import (
     _pathway_change_logs_from_versions,
 )
 from lcfs.web.exception.exceptions import DataNotFoundException
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -943,29 +941,23 @@ async def test_update_step3_succeeds_when_required_present(service, repo, mock_u
 
 
 @pytest.mark.anyio
-async def test_update_step3_rejects_when_technical_report_missing(
-    service, repo, mock_user
-):
+async def test_update_step3_succeeds_when_documents_missing(service, repo, mock_user):
+    # The mandatory Technical report / GHGenius upload validation is disabled
+    # for the simplified Step 3 flow (#4669), so saving proceeds even with no
+    # documents uploaded. The check is retained behind CI_STEP3_REQUIRE_DOCUMENTS.
     ci = _ci_application()
-    repo.get_document_categories.return_value = ["ghgenius_model"]
+    repo.get_document_categories.return_value = []
+    repo.update.side_effect = lambda obj: obj
+    repo.get_by_id.return_value = ci
+
     from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
 
-    with pytest.raises(Exception) as exc:
-        await service.update_step3(ci, CIApplicationStep3Schema(), mock_user)
-    assert "Technical report" in str(exc.value)
-    repo.update.assert_not_called()
+    payload = CIApplicationStep3Schema(supporting_document_other="Extra notes")
+    result = await service.update_step3(ci, payload, mock_user)
 
-
-@pytest.mark.anyio
-async def test_update_step3_rejects_when_ghgenius_missing(service, repo, mock_user):
-    ci = _ci_application()
-    repo.get_document_categories.return_value = ["technical_report"]
-    from lcfs.web.api.ci_application.schema import CIApplicationStep3Schema
-
-    with pytest.raises(Exception) as exc:
-        await service.update_step3(ci, CIApplicationStep3Schema(), mock_user)
-    assert "GHGenius" in str(exc.value)
-    repo.update.assert_not_called()
+    assert ci.supporting_document_other == "Extra notes"
+    assert ci.action_type == ActionTypeEnum.UPDATE
+    assert isinstance(result, CIApplicationSchema)
 
 
 # ---------------------------------------------------------------------------
@@ -1176,14 +1168,22 @@ async def test_step4_submit_requires_at_least_one_pathway(service, repo, mock_us
 
 
 @pytest.mark.anyio
-async def test_step4_submit_requires_required_documents(service, repo, mock_user):
+async def test_step4_submit_succeeds_when_documents_missing(service, repo, mock_user):
+    # Step 3 upload validation is disabled for the simplified flow (#4669), so
+    # submission no longer requires the Technical report / GHGenius uploads.
     ci = _draft_ci_with_pathways()
     repo.get_document_categories.return_value = []  # nothing uploaded
-    with pytest.raises(HTTPException) as exc:
-        await service.submit_application(ci, _step4_payload(), mock_user)
-    assert exc.value.status_code == 400
-    assert "Technical report" in exc.value.detail
-    assert "GHGenius" in exc.value.detail
+    submitted = _status("Submitted", 2)
+    repo.get_status_by_name.return_value = submitted
+    repo.update.side_effect = lambda obj: obj
+    repo.add_history.return_value = MagicMock()
+    repo.get_by_id.return_value = _reloaded_ci(ci)
+
+    result = await service.submit_application(ci, _step4_payload(), mock_user)
+
+    assert ci.status_id == submitted.ci_application_status_id
+    assert ci.action_type == ActionTypeEnum.UPDATE
+    assert isinstance(result, CIApplicationSchema)
 
 
 @pytest.mark.anyio
@@ -1265,6 +1265,7 @@ async def test_step4_submit_clears_consultant_when_not_consented(
 @pytest.mark.anyio
 async def test_step4_schema_requires_all_three_declarations():
     import pydantic
+
     from lcfs.web.api.ci_application.schema import CIApplicationStep4Schema
 
     with pytest.raises(pydantic.ValidationError):
@@ -1278,6 +1279,7 @@ async def test_step4_schema_requires_all_three_declarations():
 @pytest.mark.anyio
 async def test_step4_schema_requires_consultant_fields_when_consented():
     import pydantic
+
     from lcfs.web.api.ci_application.schema import CIApplicationStep4Schema
 
     with pytest.raises(pydantic.ValidationError):
@@ -1298,9 +1300,7 @@ async def test_step4_schema_requires_consultant_fields_when_consented():
 
 
 def _decision_payload(status_value="Completed", comment=None):
-    from lcfs.web.api.ci_application.schema import (
-        CIApplicationDecisionSchema,
-    )
+    from lcfs.web.api.ci_application.schema import CIApplicationDecisionSchema
 
     return CIApplicationDecisionSchema(status=status_value, comment=comment)
 
@@ -1410,9 +1410,7 @@ async def test_step5_decision_accepts_recommended_status(service, repo, mock_use
 
 
 @pytest.mark.anyio
-async def test_step5_completed_approves_generated_fuel_codes(
-    service, repo, mock_user
-):
+async def test_step5_completed_approves_generated_fuel_codes(service, repo, mock_user):
     """Approving a CI application moves its generated fuel codes to Approved (#4654)."""
     # Generate Draft fuel codes through the real generation flow.
     mock_user.role_names = {RoleEnum.ANALYST}
@@ -1665,9 +1663,8 @@ async def test_step5_decision_ignores_inline_comment_field(service, repo, mock_u
 @pytest.mark.anyio
 async def test_step5_decision_schema_rejects_non_terminal_status():
     import pydantic
-    from lcfs.web.api.ci_application.schema import (
-        CIApplicationDecisionSchema,
-    )
+
+    from lcfs.web.api.ci_application.schema import CIApplicationDecisionSchema
 
     with pytest.raises(pydantic.ValidationError):
         CIApplicationDecisionSchema(status="Recommended")

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 from fastapi import Depends, HTTPException, status
+from pydantic.alias_generators import to_camel
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models import UserProfile
@@ -69,11 +70,16 @@ from lcfs.web.exception.exceptions import (
     DataNotFoundException,
     ValidationErrorException,
 )
-from pydantic.alias_generators import to_camel
 
 # pathway_application_type.type values seeded by the migration
 PATHWAY_APPLICATION_TYPE_NEW = "New"
 PATHWAY_APPLICATION_TYPE_RENEWAL = "Renewal"
+
+# Step 3 mandatory-upload validation (Technical report + GHGenius model) is
+# disabled for the simplified single-upload flow (#4669). The validation logic
+# below is retained, not removed — set this to True to re-enable the required
+# Technical report / GHGenius upload checks on Step 3 save and on submission.
+CI_STEP3_REQUIRE_DOCUMENTS = False
 
 PATHWAY_LOG_FIELDS = [
     "application_type_id",
@@ -876,9 +882,7 @@ class CIApplicationServices:
         # field-level validation error the grid renders inline; genuinely
         # nullable fields fall through and are flagged by the row validator.
         non_nullable_columns = {
-            column.name
-            for column in FuelCode.__table__.columns
-            if not column.nullable
+            column.name for column in FuelCode.__table__.columns if not column.nullable
         }
         cleared_required = [
             field
@@ -1703,24 +1707,31 @@ class CIApplicationServices:
         user: UserProfile,
     ) -> CIApplicationSchema:
         """
-        Persists the optional "other supporting" description and verifies
-        the mandatory uploads (Technical report + GHGenius model) are
-        present. Files are uploaded out-of-band via the generic document
+        Persists the optional "other supporting" description.
+
+        Historically this also enforced the mandatory Technical report +
+        GHGenius uploads. That validation is disabled for the simplified
+        single-upload flow (#4669) and retained behind
+        ``CI_STEP3_REQUIRE_DOCUMENTS`` so it can be re-enabled without
+        redevelopment. Files are uploaded out-of-band via the generic document
         endpoint with a category query param.
         """
-        present_categories = set(
-            await self.repo.get_document_categories(ci_application.ci_application_id)
-        )
-        missing = []
-        if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
-            missing.append("Technical report")
-        if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
-            missing.append("GHGenius model")
-        if missing:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=("Missing required upload(s): " + ", ".join(missing) + "."),
+        if CI_STEP3_REQUIRE_DOCUMENTS:
+            present_categories = set(
+                await self.repo.get_document_categories(
+                    ci_application.ci_application_id
+                )
             )
+            missing = []
+            if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
+                missing.append("Technical report")
+            if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
+                missing.append("GHGenius model")
+            if missing:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=("Missing required upload(s): " + ", ".join(missing) + "."),
+                )
 
         ci_application.supporting_document_other = data.supporting_document_other
         ci_application.update_user = user.keycloak_username
@@ -1757,32 +1768,32 @@ class CIApplicationServices:
 
         # Sanity-check the prior steps. Step 1 is enforced by NOT NULL
         # columns at the DB layer; we re-check Step 2 (at least one
-        # pathway) and Step 3 (technical report + GHGenius model) so
-        # signing authorities cannot bypass the wizard via the API.
+        # pathway) so signing authorities cannot bypass the wizard via the API.
         if not (ci_application.pathways or []):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="At least one fuel pathway is required before submission.",
             )
 
-        from lcfs.db.models.ci_application.CIApplication import (
-            CI_DOC_CATEGORY_GHGENIUS_MODEL,
-            CI_DOC_CATEGORY_TECHNICAL_REPORT,
-        )
-
-        present_categories = set(
-            await self.repo.get_document_categories(ci_application.ci_application_id)
-        )
-        missing = []
-        if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
-            missing.append("Technical report")
-        if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
-            missing.append("GHGenius model")
-        if missing:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Missing required upload(s): " + ", ".join(missing) + ".",
+        # Step 3 mandatory-upload validation (technical report + GHGenius) is
+        # disabled for the simplified flow (#4669) and retained behind
+        # CI_STEP3_REQUIRE_DOCUMENTS so it can be re-enabled without redevelopment.
+        if CI_STEP3_REQUIRE_DOCUMENTS:
+            present_categories = set(
+                await self.repo.get_document_categories(
+                    ci_application.ci_application_id
+                )
             )
+            missing = []
+            if CI_DOC_CATEGORY_TECHNICAL_REPORT not in present_categories:
+                missing.append("Technical report")
+            if CI_DOC_CATEGORY_GHGENIUS_MODEL not in present_categories:
+                missing.append("GHGenius model")
+            if missing:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Missing required upload(s): " + ", ".join(missing) + ".",
+                )
 
         submitted_status = await self.repo.get_status_by_name(
             CIApplicationStatusEnum.Submitted.value

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -297,7 +297,12 @@ async def update_ci_application_step3(
     service: CIApplicationServices = Depends(),
     validate: CIApplicationValidation = Depends(),
 ) -> CIApplicationSchema:
-    """Step 3 — Documents & GHGenius modelling. Validates required uploads."""
+    """Step 3 — Documents & GHGenius template.
+
+    Persists the optional supporting-document description. The mandatory
+    Technical report / GHGenius upload validation is disabled for the simplified
+    flow (#4669) and retained behind ``CI_STEP3_REQUIRE_DOCUMENTS``.
+    """
     ci = await validate.validate_access(ci_application_id)
     return await service.update_step3(ci, data, request.user)
 

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -15,7 +15,7 @@
   "steps": {
     "step1": "Application information",
     "step2": "Proposed fuel pathways",
-    "step3": "Documents & GHGenius modelling",
+    "step3": "Documents & GHGenius template",
     "step4": "Sign & submit",
     "step5": "Government decision"
   },
@@ -74,7 +74,7 @@
     }
   },
   "step3": {
-    "title": "Documents & GHGenius modelling",
+    "title": "Documents & GHGenius template",
     "uploadedHeader": "Uploaded documents for application",
     "noDocuments": "No documents uploaded yet.",
     "supportingHeader": "Supporting documentation",
@@ -85,11 +85,12 @@
     "notUploaded": "(not uploaded)",
     "bullets": {
       "technicalReport": "Technical report (required)",
+      "ghgeniusTemplate": "GHGenius template (required)",
       "notification": "Notification of representation agreement form (optional, required if applicable)",
-      "other": "Other supporting documents — describe below (optional)"
+      "other": "Other supporting documentation, enter brief description (optional)"
     },
     "otherPlaceholder": "Brief description of other supporting documentation included",
-    "ghgeniusHeader": "GHGenius Modelling — Input & output tables",
+    "ghgeniusHeader": "GHGenius template — Input & output tables",
     "ghgeniusIntro": "Complete the required modelling input and output tables in the GHGenius Excel template, then upload the completed spreadsheet.",
     "uploadGHGenius": "Upload GHGenius model",
     "ghgeniusRequired": "GHGenius model upload is required.",
@@ -106,7 +107,7 @@
   "step4": {
     "title": "Sign & submit",
     "summaryHeader": "Application information",
-    "documentsHeader": "Documents & GHGenius modelling",
+    "documentsHeader": "Documents & GHGenius template",
     "pathwaysHeader": "Proposed fuel pathways",
     "signingAuthorityHeader": "Signing authority declaration",
     "signingAuthorityLabel": "Signing authority:",
@@ -207,7 +208,7 @@
     "titleLabel": "Title:",
     "emailLabel": "Email:",
     "consultantContactLabel": "Third party consultant contact:",
-    "documentsHeader": "Documents & GHGenius modelling",
+    "documentsHeader": "Documents & GHGenius template",
     "pathwaysHeader": "Proposed fuel pathways",
     "editPathways": "Edit supplemental pathway changes",
     "pathwayChangelog": "Pathway changelog",

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -18,6 +18,7 @@ vi.mock('react-i18next', () => ({
 let mockDocs = []
 const mockUpload = vi.fn().mockResolvedValue({})
 const mockDelete = vi.fn().mockResolvedValue({})
+const mockDownloadDoc = vi.fn().mockResolvedValue({})
 
 vi.mock('@/hooks/useDocuments', () => ({
   useDocuments: vi.fn(() => ({ data: mockDocs, isLoading: false })),
@@ -28,7 +29,8 @@ vi.mock('@/hooks/useDocuments', () => ({
   useDeleteDocument: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
-  }))
+  })),
+  useDownloadDocument: vi.fn(() => mockDownloadDoc)
 }))
 
 const mockDownload = vi.fn().mockResolvedValue({})
@@ -88,6 +90,22 @@ describe('DocumentsModellingStep (simplified upload — #4669)', () => {
     })
     expect(screen.getByTestId('ci-step3-uploaded-list')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-uploaded-row')).toBeInTheDocument()
+  })
+
+  it('downloads the document when its file name is clicked (#4645)', () => {
+    mockDocs = [
+      {
+        documentId: 7,
+        fileName: 'tech.pdf',
+        fileSize: 100,
+        documentCategory: 'supporting'
+      }
+    ]
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('ci-step3-download-doc'))
+    expect(mockDownloadDoc).toHaveBeenCalledWith(7, 'tech.pdf')
   })
 
   it('allows Save & proceed with no uploads (required-doc validation disabled)', async () => {

--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -1,12 +1,5 @@
 import React from 'react'
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanup,
   fireEvent,
@@ -45,14 +38,14 @@ vi.mock('@/services/useApiService', () => ({
 
 const baseCi = { ciApplicationId: 99, supportingDocumentOther: '' }
 
-describe('DocumentsModellingStep', () => {
+describe('DocumentsModellingStep (simplified upload — #4669)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDocs = []
   })
   afterEach(cleanup)
 
-  it('renders the upload sections, description input, and Save button', () => {
+  it('renders a single upload control, description input, and Save/Delete', () => {
     render(
       <DocumentsModellingStep
         ciApplication={baseCi}
@@ -61,38 +54,43 @@ describe('DocumentsModellingStep', () => {
       />,
       { wrapper }
     )
+    expect(screen.getByTestId('ci-step3-upload-supporting')).toBeInTheDocument()
+    // The separate GHGenius upload control was removed by the simplification.
     expect(
-      screen.getByTestId('ci-step3-upload-supporting')
-    ).toBeInTheDocument()
-    expect(screen.getByTestId('ci-step3-upload-ghgenius')).toBeInTheDocument()
-    // The download-template button was removed (ticket #4534) — the template
-    // is now provided earlier in the process.
-    expect(
-      screen.queryByTestId('ci-step3-download-template')
+      screen.queryByTestId('ci-step3-upload-ghgenius')
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByTestId('ci-step3-other-description')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-guidance')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-other-description')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-save-btn')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-delete-btn')).toBeInTheDocument()
   })
 
-  it('disables Save & proceed until both required uploads are present', () => {
-    mockDocs = [
-      { documentId: 1, fileName: 'x.pdf', fileSize: 100, documentCategory: 'technical_report' }
-    ]
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
-    expect(screen.getByTestId('ci-step3-save-btn')).toBeDisabled()
+  it('hides the uploaded-documents list until a document exists', () => {
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
+    expect(
+      screen.queryByTestId('ci-step3-uploaded-list')
+    ).not.toBeInTheDocument()
   })
 
-  it('enables Save & proceed and submits when both required uploads exist', async () => {
+  it('shows the uploaded-documents list once a document exists', () => {
     mockDocs = [
-      { documentId: 1, fileName: 'tech.pdf', fileSize: 100, documentCategory: 'technical_report' },
-      { documentId: 2, fileName: 'model.xlsx', fileSize: 200, documentCategory: 'ghgenius_model' }
+      {
+        documentId: 1,
+        fileName: 'tech.pdf',
+        fileSize: 100,
+        documentCategory: 'supporting'
+      }
     ]
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
+    expect(screen.getByTestId('ci-step3-uploaded-list')).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-uploaded-row')).toBeInTheDocument()
+  })
+
+  it('allows Save & proceed with no uploads (required-doc validation disabled)', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined)
     render(
       <DocumentsModellingStep
@@ -108,42 +106,22 @@ describe('DocumentsModellingStep', () => {
     expect(onSave.mock.calls[0][0].supportingDocumentOther).toBe('CCS notes')
   })
 
-  it('uploads a chosen file with the selected supporting category', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
-    const file = new File(['hi'], 'tech.pdf', { type: 'application/pdf' })
-    const input = screen.getByTestId('ci-step3-supporting-input')
-    fireEvent.change(input, { target: { files: [file] } })
-    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
-    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
-      'technical_report'
-    )
-  })
-
-  it('uploads a GHGenius file with category ghgenius_model', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
-    const file = new File(['hi'], 'model.xlsx', {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  it('uploads a chosen file under the generic supporting category', async () => {
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
     })
-    fireEvent.change(screen.getByTestId('ci-step3-ghgenius-input'), {
+    const file = new File(['hi'], 'tech.pdf', { type: 'application/pdf' })
+    fireEvent.change(screen.getByTestId('ci-step3-supporting-input'), {
       target: { files: [file] }
     })
     await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
-    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
-      'ghgenius_model'
-    )
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe('supporting')
   })
 
   it('rejects an unsupported file type without calling upload', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
     const file = new File(['hi'], 'bad.exe', {
       type: 'application/x-msdownload'
     })

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -17,6 +17,7 @@ import {
 import {
   useDeleteDocument,
   useDocuments,
+  useDownloadDocument,
   useUploadDocument
 } from '@/hooks/useDocuments'
 import colors from '@/themes/base/colors'
@@ -70,6 +71,7 @@ export const DocumentsModellingStep = ({
   )
   const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
     useDeleteDocument(PARENT_TYPE, ciApplicationId)
+  const downloadDocument = useDownloadDocument(PARENT_TYPE, ciApplicationId)
 
   const hasDocuments = documents.length > 0
 
@@ -165,7 +167,22 @@ export const DocumentsModellingStep = ({
                 }}
                 data-test="ci-step3-uploaded-row"
               >
-                <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+                <Link
+                  component="button"
+                  type="button"
+                  underline="hover"
+                  onClick={() => downloadDocument(doc.documentId, doc.fileName)}
+                  sx={{
+                    minWidth: 0,
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
+                  }}
+                  title={doc.fileName}
+                  data-test="ci-step3-download-doc"
+                >
                   {doc.fileName}
                 </Link>
                 <BCTypography variant="body2">

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -1,16 +1,6 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  Box,
-  IconButton,
-  InputLabel,
-  Link,
-  MenuItem,
-  Select,
-  Stack,
-  TextField,
-  Tooltip
-} from '@mui/material'
+import { Box, IconButton, Link, Stack, TextField, Tooltip } from '@mui/material'
 import {
   CloudUpload as CloudUploadIcon,
   Delete as DeleteIcon
@@ -32,6 +22,11 @@ import {
 import colors from '@/themes/base/colors'
 import { validateFile } from '@/utils/fileValidation'
 
+// Document category constants. The Technical report / GHGenius categories are
+// retained for when the mandatory-upload validation is re-enabled (the previous
+// categorized multi-upload layout lives in DocumentsModellingStep.legacy.jsx —
+// see #4669). The simplified single-upload flow stores every Step 3 file under
+// the generic supporting category.
 export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
 export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
 export const DOC_CATEGORY_SUPPORTING = 'supporting'
@@ -60,11 +55,6 @@ export const DocumentsModellingStep = ({
   const ciApplicationId = ciApplication?.ciApplicationId
 
   const supportingFileRef = useRef(null)
-  const ghgeniusFileRef = useRef(null)
-
-  const [supportingCategory, setSupportingCategory] = useState(
-    DOC_CATEGORY_TECHNICAL_REPORT
-  )
   const [otherDescription, setOtherDescription] = useState(
     ciApplication?.supportingDocumentOther || ''
   )
@@ -81,14 +71,9 @@ export const DocumentsModellingStep = ({
   const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
     useDeleteDocument(PARENT_TYPE, ciApplicationId)
 
-  const hasTechnicalReport = documents.some(
-    (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
-  )
-  const hasGHGeniusModel = documents.some(
-    (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
-  )
+  const hasDocuments = documents.length > 0
 
-  const handleFileChosen = async (event, category) => {
+  const handleFileChosen = async (event) => {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
@@ -104,7 +89,8 @@ export const DocumentsModellingStep = ({
     }
     setUploadError(null)
     try {
-      await uploadDoc({ file, documentCategory: category })
+      // Simplified flow: every Step 3 file is stored as a supporting document.
+      await uploadDoc({ file, documentCategory: DOC_CATEGORY_SUPPORTING })
     } catch (err) {
       setUploadError(
         err?.response?.data?.detail ||
@@ -126,14 +112,14 @@ export const DocumentsModellingStep = ({
     }
   }
 
-  const canProceed = hasTechnicalReport && hasGHGeniusModel && !readOnly
+  // Required-upload validation is intentionally disabled for the simplified
+  // flow (#4669). The previous mandatory Technical report / GHGenius checks are
+  // retained in DocumentsModellingStep.legacy.jsx (frontend) and behind the
+  // backend CI_STEP3_REQUIRE_DOCUMENTS flag. Proceeding is always allowed here.
+  const canProceed = !readOnly
 
   const handleSaveAndProceed = async () => {
     setUploadError(null)
-    if (!hasTechnicalReport || !hasGHGeniusModel) {
-      setUploadError(t('carbonIntensity:step3.errors.missingRequired'))
-      return
-    }
     await onSave?.({ supportingDocumentOther: otherDescription || null })
   }
 
@@ -145,74 +131,72 @@ export const DocumentsModellingStep = ({
         </BCTypography>
       )}
 
-      {/* Uploaded documents list */}
-      <BCBox
-        sx={{
-          border: 1,
-          borderColor: 'divider',
-          borderRadius: 1,
-          p: 2,
-          mb: 3,
-          maxHeight: 240,
-          overflowY: 'auto'
-        }}
-        data-test="ci-step3-uploaded-list"
-      >
-        <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-          {t('carbonIntensity:step3.uploadedHeader')}
-        </BCTypography>
-        {isLoadingDocs ? (
-          <BCTypography variant="body2" color="text.secondary">
-            {t('common:loading')}
+      {/* Uploaded documents — hidden until at least one document exists (#4669) */}
+      {hasDocuments && (
+        <BCBox
+          sx={{
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+            mb: 3,
+            maxHeight: 240,
+            overflowY: 'auto'
+          }}
+          data-test="ci-step3-uploaded-list"
+        >
+          <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+            {t('carbonIntensity:step3.uploadedHeader')}
           </BCTypography>
-        ) : documents.length === 0 ? (
-          <BCTypography variant="body2" color="text.secondary">
-            {t('carbonIntensity:step3.noDocuments')}
-          </BCTypography>
-        ) : (
-          documents.map((doc) => (
-            <Box
-              key={doc.documentId}
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: '2fr 1fr 1fr 1fr auto',
-                alignItems: 'center',
-                py: 0.5,
-                gap: 2
-              }}
-              data-test="ci-step3-uploaded-row"
-            >
-              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
-                {doc.fileName}
-              </Link>
-              <BCTypography variant="body2">
-                {formatBytes(doc.fileSize)}
-              </BCTypography>
-              <BCTypography variant="body2">
-                {doc.createUser || ''}
-              </BCTypography>
-              <BCTypography variant="body2">
-                {formatDate(doc.createDate)}
-              </BCTypography>
-              {!readOnly && (
-                <Tooltip title={t('common:deleteBtn')}>
-                  <span>
-                    <IconButton
-                      aria-label="delete document"
-                      size="small"
-                      onClick={() => handleDelete(doc.documentId)}
-                      disabled={isDeletingDoc}
-                      data-test="ci-step3-delete-doc"
-                    >
-                      <DeleteIcon fontSize="small" color="error" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              )}
-            </Box>
-          ))
-        )}
-      </BCBox>
+          {isLoadingDocs ? (
+            <BCTypography variant="body2" color="text.secondary">
+              {t('common:loading')}
+            </BCTypography>
+          ) : (
+            documents.map((doc) => (
+              <Box
+                key={doc.documentId}
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: '2fr 1fr 1fr 1fr auto',
+                  alignItems: 'center',
+                  py: 0.5,
+                  gap: 2
+                }}
+                data-test="ci-step3-uploaded-row"
+              >
+                <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+                  {doc.fileName}
+                </Link>
+                <BCTypography variant="body2">
+                  {formatBytes(doc.fileSize)}
+                </BCTypography>
+                <BCTypography variant="body2">
+                  {doc.createUser || ''}
+                </BCTypography>
+                <BCTypography variant="body2">
+                  {formatDate(doc.createDate)}
+                </BCTypography>
+                {!readOnly && (
+                  <Tooltip title={t('common:deleteBtn')}>
+                    <span>
+                      <IconButton
+                        aria-label="delete document"
+                        size="small"
+                        onClick={() => handleDelete(doc.documentId)}
+                        disabled={isDeletingDoc}
+                        data-test="ci-step3-delete-doc"
+                      >
+                        <DeleteIcon fontSize="small" color="error" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
+              </Box>
+            ))
+          )}
+        </BCBox>
+      )}
 
       {uploadError && (
         <Box mb={2}>
@@ -222,38 +206,8 @@ export const DocumentsModellingStep = ({
         </Box>
       )}
 
-      {/* Supporting documentation */}
-      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-        {t('carbonIntensity:step3.supportingHeader')}
-      </BCTypography>
-
-      <Stack direction="row" spacing={2} alignItems="flex-end" sx={{ mb: 1 }}>
-        <Box sx={{ minWidth: 340 }}>
-          <InputLabel
-            htmlFor="ci-step3-supporting-category"
-            shrink={false}
-            sx={{ pb: 1, color: 'text.primary', position: 'static' }}
-          >
-            {t('carbonIntensity:step3.documentCategoryLabel')}
-          </InputLabel>
-          <Select
-            id="ci-step3-supporting-category"
-            value={supportingCategory}
-            onChange={(e) => setSupportingCategory(e.target.value)}
-            disabled={readOnly}
-            displayEmpty
-            fullWidth
-            inputProps={{ 'data-test': 'ci-step3-supporting-category' }}
-            sx={{ height: 40 }}
-          >
-            <MenuItem value={DOC_CATEGORY_TECHNICAL_REPORT}>
-              {t('carbonIntensity:step3.categoryTechnicalReport')}
-            </MenuItem>
-            <MenuItem value={DOC_CATEGORY_SUPPORTING}>
-              {t('carbonIntensity:step3.categorySupporting')}
-            </MenuItem>
-          </Select>
-        </Box>
+      {/* Single upload control (#4669) */}
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <BCButton
           type="button"
           variant="outlined"
@@ -263,7 +217,6 @@ export const DocumentsModellingStep = ({
           onClick={() => supportingFileRef.current?.click()}
           disabled={readOnly || isUploading}
           data-test="ci-step3-upload-supporting"
-          sx={{ height: 40 }}
         >
           {t('carbonIntensity:step3.uploadSupporting')}
         </BCButton>
@@ -272,25 +225,21 @@ export const DocumentsModellingStep = ({
           type="file"
           accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
           hidden
-          onChange={(e) => handleFileChosen(e, supportingCategory)}
+          onChange={handleFileChosen}
           data-test="ci-step3-supporting-input"
         />
       </Stack>
 
-      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
+      {/* Guidance on what to include — informational only, not enforced (#4669) */}
+      <Box component="ul" sx={{ pl: 3, mb: 2 }} data-test="ci-step3-guidance">
         <li>
           <BCTypography variant="body2">
             {t('carbonIntensity:step3.bullets.technicalReport')}
-            {!hasTechnicalReport && (
-              <BCTypography
-                component="span"
-                variant="body2"
-                color="error"
-                sx={{ ml: 1 }}
-              >
-                {t('carbonIntensity:step3.notUploaded')}
-              </BCTypography>
-            )}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.ghgeniusTemplate')}
           </BCTypography>
         </li>
         <li>
@@ -317,43 +266,6 @@ export const DocumentsModellingStep = ({
         }}
         sx={{ mb: 4 }}
       />
-
-      {/* GHGenius modelling */}
-      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-        {t('carbonIntensity:step3.ghgeniusHeader')}
-      </BCTypography>
-      <BCTypography variant="body2" sx={{ mb: 2 }}>
-        {t('carbonIntensity:step3.ghgeniusIntro')}
-      </BCTypography>
-
-      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-        <BCButton
-          type="button"
-          variant="outlined"
-          color="primary"
-          size="medium"
-          startIcon={<CloudUploadIcon sx={{ fontSize: '1.5rem !important' }} />}
-          onClick={() => ghgeniusFileRef.current?.click()}
-          disabled={readOnly || isUploading}
-          data-test="ci-step3-upload-ghgenius"
-        >
-          {t('carbonIntensity:step3.uploadGHGenius')}
-        </BCButton>
-        <input
-          ref={ghgeniusFileRef}
-          type="file"
-          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
-          hidden
-          onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
-          data-test="ci-step3-ghgenius-input"
-        />
-      </Stack>
-
-      {!hasGHGeniusModel && (
-        <BCTypography variant="body2" color="error" sx={{ mb: 2 }}>
-          {t('carbonIntensity:step3.ghgeniusRequired')}
-        </BCTypography>
-      )}
 
       {showSaveControls && (
         <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.legacy.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.legacy.jsx
@@ -1,0 +1,403 @@
+/*
+ * LEGACY BACKUP — pre-#4669 Step 3 layout + document validation.
+ *
+ * This is the original multi-section upload UI (separate supporting-document
+ * category picker + a dedicated GHGenius upload) together with the mandatory
+ * Technical report / GHGenius upload gating. It was replaced by the simplified
+ * single-upload flow in `DocumentsModellingStep.jsx` for #4669.
+ *
+ * It is retained (unused) so the previous layout and validation can be
+ * re-enabled without redevelopment: swap the import in
+ * `EditViewCIApplication.jsx` back to this component and re-enable the backend
+ * check via `CI_STEP3_REQUIRE_DOCUMENTS` in the CI application service.
+ *
+ * Do not delete. Kept intentionally out of the active render path.
+ */
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  IconButton,
+  InputLabel,
+  Link,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip
+} from '@mui/material'
+import {
+  CloudUpload as CloudUploadIcon,
+  Delete as DeleteIcon
+} from '@mui/icons-material'
+
+import BCAlert from '@/components/BCAlert'
+import BCButton from '@/components/BCButton'
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import {
+  COMPLIANCE_REPORT_FILE_TYPES,
+  MAX_FILE_SIZE_BYTES
+} from '@/constants/common'
+import {
+  useDeleteDocument,
+  useDocuments,
+  useUploadDocument
+} from '@/hooks/useDocuments'
+import colors from '@/themes/base/colors'
+import { validateFile } from '@/utils/fileValidation'
+
+export const DOC_CATEGORY_TECHNICAL_REPORT = 'technical_report'
+export const DOC_CATEGORY_GHGENIUS_MODEL = 'ghgenius_model'
+export const DOC_CATEGORY_SUPPORTING = 'supporting'
+
+const PARENT_TYPE = 'ci_application'
+
+const formatBytes = (bytes) => {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+const formatDate = (iso) => (iso ? String(iso).slice(0, 10) : '')
+
+export const DocumentsModellingStepLegacy = ({
+  ciApplication,
+  onSave,
+  onDelete,
+  isSaving = false,
+  readOnly = false,
+  showTitle = true,
+  showSaveControls = true
+}) => {
+  const { t } = useTranslation(['common', 'carbonIntensity'])
+  const ciApplicationId = ciApplication?.ciApplicationId
+
+  const supportingFileRef = useRef(null)
+  const ghgeniusFileRef = useRef(null)
+
+  const [supportingCategory, setSupportingCategory] = useState(
+    DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const [otherDescription, setOtherDescription] = useState(
+    ciApplication?.supportingDocumentOther || ''
+  )
+  const [uploadError, setUploadError] = useState(null)
+
+  const { data: documents = [], isLoading: isLoadingDocs } = useDocuments(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: uploadDoc, isPending: isUploading } = useUploadDocument(
+    PARENT_TYPE,
+    ciApplicationId
+  )
+  const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
+    useDeleteDocument(PARENT_TYPE, ciApplicationId)
+
+  const hasTechnicalReport = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
+  )
+  const hasGHGeniusModel = documents.some(
+    (d) => d.documentCategory === DOC_CATEGORY_GHGENIUS_MODEL
+  )
+
+  const handleFileChosen = async (event, category) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+
+    const result = validateFile(
+      file,
+      MAX_FILE_SIZE_BYTES,
+      COMPLIANCE_REPORT_FILE_TYPES
+    )
+    if (!result.isValid) {
+      setUploadError(result.errorMessage)
+      return
+    }
+    setUploadError(null)
+    try {
+      await uploadDoc({ file, documentCategory: category })
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.uploadFailed')
+      )
+    }
+  }
+
+  const handleDelete = async (documentId) => {
+    try {
+      await deleteDoc(documentId)
+    } catch (err) {
+      setUploadError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          t('carbonIntensity:step3.errors.deleteFailed')
+      )
+    }
+  }
+
+  const canProceed = hasTechnicalReport && hasGHGeniusModel && !readOnly
+
+  const handleSaveAndProceed = async () => {
+    setUploadError(null)
+    if (!hasTechnicalReport || !hasGHGeniusModel) {
+      setUploadError(t('carbonIntensity:step3.errors.missingRequired'))
+      return
+    }
+    await onSave?.({ supportingDocumentOther: otherDescription || null })
+  }
+
+  return (
+    <Box>
+      {showTitle && (
+        <BCTypography variant="h6" sx={{ pb: 2, color: colors.primary.main }}>
+          {t('carbonIntensity:step3.title')}
+        </BCTypography>
+      )}
+
+      {/* Uploaded documents list */}
+      <BCBox
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          mb: 3,
+          maxHeight: 240,
+          overflowY: 'auto'
+        }}
+        data-test="ci-step3-uploaded-list"
+      >
+        <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+          {t('carbonIntensity:step3.uploadedHeader')}
+        </BCTypography>
+        {isLoadingDocs ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('common:loading')}
+          </BCTypography>
+        ) : documents.length === 0 ? (
+          <BCTypography variant="body2" color="text.secondary">
+            {t('carbonIntensity:step3.noDocuments')}
+          </BCTypography>
+        ) : (
+          documents.map((doc) => (
+            <Box
+              key={doc.documentId}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '2fr 1fr 1fr 1fr auto',
+                alignItems: 'center',
+                py: 0.5,
+                gap: 2
+              }}
+              data-test="ci-step3-uploaded-row"
+            >
+              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+                {doc.fileName}
+              </Link>
+              <BCTypography variant="body2">
+                {formatBytes(doc.fileSize)}
+              </BCTypography>
+              <BCTypography variant="body2">
+                {doc.createUser || ''}
+              </BCTypography>
+              <BCTypography variant="body2">
+                {formatDate(doc.createDate)}
+              </BCTypography>
+              {!readOnly && (
+                <Tooltip title={t('common:deleteBtn')}>
+                  <span>
+                    <IconButton
+                      aria-label="delete document"
+                      size="small"
+                      onClick={() => handleDelete(doc.documentId)}
+                      disabled={isDeletingDoc}
+                      data-test="ci-step3-delete-doc"
+                    >
+                      <DeleteIcon fontSize="small" color="error" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+            </Box>
+          ))
+        )}
+      </BCBox>
+
+      {uploadError && (
+        <Box mb={2}>
+          <BCAlert severity="error" onClose={() => setUploadError(null)}>
+            {uploadError}
+          </BCAlert>
+        </Box>
+      )}
+
+      {/* Supporting documentation */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.supportingHeader')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} alignItems="flex-end" sx={{ mb: 1 }}>
+        <Box sx={{ minWidth: 340 }}>
+          <InputLabel
+            htmlFor="ci-step3-supporting-category"
+            shrink={false}
+            sx={{ pb: 1, color: 'text.primary', position: 'static' }}
+          >
+            {t('carbonIntensity:step3.documentCategoryLabel')}
+          </InputLabel>
+          <Select
+            id="ci-step3-supporting-category"
+            value={supportingCategory}
+            onChange={(e) => setSupportingCategory(e.target.value)}
+            disabled={readOnly}
+            displayEmpty
+            fullWidth
+            inputProps={{ 'data-test': 'ci-step3-supporting-category' }}
+            sx={{ height: 40 }}
+          >
+            <MenuItem value={DOC_CATEGORY_TECHNICAL_REPORT}>
+              {t('carbonIntensity:step3.categoryTechnicalReport')}
+            </MenuItem>
+            <MenuItem value={DOC_CATEGORY_SUPPORTING}>
+              {t('carbonIntensity:step3.categorySupporting')}
+            </MenuItem>
+          </Select>
+        </Box>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          size="medium"
+          startIcon={<CloudUploadIcon sx={{ fontSize: '1.5rem !important' }} />}
+          onClick={() => supportingFileRef.current?.click()}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-supporting"
+          sx={{ height: 40 }}
+        >
+          {t('carbonIntensity:step3.uploadSupporting')}
+        </BCButton>
+        <input
+          ref={supportingFileRef}
+          type="file"
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
+          hidden
+          onChange={(e) => handleFileChosen(e, supportingCategory)}
+          data-test="ci-step3-supporting-input"
+        />
+      </Stack>
+
+      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.technicalReport')}
+            {!hasTechnicalReport && (
+              <BCTypography
+                component="span"
+                variant="body2"
+                color="error"
+                sx={{ ml: 1 }}
+              >
+                {t('carbonIntensity:step3.notUploaded')}
+              </BCTypography>
+            )}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.notification')}
+          </BCTypography>
+        </li>
+        <li>
+          <BCTypography variant="body2">
+            {t('carbonIntensity:step3.bullets.other')}
+          </BCTypography>
+        </li>
+      </Box>
+
+      <TextField
+        fullWidth
+        value={otherDescription}
+        onChange={(e) => setOtherDescription(e.target.value)}
+        disabled={readOnly}
+        placeholder={t('carbonIntensity:step3.otherPlaceholder')}
+        inputProps={{
+          'data-test': 'ci-step3-other-description',
+          maxLength: 1000
+        }}
+        sx={{ mb: 4 }}
+      />
+
+      {/* GHGenius modelling */}
+      <BCTypography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        {t('carbonIntensity:step3.ghgeniusHeader')}
+      </BCTypography>
+      <BCTypography variant="body2" sx={{ mb: 2 }}>
+        {t('carbonIntensity:step3.ghgeniusIntro')}
+      </BCTypography>
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <BCButton
+          type="button"
+          variant="outlined"
+          color="primary"
+          size="medium"
+          startIcon={<CloudUploadIcon sx={{ fontSize: '1.5rem !important' }} />}
+          onClick={() => ghgeniusFileRef.current?.click()}
+          disabled={readOnly || isUploading}
+          data-test="ci-step3-upload-ghgenius"
+        >
+          {t('carbonIntensity:step3.uploadGHGenius')}
+        </BCButton>
+        <input
+          ref={ghgeniusFileRef}
+          type="file"
+          accept={COMPLIANCE_REPORT_FILE_TYPES.ACCEPT_STRING}
+          hidden
+          onChange={(e) => handleFileChosen(e, DOC_CATEGORY_GHGENIUS_MODEL)}
+          data-test="ci-step3-ghgenius-input"
+        />
+      </Stack>
+
+      {!hasGHGeniusModel && (
+        <BCTypography variant="body2" color="error" sx={{ mb: 2 }}>
+          {t('carbonIntensity:step3.ghgeniusRequired')}
+        </BCTypography>
+      )}
+
+      {showSaveControls && (
+        <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+          <BCButton
+            type="button"
+            variant="contained"
+            color="primary"
+            onClick={handleSaveAndProceed}
+            disabled={!canProceed || isSaving || isUploading}
+            data-test="ci-step3-save-btn"
+          >
+            {t('carbonIntensity:step3.saveAndProceed')}
+          </BCButton>
+          {ciApplicationId && onDelete && (
+            <BCButton
+              type="button"
+              variant="outlined"
+              color="error"
+              onClick={onDelete}
+              disabled={readOnly || isSaving}
+              data-test="ci-step3-delete-btn"
+            >
+              {t('carbonIntensity:step1.deleteDraft')}
+            </BCButton>
+          )}
+        </Stack>
+      )}
+    </Box>
+  )
+}
+
+DocumentsModellingStepLegacy.displayName = 'DocumentsModellingStepLegacy'

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.legacy.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.legacy.jsx
@@ -42,6 +42,7 @@ import {
 import {
   useDeleteDocument,
   useDocuments,
+  useDownloadDocument,
   useUploadDocument
 } from '@/hooks/useDocuments'
 import colors from '@/themes/base/colors'
@@ -95,6 +96,7 @@ export const DocumentsModellingStepLegacy = ({
   )
   const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
     useDeleteDocument(PARENT_TYPE, ciApplicationId)
+  const downloadDocument = useDownloadDocument(PARENT_TYPE, ciApplicationId)
 
   const hasTechnicalReport = documents.some(
     (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
@@ -197,7 +199,22 @@ export const DocumentsModellingStepLegacy = ({
               }}
               data-test="ci-step3-uploaded-row"
             >
-              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+              <Link
+                component="button"
+                type="button"
+                underline="hover"
+                onClick={() => downloadDocument(doc.documentId, doc.fileName)}
+                sx={{
+                  minWidth: 0,
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap'
+                }}
+                title={doc.fileName}
+                data-test="ci-step3-download-doc"
+              >
                 {doc.fileName}
               </Link>
               <BCTypography variant="body2">


### PR DESCRIPTION
## Summary

Fixes #4669. Simplifies the CI application Step 3 document upload to a single upload control per the approved wireframe, disables the mandatory Technical report / GHGenius upload validation (retained, not removed), and renames "GHGenius modelling" to "GHGenius template".

## Changes

**Frontend**
- `DocumentsModellingStep.jsx` rewritten as the simplified flow: one **"Upload supporting documentation"** button (files stored under the generic `supporting` category), a guidance bullet list, the description field, and Save/Delete. The **uploaded-documents list is hidden until at least one document exists**, and there is no required-upload gating (Save & proceed is always enabled).
- `DocumentsModellingStep.legacy.jsx` **(new)** — verbatim backup of the previous multi-section layout + validation, kept out of the active render path so it can be reactivated by swapping the import.
- `carbonIntensity.json` — renamed all user-facing "GHGenius modelling/Modelling" → "GHGenius template" (Step 3 heading, stepper/pipeline label, Sign & submit + summary headers); added the "GHGenius template (required)" bullet and updated the "other" bullet to the wireframe wording.

**Backend**
- `services.py` — added `CI_STEP3_REQUIRE_DOCUMENTS = False`; both required-doc checks (Step 3 save and submission) are gated by it — **disabled, not removed**. Flip to `True` to re-enable.
- `views.py` — corrected the now-stale Step 3 docstring.

## Acceptance criteria
- [x] Single upload button; "Uploaded documents" display hidden until documents exist
- [x] Technical Report validation not required
- [x] GHG Input validation not required
- [x] "GHGenius Modelling" → "GHGenius template" in Step 3 and the stepper/pipeline label
- [x] Existing validation logic retained and re-enableable without redevelopment
- [x] Existing upload/delete functionality continues to operate

## Notes
- Existing validation is disabled, not removed: frontend via `DocumentsModellingStep.legacy.jsx`, backend via `CI_STEP3_REQUIRE_DOCUMENTS`.
- The "(required)" wording on the Technical report / GHGenius bullets is kept to match the wireframe, even though nothing is enforced.

## Testing
- Frontend `vitest` — Step 3 + edit-view + summary/stepper suites pass (35 tests), including new cases for the single control, hidden uploaded list, save-with-no-uploads, and `supporting`-category upload.
- Backend `pytest lcfs/tests/ci_application` — 89 passed; the former "rejects when documents missing" cases now assert save/submit succeed with validation disabled.
- Not browser-verified: Step 3 sits behind a CI-applicant login + the `ciApplications` flag and requires a draft application to reach, so it isn't reachable in a quick preview.
