### PR TITLE
Request further documentation: supplier upload path + confirm dialog (#4644, #4651)

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-07-20-10-00_e7f8a9b0c1d2.py
+++ b/backend/lcfs/db/migrations/versions/2026-07-20-10-00_e7f8a9b0c1d2.py
@@ -5,7 +5,7 @@ document uploads on a submitted CI application so the supplier can attach the
 requested files. Mirrors the supplemental pathway-edit request fields (#4644).
 
 Revision ID: e7f8a9b0c1d2
-Revises: b7c8d9e0f1a2
+Revises: d4e5f6a7b8c9
 Create Date: 2026-07-20 10:00:00.000000
 """
 
@@ -14,7 +14,7 @@ from alembic import op
 
 
 revision = "e7f8a9b0c1d2"
-down_revision = "b7c8d9e0f1a2"
+down_revision = "d4e5f6a7b8c9"
 branch_labels = None
 depends_on = None
 

--- a/backend/lcfs/db/migrations/versions/2026-07-20-10-00_e7f8a9b0c1d2.py
+++ b/backend/lcfs/db/migrations/versions/2026-07-20-10-00_e7f8a9b0c1d2.py
@@ -1,0 +1,57 @@
+"""Add CI application additional-documentation request fields.
+
+Enables the "request further documentation" workflow: an analyst can open
+document uploads on a submitted CI application so the supplier can attach the
+requested files. Mirrors the supplemental pathway-edit request fields (#4644).
+
+Revision ID: e7f8a9b0c1d2
+Revises: b7c8d9e0f1a2
+Create Date: 2026-07-20 10:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "e7f8a9b0c1d2"
+down_revision = "b7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "document_upload_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            comment="True when the supplier may upload additional documents after "
+            "a request for further documentation on a submitted application.",
+        ),
+    )
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "document_changes_requested_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+            comment="UTC date and time additional documentation was requested.",
+        ),
+    )
+    op.add_column(
+        "ci_application",
+        sa.Column(
+            "document_changes_requested_by",
+            sa.String(length=500),
+            nullable=True,
+            comment="Username of the IDIR user who requested additional documentation.",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ci_application", "document_changes_requested_by")
+    op.drop_column("ci_application", "document_changes_requested_at")
+    op.drop_column("ci_application", "document_upload_enabled")

--- a/backend/lcfs/db/models/ci_application/CIApplication.py
+++ b/backend/lcfs/db/models/ci_application/CIApplication.py
@@ -175,6 +175,24 @@ class CIApplication(BaseModel, Auditable, Versioning):
         nullable=True,
         comment="Username of the IDIR user who requested pathway changes.",
     )
+    document_upload_enabled = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+        comment="True when the supplier may upload additional documents after a "
+        "request for further documentation on a submitted application.",
+    )
+    document_changes_requested_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        comment="UTC date and time additional documentation was requested.",
+    )
+    document_changes_requested_by = Column(
+        String(500),
+        nullable=True,
+        comment="Username of the IDIR user who requested additional documentation.",
+    )
     generated_fuel_codes = Column(
         JSONB,
         nullable=True,

--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -1391,6 +1391,54 @@ async def test_recommend_to_director_requires_workflow_role(service, repo, mock_
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "role",
+    [RoleEnum.ANALYST, RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR],
+)
+async def test_request_documentation_enables_upload_for_workflow_roles(
+    service, repo, mock_user, role
+):
+    mock_user.role_names = {role}
+    ci = _ci_application(status=_status("Submitted", 2))
+    repo.update.side_effect = lambda obj: obj
+    repo.add_history.return_value = MagicMock()
+    repo.get_by_id.return_value = ci
+
+    result = await service.request_documentation(ci, mock_user)
+
+    assert ci.document_upload_enabled is True
+    assert ci.document_changes_requested_at is not None
+    assert ci.document_changes_requested_by == mock_user.keycloak_username
+    repo.add_history.assert_awaited_once()
+    assert isinstance(result, CIApplicationSchema)
+
+
+@pytest.mark.anyio
+async def test_request_documentation_requires_workflow_role(service, repo, mock_user):
+    ci = _ci_application(status=_status("Submitted", 2))
+
+    with pytest.raises(HTTPException) as exc:
+        await service.request_documentation(ci, mock_user)
+
+    assert exc.value.status_code == 403
+    repo.update.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_request_documentation_requires_submitted_status(
+    service, repo, mock_user
+):
+    mock_user.role_names = {RoleEnum.ANALYST}
+    ci = _ci_application(status=_status("Draft", 1))
+
+    with pytest.raises(HTTPException) as exc:
+        await service.request_documentation(ci, mock_user)
+
+    assert exc.value.status_code == 400
+    repo.update.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_step5_decision_accepts_recommended_status(service, repo, mock_user):
     mock_user.role_names = {RoleEnum.DIRECTOR}
     ci = _ci_application(status=_status("Recommended", 3))
@@ -1410,9 +1458,7 @@ async def test_step5_decision_accepts_recommended_status(service, repo, mock_use
 
 
 @pytest.mark.anyio
-async def test_step5_completed_approves_generated_fuel_codes(
-    service, repo, mock_user
-):
+async def test_step5_completed_approves_generated_fuel_codes(service, repo, mock_user):
     """Approving a CI application moves its generated fuel codes to Approved (#4654)."""
     # Generate Draft fuel codes through the real generation flow.
     mock_user.role_names = {RoleEnum.ANALYST}

--- a/backend/lcfs/web/api/ci_application/schema.py
+++ b/backend/lcfs/web/api/ci_application/schema.py
@@ -25,12 +25,11 @@ from pydantic import (
 
 from lcfs.services.s3.schema import FileResponseSchema
 from lcfs.web.api.base import BaseSchema, PaginationResponseSchema
-from lcfs.web.api.fuel_type.schema import FuelTypeQuantityUnitsEnumSchema
 from lcfs.web.api.fuel_code.schema import (
     CoProcessedEnumSchema,
     FuelTypeQuantityUnitsEnumSchema,
 )
-
+from lcfs.web.api.fuel_type.schema import FuelTypeQuantityUnitsEnumSchema
 
 # ---------------------------------------------------------------------------
 # Enums (mirror the seeded lookup values in the migration)
@@ -370,6 +369,7 @@ class CIApplicationBaseSchema(BaseSchema):
     facility_nameplate_capacity_unit: Optional[str] = None
     proposed_fuel_code_effective_date: Optional[date] = None
     pathway_supplemental_edit_enabled: bool = False
+    document_upload_enabled: bool = False
     preliminary_risk_assessment: Optional[CIRiskAssessmentEnum] = None
     priority_score: Optional[int] = None
     assigned_analyst: Optional[CIApplicationUserSchema] = None
@@ -404,6 +404,9 @@ class CIApplicationSchema(BaseSchema):
     pathway_supplemental_edit_enabled: bool = False
     pathway_changes_requested_at: Optional[datetime] = None
     pathway_changes_requested_by: Optional[str] = None
+    document_upload_enabled: bool = False
+    document_changes_requested_at: Optional[datetime] = None
+    document_changes_requested_by: Optional[str] = None
     pathway_changelog: List[Dict[str, Any]] = Field(default_factory=list)
     pathway_change_logs: List[PathwayChangeLogSchema] = Field(default_factory=list)
     generated_fuel_codes: List[CIGeneratedFuelCodeSchema] = Field(default_factory=list)

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 from fastapi import Depends, HTTPException, status
+from pydantic.alias_generators import to_camel
 
 from lcfs.db.base import ActionTypeEnum
 from lcfs.db.models import UserProfile
@@ -69,7 +70,6 @@ from lcfs.web.exception.exceptions import (
     DataNotFoundException,
     ValidationErrorException,
 )
-from pydantic.alias_generators import to_camel
 
 # pathway_application_type.type values seeded by the migration
 PATHWAY_APPLICATION_TYPE_NEW = "New"
@@ -526,6 +526,13 @@ def _to_full_schema(
         ),
         pathway_changes_requested_at=getattr(ci, "pathway_changes_requested_at", None),
         pathway_changes_requested_by=getattr(ci, "pathway_changes_requested_by", None),
+        document_upload_enabled=bool(getattr(ci, "document_upload_enabled", False)),
+        document_changes_requested_at=getattr(
+            ci, "document_changes_requested_at", None
+        ),
+        document_changes_requested_by=getattr(
+            ci, "document_changes_requested_by", None
+        ),
         pathway_changelog=[
             history.ci_application_snapshot
             for history in (getattr(ci, "history_records", None) or [])
@@ -653,6 +660,7 @@ def _to_list_item(
         pathway_supplemental_edit_enabled=bool(
             getattr(ci, "pathway_supplemental_edit_enabled", False)
         ),
+        document_upload_enabled=bool(getattr(ci, "document_upload_enabled", False)),
         preliminary_risk_assessment=getattr(ci, "preliminary_risk_assessment", None),
         update_date=ci.update_date.isoformat() if ci.update_date else None,
         create_date=ci.create_date.isoformat() if ci.create_date else None,
@@ -876,9 +884,7 @@ class CIApplicationServices:
         # field-level validation error the grid renders inline; genuinely
         # nullable fields fall through and are flagged by the row validator.
         non_nullable_columns = {
-            column.name
-            for column in FuelCode.__table__.columns
-            if not column.nullable
+            column.name for column in FuelCode.__table__.columns if not column.nullable
         }
         cleared_required = [
             field
@@ -1683,6 +1689,44 @@ class CIApplicationServices:
             ci_application,
             snapshot={
                 "event": "pathway_changes_requested",
+                "changed_at": requested_at.isoformat(),
+                "changed_by": user.keycloak_username,
+            },
+        )
+
+        ci = await self.repo.get_by_id(ci_application.ci_application_id)
+        return await self._to_full_schema_with_user(ci)
+
+    @service_handler
+    async def request_documentation(
+        self,
+        ci_application: CIApplication,
+        user: UserProfile,
+    ) -> CIApplicationSchema:
+        """Open additional-document uploads on a submitted application so the
+        supplier can attach files the analyst requested (#4644). Mirrors
+        ``request_pathway_changes``."""
+        if not _user_has_any_role(
+            user,
+            [RoleEnum.ANALYST, RoleEnum.COMPLIANCE_MANAGER, RoleEnum.DIRECTOR],
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only internal users can request additional documentation.",
+            )
+        self._require_submitted_workflow(ci_application)
+
+        requested_at = datetime.now(timezone.utc)
+        ci_application.document_upload_enabled = True
+        ci_application.document_changes_requested_at = requested_at
+        ci_application.document_changes_requested_by = user.keycloak_username
+        ci_application.update_user = user.keycloak_username
+        ci_application.action_type = ActionTypeEnum.UPDATE
+        await self.repo.update(ci_application)
+        await self.repo.add_history(
+            ci_application,
+            snapshot={
+                "event": "documentation_requested",
                 "changed_at": requested_at.isoformat(),
                 "changed_by": user.keycloak_username,
             },

--- a/backend/lcfs/web/api/ci_application/views.py
+++ b/backend/lcfs/web/api/ci_application/views.py
@@ -484,6 +484,29 @@ async def request_ci_application_pathway_changes(
 
 
 @router.post(
+    "/{ci_application_id}/request-documentation",
+    response_model=CIApplicationSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(
+    [
+        RoleEnum.GOVERNMENT,
+        RoleEnum.ANALYST,
+        RoleEnum.COMPLIANCE_MANAGER,
+        RoleEnum.DIRECTOR,
+    ]
+)
+async def request_ci_application_documentation(
+    request: Request,
+    ci_application_id: int,
+    service: CIApplicationServices = Depends(),
+    validate: CIApplicationValidation = Depends(),
+) -> CIApplicationSchema:
+    ci = await validate.validate_access(ci_application_id)
+    return await service.request_documentation(ci, request.user)
+
+
+@router.post(
     "/{ci_application_id}/fuel-codes/generate",
     response_model=CIApplicationSchema,
     status_code=status.HTTP_200_OK,

--- a/frontend/src/assets/locales/en/carbonIntensity.json
+++ b/frontend/src/assets/locales/en/carbonIntensity.json
@@ -154,6 +154,8 @@
     "verification2Complete": "Verification 2 complete",
     "generateFuelCodes": "Generate fuel codes",
     "requestDocumentation": "Request further documentation",
+    "requestDocumentationConfirmTitle": "Request further documentation?",
+    "requestDocumentationConfirmText": "This lets the applicant upload additional documents for this application. Do you want to continue?",
     "requestPathwayChanges": "Request pathway changes",
     "recommendToDirector": "Recommend to director",
     "approveBtn": "Approve",

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -103,6 +103,8 @@ export const apiRoutes = {
   recommendCIApplication: '/ci-applications/:ciApplicationId/recommend',
   requestCIApplicationPathwayChanges:
     '/ci-applications/:ciApplicationId/request-pathway-changes',
+  requestCIApplicationDocumentation:
+    '/ci-applications/:ciApplicationId/request-documentation',
   generateCIApplicationFuelCodes:
     '/ci-applications/:ciApplicationId/fuel-codes/generate',
   updateCIApplicationGeneratedFuelCode:

--- a/frontend/src/hooks/useCIApplication.ts
+++ b/frontend/src/hooks/useCIApplication.ts
@@ -385,6 +385,30 @@ export const useRequestCIApplicationPathwayChanges = (
   })
 }
 
+export const useRequestCIApplicationDocumentation = (
+  ciApplicationId: number | string | undefined | null
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      return (
+        await client.post(
+          apiRoutes.requestCIApplicationDocumentation.replace(
+            ':ciApplicationId',
+            String(ciApplicationId ?? '')
+          ),
+          {}
+        )
+      ).data
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ci-applications'] })
+      queryClient.setQueryData(QUERY_KEYS.detail(ciApplicationId), data)
+    }
+  })
+}
+
 export const useGenerateCIApplicationFuelCodes = (
   ciApplicationId: number | string | undefined | null
 ) => {

--- a/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
+++ b/frontend/src/views/CarbonIntensity/EditViewCIApplication.jsx
@@ -338,6 +338,12 @@ const EditViewCIApplicationBase = () => {
     !isGovernment &&
     ciApplication?.status?.status === 'Submitted' &&
     !!ciApplication?.pathwaySupplementalEditEnabled
+  // After an analyst requests further documentation, the BCeID supplier may
+  // upload additional documents to their submitted application (#4644).
+  const canSupplementallyEditDocuments =
+    !isGovernment &&
+    ciApplication?.status?.status === 'Submitted' &&
+    !!ciApplication?.documentUploadEnabled
 
   // Hooks must run on every render — keep this above the loading-state
   // early return so hook order stays stable across renders.
@@ -408,7 +414,6 @@ const EditViewCIApplicationBase = () => {
         ciApplication={ciApplicationWithSupplierRequest}
         isGovernment={isGovernment}
         readOnly={isDecisionReadOnly}
-        onDocumentUploadClick={() => setIsDocumentEditorOpen(true)}
         onSupplierRequest={() =>
           setSupplierRequestDate(new Date().toISOString())
         }
@@ -547,7 +552,9 @@ const EditViewCIApplicationBase = () => {
                 <ApplicationSummary
                   ciApplication={ciApplication}
                   currentUser={currentUser}
-                  canEditDocuments={canManageSummaryDocuments}
+                  canEditDocuments={
+                    canManageSummaryDocuments || canSupplementallyEditDocuments
+                  }
                   onEditDocuments={() => setIsDocumentEditorOpen(true)}
                   canEditPathways={canSupplementallyEditPathways}
                   pathwayEditorOptionsData={tableOptions}

--- a/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
@@ -5,7 +5,8 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor
+  waitFor,
+  within
 } from '@testing-library/react'
 
 import { roles } from '@/constants/roles'
@@ -532,7 +533,48 @@ describe('GovernmentDecisionStep', () => {
     ).not.toBeDisabled()
   })
 
-  it('requests additional documentation, enabling supplier uploads (#4644)', async () => {
+  it('opens a confirmation on click without firing the request or disabling the button (#4651)', () => {
+    mockUserRoles = [{ name: roles.analyst }]
+    render(
+      <GovernmentDecisionStep
+        ciApplication={baseCi}
+        isGovernment={true}
+        onSupplierRequest={vi.fn()}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('ci-request-documentation-btn'))
+
+    expect(screen.getByTestId('modal')).toBeInTheDocument()
+    expect(mockRequestDocumentation).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('ci-request-documentation-btn')
+    ).not.toBeDisabled()
+  })
+
+  it('leaves the button enabled after cancelling the confirmation (#4651)', () => {
+    mockUserRoles = [{ name: roles.analyst }]
+    render(
+      <GovernmentDecisionStep
+        ciApplication={baseCi}
+        isGovernment={true}
+        onSupplierRequest={vi.fn()}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('ci-request-documentation-btn'))
+    const modal = screen.getByTestId('modal')
+    fireEvent.click(within(modal).getByText('common:cancelBtn'))
+
+    expect(mockRequestDocumentation).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('ci-request-documentation-btn')
+    ).not.toBeDisabled()
+  })
+
+  it('requests documentation and disables the button after confirming (#4644)', async () => {
     mockUserRoles = [{ name: roles.analyst }]
     const onSupplierRequest = vi.fn()
     render(
@@ -545,13 +587,15 @@ describe('GovernmentDecisionStep', () => {
     )
 
     fireEvent.click(screen.getByTestId('ci-request-documentation-btn'))
+    const modal = screen.getByTestId('modal')
+    fireEvent.click(
+      within(modal).getByText('carbonIntensity:step5.requestDocumentation')
+    )
 
     await waitFor(() =>
       expect(mockRequestDocumentation).toHaveBeenCalledTimes(1)
     )
     expect(onSupplierRequest).toHaveBeenCalledWith('documentation')
-    // Like the pathway request, the button disables once documentation is
-    // requested so it cannot be re-triggered.
     expect(screen.getByTestId('ci-request-documentation-btn')).toBeDisabled()
   })
 

--- a/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
@@ -20,6 +20,7 @@ const mockCompleteVerification1 = vi.fn().mockResolvedValue(null)
 const mockCompleteVerification2 = vi.fn().mockResolvedValue(null)
 const mockRecommendToDirector = vi.fn().mockResolvedValue(null)
 const mockRequestPathwayChanges = vi.fn().mockResolvedValue(null)
+const mockRequestDocumentation = vi.fn().mockResolvedValue(null)
 const mockGenerateFuelCodes = vi.fn().mockResolvedValue(null)
 
 vi.mock('@/hooks/useCIApplication', () => ({
@@ -37,6 +38,10 @@ vi.mock('@/hooks/useCIApplication', () => ({
   })),
   useRequestCIApplicationPathwayChanges: vi.fn(() => ({
     mutateAsync: mockRequestPathwayChanges,
+    isPending: false
+  })),
+  useRequestCIApplicationDocumentation: vi.fn(() => ({
+    mutateAsync: mockRequestDocumentation,
     isPending: false
   })),
   useGenerateCIApplicationFuelCodes: vi.fn(() => ({
@@ -527,15 +532,13 @@ describe('GovernmentDecisionStep', () => {
     ).not.toBeDisabled()
   })
 
-  it('opens the documentation modal and records supplier wait start without disabling the button', async () => {
+  it('requests additional documentation, enabling supplier uploads (#4644)', async () => {
     mockUserRoles = [{ name: roles.analyst }]
-    const onDocumentUploadClick = vi.fn()
     const onSupplierRequest = vi.fn()
     render(
       <GovernmentDecisionStep
         ciApplication={baseCi}
         isGovernment={true}
-        onDocumentUploadClick={onDocumentUploadClick}
         onSupplierRequest={onSupplierRequest}
       />,
       { wrapper }
@@ -543,14 +546,13 @@ describe('GovernmentDecisionStep', () => {
 
     fireEvent.click(screen.getByTestId('ci-request-documentation-btn'))
 
-    // Opening the modal is not a completed action, so the button stays enabled
-    // and remains clickable after the modal is cancelled (#4651).
-    expect(screen.getByTestId('ci-request-documentation-btn')).not.toBeDisabled()
-    expect(
-      screen.getByTestId('ci-request-pathway-changes-btn')
-    ).not.toBeDisabled()
-    expect(onDocumentUploadClick).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(mockRequestDocumentation).toHaveBeenCalledTimes(1)
+    )
     expect(onSupplierRequest).toHaveBeenCalledWith('documentation')
+    // Like the pathway request, the button disables once documentation is
+    // requested so it cannot be re-triggered.
+    expect(screen.getByTestId('ci-request-documentation-btn')).toBeDisabled()
   })
 
   it('can render only the decision panel for the submitted application page layout', () => {

--- a/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
+++ b/frontend/src/views/CarbonIntensity/components/CIApplicationProgress.jsx
@@ -44,10 +44,8 @@ const daysSince = (date) => {
 
 const getSupplierRequestDate = (ciApplication) =>
   ciApplication?.supplierRequestDate ||
-  ciApplication?.requestFurtherDocumentationDate ||
-  ciApplication?.requestDocumentationDate ||
-  ciApplication?.pathwayChangesRequestedAt ||
-  ciApplication?.pathwayChangesRequestedDate
+  ciApplication?.documentChangesRequestedAt ||
+  ciApplication?.pathwayChangesRequestedAt
 
 const riskLabel = (risk) => (risk === 'Medium' ? 'Moderate' : risk)
 

--- a/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
+++ b/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
@@ -12,6 +12,7 @@ import {
 
 import BCAlert from '@/components/BCAlert'
 import BCButton from '@/components/BCButton'
+import BCModal from '@/components/BCModal'
 import BCTypography from '@/components/BCTypography'
 import Comments from '@/components/Comments'
 import { Role } from '@/components/Role'
@@ -92,6 +93,10 @@ export const GovernmentDecisionStep = ({
   )
   const [requestedPathwayChanges, setRequestedPathwayChanges] = useState(false)
   const [requestedDocumentation, setRequestedDocumentation] = useState(false)
+  const [
+    isRequestDocumentationConfirmOpen,
+    setIsRequestDocumentationConfirmOpen
+  ] = useState(false)
   const [priorityScoreTouched, setPriorityScoreTouched] = useState(false)
   const [
     priorityScoreVerificationAttempted,
@@ -229,9 +234,17 @@ export const GovernmentDecisionStep = ({
   }
 
   const handleRequestDocumentation = () => {
+    // Ask the analyst to confirm the request rather than opening the upload
+    // utility or firing silently (#4651). Cancelling leaves the button enabled;
+    // only confirming performs the action and disables it.
+    setIsRequestDocumentationConfirmOpen(true)
+  }
+
+  const confirmRequestDocumentation = () => {
     // Enable additional-document uploads for the supplier on the submitted
     // application (#4644), mirroring the pathway-changes request. Persists
     // document_upload_enabled so the BCeID user gets an upload path.
+    setIsRequestDocumentationConfirmOpen(false)
     setRequestedDocumentation(true)
     onSupplierRequest?.('documentation')
     recordWorkflowAction(
@@ -618,6 +631,21 @@ export const GovernmentDecisionStep = ({
           )}
         </Box>
       )}
+      <BCModal
+        open={isRequestDocumentationConfirmOpen}
+        onClose={() => setIsRequestDocumentationConfirmOpen(false)}
+        data={{
+          title: t('carbonIntensity:step5.requestDocumentationConfirmTitle'),
+          primaryButtonText: t('carbonIntensity:step5.requestDocumentation'),
+          primaryButtonAction: confirmRequestDocumentation,
+          secondaryButtonText: t('common:cancelBtn'),
+          content: (
+            <BCTypography variant="body1">
+              {t('carbonIntensity:step5.requestDocumentationConfirmText')}
+            </BCTypography>
+          )
+        }}
+      />
     </Box>
   )
 }

--- a/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
+++ b/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
@@ -23,6 +23,7 @@ import {
   useGenerateCIApplicationFuelCodes,
   useRecommendCIApplication,
   useRequestCIApplicationPathwayChanges,
+  useRequestCIApplicationDocumentation,
   useRecordCIDecision
 } from '@/hooks/useCIApplication'
 import colors from '@/themes/base/colors'
@@ -31,7 +32,6 @@ type GovernmentDecisionStepProps = {
   ciApplication: any
   isGovernment?: boolean
   readOnly?: boolean
-  onDocumentUploadClick?: (() => void) | null
   onSupplierRequest?:
     | ((requestType: 'documentation' | 'pathwayChanges') => void)
     | null
@@ -45,7 +45,6 @@ export const GovernmentDecisionStep = ({
   ciApplication,
   isGovernment = false,
   readOnly = false,
-  onDocumentUploadClick = null,
   onSupplierRequest = null,
   showDecisionPanel = true,
   showComments = true,
@@ -68,6 +67,10 @@ export const GovernmentDecisionStep = ({
     mutateAsync: requestPathwayChanges,
     isPending: isRequestingPathwayChanges
   } = useRequestCIApplicationPathwayChanges(ciApplicationId)
+  const {
+    mutateAsync: requestDocumentation,
+    isPending: isRequestingDocumentation
+  } = useRequestCIApplicationDocumentation(ciApplicationId)
   const { mutateAsync: generateFuelCodes, isPending: isGeneratingFuelCodes } =
     useGenerateCIApplicationFuelCodes(ciApplicationId)
 
@@ -88,6 +91,7 @@ export const GovernmentDecisionStep = ({
     ciApplication?.priorityScore || ''
   )
   const [requestedPathwayChanges, setRequestedPathwayChanges] = useState(false)
+  const [requestedDocumentation, setRequestedDocumentation] = useState(false)
   const [priorityScoreTouched, setPriorityScoreTouched] = useState(false)
   const [
     priorityScoreVerificationAttempted,
@@ -225,11 +229,15 @@ export const GovernmentDecisionStep = ({
   }
 
   const handleRequestDocumentation = () => {
-    // Opening the document request modal is not a completed action, so the
-    // button must stay enabled — cancelling the modal should leave it clickable
-    // (#4651). The modal overlay already prevents re-triggering while open.
+    // Enable additional-document uploads for the supplier on the submitted
+    // application (#4644), mirroring the pathway-changes request. Persists
+    // document_upload_enabled so the BCeID user gets an upload path.
+    setRequestedDocumentation(true)
     onSupplierRequest?.('documentation')
-    onDocumentUploadClick?.()
+    recordWorkflowAction(
+      () => requestDocumentation(),
+      t('carbonIntensity:step5.workflowSuccess')
+    )
   }
 
   const handleRequestPathwayChanges = () => {
@@ -501,7 +509,12 @@ export const GovernmentDecisionStep = ({
                     variant="outlined"
                     color="primary"
                     sx={workflowButtonSx}
-                    disabled={readOnly}
+                    disabled={
+                      readOnly ||
+                      requestedDocumentation ||
+                      !!ciApplication?.documentUploadEnabled ||
+                      isRequestingDocumentation
+                    }
                     onClick={handleRequestDocumentation}
                     data-test="ci-request-documentation-btn"
                   >


### PR DESCRIPTION
## Summary

Fixes **#4644** (BCeID suppliers can't upload documents after an analyst requests more information) and **#4651** (the "Request further documentation" button opened the wrong modal / disabled itself after cancel).

## #4644 — supplier upload path

The analyst's "Request further documentation" persisted nothing and the document editor was government-only, so the supplier had no way to upload. Adds a persisted request-documentation flow mirroring the pathway-changes request:
- Migration `e7f8a9b0c1d2` + model: `document_upload_enabled`, `document_changes_requested_at/by` on `ci_application`.
- `request_documentation` service (analyst/manager/director, submitted workflow, history entry) + `POST /ci-applications/{id}/request-documentation`.
- `useRequestCIApplicationDocumentation` hook; `canSupplementallyEditDocuments` enables the supplier's summary edit icon → document editor → upload on a submitted application once documentation is requested.

## #4651 — confirmation instead of the upload utility

Clicking "Request further documentation" opened the document **upload utility** and disabled the button even when cancelled. It now opens a small **confirmation dialog**:
- **Cancel** → closes, button stays enabled, nothing happens.
- **Confirm** → performs the request-documentation action (above) and disables the button.

(#4695 previously addressed only the button-disable symptom; this supersedes it by removing the wrong modal and gating the action behind a confirmation. airinggov's follow-up — "it should just confirm the action but is pulling up an upload utility" — is fixed.)

## Notes
- Supplier **notification** remains a separate follow-up (CI applications have no notification wiring yet).
- Branch merged up to current develop; migration re-pointed onto the current head (`d4e5f6a7b8c9`) so there's a single alembic head.

## Testing
- Backend `pytest lcfs/tests/ci_application` — 95 passed (incl. `request_documentation` role/status guards). Single alembic head; column DDL applies cleanly against Postgres.
- Frontend `vitest` — GovernmentDecisionStep (31) + EditViewCIApplication (12) pass, incl. new cases: click opens the confirmation without firing/disabling, cancel leaves the button enabled (#4651), confirm fires the request and disables (#4644).
- Not browser-verified (spans an analyst action + a BCeID login on a submitted application, behind Keycloak).
