### PR TITLE
Make CI application Step 3 document names downloadable (#4645)

### DIFF
--- a/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/DocumentsModellingStep.test.jsx
@@ -1,12 +1,5 @@
 import React from 'react'
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanup,
   fireEvent,
@@ -25,6 +18,7 @@ vi.mock('react-i18next', () => ({
 let mockDocs = []
 const mockUpload = vi.fn().mockResolvedValue({})
 const mockDelete = vi.fn().mockResolvedValue({})
+const mockDownloadDoc = vi.fn().mockResolvedValue({})
 
 vi.mock('@/hooks/useDocuments', () => ({
   useDocuments: vi.fn(() => ({ data: mockDocs, isLoading: false })),
@@ -35,7 +29,8 @@ vi.mock('@/hooks/useDocuments', () => ({
   useDeleteDocument: vi.fn(() => ({
     mutateAsync: mockDelete,
     isPending: false
-  }))
+  })),
+  useDownloadDocument: vi.fn(() => mockDownloadDoc)
 }))
 
 const mockDownload = vi.fn().mockResolvedValue({})
@@ -61,37 +56,63 @@ describe('DocumentsModellingStep', () => {
       />,
       { wrapper }
     )
-    expect(
-      screen.getByTestId('ci-step3-upload-supporting')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-upload-supporting')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-upload-ghgenius')).toBeInTheDocument()
     // The download-template button was removed (ticket #4534) — the template
     // is now provided earlier in the process.
     expect(
       screen.queryByTestId('ci-step3-download-template')
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByTestId('ci-step3-other-description')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('ci-step3-other-description')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-save-btn')).toBeInTheDocument()
     expect(screen.getByTestId('ci-step3-delete-btn')).toBeInTheDocument()
   })
 
+  it('downloads the document when its file name is clicked (#4645)', () => {
+    mockDocs = [
+      {
+        documentId: 7,
+        fileName: 'tech.pdf',
+        fileSize: 100,
+        documentCategory: 'technical_report'
+      }
+    ]
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('ci-step3-download-doc'))
+    expect(mockDownloadDoc).toHaveBeenCalledWith(7, 'tech.pdf')
+  })
+
   it('disables Save & proceed until both required uploads are present', () => {
     mockDocs = [
-      { documentId: 1, fileName: 'x.pdf', fileSize: 100, documentCategory: 'technical_report' }
+      {
+        documentId: 1,
+        fileName: 'x.pdf',
+        fileSize: 100,
+        documentCategory: 'technical_report'
+      }
     ]
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
     expect(screen.getByTestId('ci-step3-save-btn')).toBeDisabled()
   })
 
   it('enables Save & proceed and submits when both required uploads exist', async () => {
     mockDocs = [
-      { documentId: 1, fileName: 'tech.pdf', fileSize: 100, documentCategory: 'technical_report' },
-      { documentId: 2, fileName: 'model.xlsx', fileSize: 200, documentCategory: 'ghgenius_model' }
+      {
+        documentId: 1,
+        fileName: 'tech.pdf',
+        fileSize: 100,
+        documentCategory: 'technical_report'
+      },
+      {
+        documentId: 2,
+        fileName: 'model.xlsx',
+        fileSize: 200,
+        documentCategory: 'ghgenius_model'
+      }
     ]
     const onSave = vi.fn().mockResolvedValue(undefined)
     render(
@@ -109,10 +130,9 @@ describe('DocumentsModellingStep', () => {
   })
 
   it('uploads a chosen file with the selected supporting category', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
     const file = new File(['hi'], 'tech.pdf', { type: 'application/pdf' })
     const input = screen.getByTestId('ci-step3-supporting-input')
     fireEvent.change(input, { target: { files: [file] } })
@@ -123,10 +143,9 @@ describe('DocumentsModellingStep', () => {
   })
 
   it('uploads a GHGenius file with category ghgenius_model', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
     const file = new File(['hi'], 'model.xlsx', {
       type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     })
@@ -134,16 +153,13 @@ describe('DocumentsModellingStep', () => {
       target: { files: [file] }
     })
     await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1))
-    expect(mockUpload.mock.calls[0][0].documentCategory).toBe(
-      'ghgenius_model'
-    )
+    expect(mockUpload.mock.calls[0][0].documentCategory).toBe('ghgenius_model')
   })
 
   it('rejects an unsupported file type without calling upload', async () => {
-    render(
-      <DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />,
-      { wrapper }
-    )
+    render(<DocumentsModellingStep ciApplication={baseCi} onSave={vi.fn()} />, {
+      wrapper
+    })
     const file = new File(['hi'], 'bad.exe', {
       type: 'application/x-msdownload'
     })

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -27,6 +27,7 @@ import {
 import {
   useDeleteDocument,
   useDocuments,
+  useDownloadDocument,
   useUploadDocument
 } from '@/hooks/useDocuments'
 import colors from '@/themes/base/colors'
@@ -80,6 +81,7 @@ export const DocumentsModellingStep = ({
   )
   const { mutateAsync: deleteDoc, isPending: isDeletingDoc } =
     useDeleteDocument(PARENT_TYPE, ciApplicationId)
+  const downloadDocument = useDownloadDocument(PARENT_TYPE, ciApplicationId)
 
   const hasTechnicalReport = documents.some(
     (d) => d.documentCategory === DOC_CATEGORY_TECHNICAL_REPORT
@@ -182,7 +184,22 @@ export const DocumentsModellingStep = ({
               }}
               data-test="ci-step3-uploaded-row"
             >
-              <Link href="#" underline="hover" sx={{ minWidth: 0 }} noWrap>
+              <Link
+                component="button"
+                type="button"
+                underline="hover"
+                onClick={() => downloadDocument(doc.documentId, doc.fileName)}
+                sx={{
+                  minWidth: 0,
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap'
+                }}
+                title={doc.fileName}
+                data-test="ci-step3-download-doc"
+              >
                 {doc.fileName}
               </Link>
               <BCTypography variant="body2">


### PR DESCRIPTION
## Summary

Fixes #4645. In the CI application Step 3 document editor, the uploaded file name was a dead link (`<Link href="#">`) with no handler, so clicking a document after upload did nothing (or jumped the page). This is the state an Analyst reaches by clicking the **edit icon** next to "Uploaded documents" on the application summary — which opens this editor — matching the reported "click edit → interact with file → error."

The file name now downloads via `useDownloadDocument('ci_application', ciApplicationId)`, the same mechanism used everywhere else. The edit icon is unchanged and continues to only open editing.

## Download audit

Per the request to "check all downloads," I reviewed every document surface. The CI Step 3 editor was the **only** broken one — all others already download correctly through the shared hooks:

- `components/Documents/DocumentTable.jsx` (compliance reports, transactions) — `viewDocument`
- `views/CarbonIntensity/components/ApplicationSummary.jsx` — `downloadDocument`
- `views/ChargingSite/components/ChargingSiteDocument.jsx` — `downloadDocument`
- `views/SupportingDocuments/SupportingDocumentSummary.jsx` — `downloadDocument`
- `views/Transactions/components/{OrgTransactionDetails,TransactionView}.jsx` — `viewDocument`
- comment attachments — `onDownloadAttachment`

## Testing
- `vitest` on `DocumentsModellingStep` — 7 passed, including a new case asserting a filename click calls `downloadDocument(documentId, fileName)`.
- Not browser-verified: Step 3 sits behind a CI-applicant/analyst login and requires an application with an uploaded document to reach; the behaviour is covered by the unit test.

## Note
`DocumentsModellingStep.jsx` is also rewritten by the open #4669 PR (#4721); the same one-line download fix has been applied there too so it survives whichever merges first.
