### PR TITLE
Restore original organization menu styling (keep wrapping)

### DIFF
--- a/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/OrganizationView.jsx
@@ -173,10 +173,13 @@ export const OrganizationView = ({ addMode = false }) => {
             flexWrap: 'wrap',
             gap: '4px',
             p: '4px',
-            width: '100%',
+            // Shrink to the tabs' width (compact pill, matching the original
+            // look) but wrap onto more rows once they exceed the available
+            // width instead of clipping.
+            width: 'fit-content',
             maxWidth: '100%',
             boxSizing: 'border-box',
-            backgroundColor: colors.grey[100],
+            background: 'rgba(0, 0, 0, 0.08)',
             borderRadius: borders.borderRadius.xl
           }}
         >
@@ -216,7 +219,7 @@ export const OrganizationView = ({ addMode = false }) => {
                   },
                   '&:focus-visible': {
                     outline: `2px solid ${colors.primary.main}`,
-                    outlineOffset: '-2px'
+                    outlineOffset: '2px'
                   }
                 }}
               >


### PR DESCRIPTION
## Summary

Follow-up to #4728 (which made the organization section tabs wrap instead of clip). The wrapping bar changed the look — a full-width bar with a lighter grey background and an inset focus outline that made the active tab appear bordered. This restores the original styling while keeping the wrapping.

## Changes

`OrganizationView.jsx` (nav container + selected-tab styling):
- `width: fit-content` instead of `100%` — a compact pill that still wraps onto more rows once the tabs exceed the available width.
- Background back to `rgba(0, 0, 0, 0.08)` (the original shade) instead of `grey[100]`.
- Focus ring moved outside the tab (`outlineOffset: 2px`) so the selected tab no longer looks bordered; it keeps the soft white active highlight.

## Testing
- `vitest` on `OrganizationView` — 21 passed.
- Verified with an exact-CSS reproduction at wide (compact pill, one row) and narrow (wraps to a second row, nothing clipped) widths. Not driven in the live IDIR view (Keycloak-gated).
