### PR TITLE
Wrap organization menu tabs so all sections stay visible

### DIFF
--- a/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { AppBar, Tab, Tabs } from '@mui/material'
 import BCBox from '@/components/BCBox'
 import BCAlert from '@/components/BCAlert'
 import BCTypography from '@/components/BCTypography'
@@ -15,7 +14,9 @@ import ComplianceTracking from './components/ComplianceTracking'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { roles } from '@/constants/roles'
 import { ROUTES } from '@/routes/routes'
-import breakpoints from '@/themes/base/breakpoints'
+import colors from '@/themes/base/colors'
+import borders from '@/themes/base/borders'
+import boxShadows from '@/themes/base/boxShadows'
 import {
   orgDashboardRenderers,
   orgDashboardRoutes
@@ -37,8 +38,6 @@ function TabPanel({ children, value, index }) {
 }
 
 export const OrganizationView = ({ addMode = false }) => {
-  const [tabsOrientation, setTabsOrientation] = useState('horizontal')
-
   const location = useLocation()
   const navigate = useNavigate()
   const { orgID } = useParams()
@@ -97,18 +96,6 @@ export const OrganizationView = ({ addMode = false }) => {
     })
     return matchIndex >= 0 ? matchIndex : 0
   }, [location.pathname, tabConfig])
-
-  useEffect(() => {
-    // A function that sets the orientation state of the tabs.
-    function handleTabsOrientation() {
-      return window.innerWidth < breakpoints.values.lg
-        ? setTabsOrientation('vertical')
-        : setTabsOrientation('horizontal')
-    }
-    window.addEventListener('resize', handleTabsOrientation)
-    handleTabsOrientation()
-    return () => window.removeEventListener('resize', handleTabsOrientation)
-  }, [tabsOrientation])
 
   const handleTabChange = (event, newValue) => {
     const targetPath = tabConfig[newValue]?.path
@@ -175,36 +162,69 @@ export const OrganizationView = ({ addMode = false }) => {
       )}
 
       <BCBox sx={{ mt: 0, bgcolor: 'background.paper' }}>
-        <AppBar
-          position="static"
-          sx={{ boxShadow: 'none', border: 'none', width: 'fit-content' }}
+        {/* Section navigation. A wrapping flex row (not MUI <Tabs>, which is a
+            single scrollable row) so every section stays visible at any width —
+            tabs fold onto additional rows instead of being clipped. */}
+        <BCBox
+          role="tablist"
+          aria-label="Organization tabs"
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            p: '4px',
+            width: '100%',
+            maxWidth: '100%',
+            boxSizing: 'border-box',
+            backgroundColor: colors.grey[100],
+            borderRadius: borders.borderRadius.xl
+          }}
         >
-          <Tabs
-            orientation={tabsOrientation}
-            value={tabIndex}
-            onChange={handleTabChange}
-            aria-label="Organization tabs"
-            sx={{
-              background: 'rgba(0, 0, 0, 0.08)',
-              maxWidth: '100%',
-              '& .MuiTab-root': {
-                minWidth: 'auto',
-                paddingX: 2,
-                marginX: 1,
-                whiteSpace: 'nowrap'
-              },
-              '& .MuiTabs-flexContainer': {
-                flexWrap: 'nowrap'
-              }
-            }}
-            variant="scrollable"
-            scrollButtons="auto"
-          >
-            {tabConfig.map((config, idx) => (
-              <Tab key={config.path} label={config.label} />
-            ))}
-          </Tabs>
-        </AppBar>
+          {tabConfig.map((config, idx) => {
+            const selected = idx === tabIndex
+            return (
+              <BCBox
+                key={config.path}
+                component="button"
+                type="button"
+                role="tab"
+                id={`organization-tab-${idx}`}
+                aria-selected={selected}
+                aria-controls={`organization-tabpanel-${idx}`}
+                onClick={() => handleTabChange(null, idx)}
+                sx={{
+                  border: 'none',
+                  cursor: 'pointer',
+                  font: 'inherit',
+                  fontSize: '0.875rem',
+                  fontWeight: selected ? 700 : 500,
+                  whiteSpace: 'nowrap',
+                  px: 2,
+                  py: 1,
+                  borderRadius: borders.borderRadius.lg,
+                  color: colors.text.primary,
+                  backgroundColor: selected ? colors.white.main : 'transparent',
+                  boxShadow: selected
+                    ? boxShadows.tabsBoxShadow.indicator
+                    : 'none',
+                  transition:
+                    'background-color 200ms ease, box-shadow 200ms ease',
+                  '&:hover': {
+                    backgroundColor: selected
+                      ? colors.white.main
+                      : 'rgba(0, 0, 0, 0.06)'
+                  },
+                  '&:focus-visible': {
+                    outline: `2px solid ${colors.primary.main}`,
+                    outlineOffset: '-2px'
+                  }
+                }}
+              >
+                {config.label}
+              </BCBox>
+            )
+          })}
+        </BCBox>
         {organizationTitle && (
           <BCTypography variant="h5" color="primary" mt={3}>
             {organizationTitle}

--- a/frontend/src/views/Organizations/OrganizationView/__tests__/OrganizationView.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/__tests__/OrganizationView.test.jsx
@@ -375,47 +375,17 @@ describe('OrganizationView', () => {
     })
   })
 
-  describe('Window Resize Handling', () => {
-    it('adds resize event listener on mount', () => {
-      renderComponent()
-
-      expect(global.addEventListener).toHaveBeenCalledWith(
-        'resize',
-        expect.any(Function)
-      )
-    })
-
-    it('removes resize event listener on unmount', () => {
-      const { unmount } = renderComponent()
-
-      unmount()
-
-      expect(global.removeEventListener).toHaveBeenCalledWith(
-        'resize',
-        expect.any(Function)
-      )
-    })
-
-    it('handles window resize events', () => {
-      Object.defineProperty(window, 'innerWidth', {
-        value: 400,
-        configurable: true
-      })
-
-      let resizeHandler
-      global.addEventListener = vi.fn((event, handler) => {
-        if (event === 'resize') resizeHandler = handler
-      })
-
-      renderComponent()
-
-      // Just verify the handler exists, don't trigger it
-      expect(resizeHandler).toBeDefined()
-      expect(typeof resizeHandler).toBe('function')
-    })
-  })
-
   describe('Tab Navigation', () => {
+    it('renders every section as a tab so none are clipped/hidden', () => {
+      renderComponent()
+
+      const tabs = screen.getAllByRole('tab')
+      expect(tabs.length).toBeGreaterThan(1)
+      ;['Dashboard', 'Users', 'Credit ledger'].forEach((label) => {
+        expect(screen.getByRole('tab', { name: label })).toBeInTheDocument()
+      })
+    })
+
     it('changes tab when handleChangeTab is called', () => {
       renderComponent()
 


### PR DESCRIPTION
## Summary

Follow-up to #4727 (which restored the organization section tab row for government users). That restored the MUI `<Tabs variant="scrollable">` navigation, which is a **single row** — so on mid-range browser widths the later sections (e.g. "Comment log") are still **clipped**.

This replaces it with a **flex-wrap tab bar** so the sections fold onto additional rows and **every section stays visible at any width** — no horizontal clipping.

## Changes

`OrganizationView.jsx`:
- Replaced MUI `<Tabs>`/`<Tab>` with a `display:flex; flexWrap:wrap` bar of `role="tab"` buttons. The selected tab carries the white rounded highlight itself (MUI's single sliding indicator can't track a selected tab across wrapped rows), reusing the existing theme tokens (grey bar, `borderRadius.xl/lg`, `tabsBoxShadow.indicator`) so the look is unchanged.
- Dropped the now-unneeded responsive vertical-orientation resize handling (wrapping covers narrow widths).

## Testing
- `vitest` on `OrganizationView` — 21 passed, incl. a new case asserting every section renders as a tab (none dropped) and the existing navigation tests.
- Not live-browser-verified (the IDIR org view is behind Keycloak). `flexWrap: 'wrap'` is a layout guarantee — items wrap to new rows when they don't fit — so all tabs remain visible by construction.
