### PR TITLE
Move CI delete draft button right (#4770); make Company Overview comments internal only

### DIFF
--- a/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
@@ -231,6 +231,9 @@ def _build_service_with_user_roles(role_names):
     service.repo.get_category_id_by_name = AsyncMock(return_value=99)
     service.repo.get_entity_org_and_year = AsyncMock(return_value=(7, 2025))
     service.repo.get_comments_for_organization = AsyncMock()
+    # Most comments are not Company Overview notes; tests that need the
+    # organization-comment path override this.
+    service.repo.is_organization_comment = AsyncMock(return_value=False)
     return service
 
 
@@ -394,6 +397,72 @@ async def test_update_internal_comment_non_gov_clamps_to_public():
     assert call_kwargs["visibility"] == CommentVisibilityEnum.PUBLIC.value
     assert call_kwargs["audience_scope"] is None
     assert call_kwargs["new_comment_text"] == "updated text"
+
+
+@pytest.mark.anyio
+async def test_create_organization_comment_is_forced_internal():
+    """
+    Company Overview notes have no public option in the UI; the service pins
+    the visibility so a client cannot file one as Public (#4608).
+    """
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.create_internal_comment.return_value = SimpleNamespace(
+        internal_comment_id=101,
+        comment="Overview note",
+        audience_scope="Analyst",
+        visibility="Internal",
+        create_user="mockuser",
+        create_date=None,
+        update_date=None,
+        full_name="Mock User",
+    )
+    payload = InternalCommentCreateSchema(
+        entity_type=EntityTypeEnum.ORGANIZATION,
+        entity_id=7,
+        comment="Overview note",
+        visibility=CommentVisibilityEnum.PUBLIC,
+    )
+
+    await service.create_internal_comment(payload)
+
+    service.repo.create_internal_comment.assert_awaited_once()
+    created_comment_arg = service.repo.create_internal_comment.await_args.args[0]
+    assert created_comment_arg.visibility == CommentVisibilityEnum.INTERNAL
+    # Internal comments still need an audience scope, resolved from the role.
+    assert created_comment_arg.audience_scope == AudienceScopeEnum.ANALYST
+
+
+@pytest.mark.anyio
+async def test_update_organization_comment_cannot_be_flipped_to_public():
+    """An edit cannot turn a Company Overview note public (#4608)."""
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.is_organization_comment = AsyncMock(return_value=True)
+    service.repo.get_internal_comment_by_id.return_value = SimpleNamespace(
+        internal_comment_id=11,
+        comment="existing",
+        audience_scope="Analyst",
+        visibility="Internal",
+    )
+    service.repo.update_internal_comment.return_value = SimpleNamespace(
+        internal_comment_id=11,
+        comment="updated",
+        audience_scope="Analyst",
+        visibility="Internal",
+        create_user="mockuser",
+        create_date=None,
+        update_date=None,
+        full_name="Mock User",
+    )
+    payload = InternalCommentUpdateSchema(
+        comment="updated",
+        visibility=CommentVisibilityEnum.PUBLIC,  # smuggled — service ignores
+    )
+
+    await service.update_internal_comment(11, payload)
+
+    call_kwargs = service.repo.update_internal_comment.await_args.kwargs
+    assert call_kwargs["visibility"] == CommentVisibilityEnum.INTERNAL.value
+    assert call_kwargs["audience_scope"] == AudienceScopeEnum.ANALYST.value
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -489,6 +489,19 @@ class InternalCommentRepository:
         return result.scalar_one_or_none()
 
     @repo_handler
+    async def is_organization_comment(self, internal_comment_id: int) -> bool:
+        """
+        True when the comment is an ORGANIZATION-entity comment (a Company
+        Overview note), identified by its association row.
+        """
+        result = await self.db.execute(
+            select(OrganizationInternalComment.internal_comment_id).where(
+                OrganizationInternalComment.internal_comment_id == internal_comment_id
+            )
+        )
+        return result.scalar_one_or_none() is not None
+
+    @repo_handler
     async def get_entity_org_and_year(
         self, entity_type: EntityTypeEnum, entity_id: int
     ) -> Tuple[Optional[int], Optional[int]]:

--- a/backend/lcfs/web/api/internal_comment/services.py
+++ b/backend/lcfs/web/api/internal_comment/services.py
@@ -144,6 +144,12 @@ class InternalCommentService:
         """
         is_government_user = self._is_government_user()
 
+        # Company Overview notes are internal working notes — the thread offers
+        # no public commenting, so pin the visibility here rather than trusting
+        # the client to send it (#4608).
+        if data.entity_type == EntityTypeEnum.ORGANIZATION:
+            data.visibility = CommentVisibilityEnum.INTERNAL
+
         # Keep legacy behavior for existing entities and enforce CI-specific visibility rules.
         if not is_government_user:
             if data.entity_type not in (
@@ -279,6 +285,11 @@ class InternalCommentService:
                 next_audience_scope = AudienceScopeEnum(
                     str(existing_comment.audience_scope)
                 )
+
+        # A Company Overview note can never be flipped to public by an edit,
+        # whatever the payload asks for (#4608).
+        if await self.repo.is_organization_comment(internal_comment_id):
+            next_visibility = CommentVisibilityEnum.INTERNAL
 
         if next_visibility == CommentVisibilityEnum.PUBLIC:
             next_audience_scope = None

--- a/frontend/src/views/CarbonIntensity/components/ApplicationInformationStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ApplicationInformationStep.jsx
@@ -381,7 +381,14 @@ export const ApplicationInformationStep = forwardRef(
           </Grid2>
         </Grid2>
 
-        <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+        {/* Delete sits far right, away from the primary action (#4770). */}
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{ mt: 2 }}
+          alignItems="center"
+          justifyContent="space-between"
+        >
           <BCButton
             type="submit"
             variant="contained"

--- a/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/DocumentsModellingStep.jsx
@@ -242,8 +242,15 @@ export const DocumentsModellingStep = ({
         sx={{ mb: 4 }}
       />
 
+      {/* Delete sits far right, away from the primary action (#4770). */}
       {showSaveControls && (
-        <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{ mt: 2 }}
+          alignItems="center"
+          justifyContent="space-between"
+        >
           <BCButton
             type="button"
             variant="contained"

--- a/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/ProposedFuelPathwaysStep.jsx
@@ -236,19 +236,30 @@ export const ProposedFuelPathwaysStep = ({
         />
       </Box>
 
-      <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
-        <BCButton
-          type="button"
-          variant="contained"
-          color="primary"
-          data-test="ci-step2-save-btn"
-          onClick={handleSave}
-          disabled={readOnly || isSaving}
-        >
-          {ciApplication?.status?.status === 'Submitted'
-            ? t('carbonIntensity:step2.saveSupplementalChanges')
-            : t('carbonIntensity:step2.saveAndProceed')}
-        </BCButton>
+      {/* Delete sits far right, away from the primary action (#4770). Any
+          secondaryAction (e.g. Cancel) stays grouped with Save on the left. */}
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ mt: 2 }}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Stack direction="row" spacing={2} alignItems="center">
+          <BCButton
+            type="button"
+            variant="contained"
+            color="primary"
+            data-test="ci-step2-save-btn"
+            onClick={handleSave}
+            disabled={readOnly || isSaving}
+          >
+            {ciApplication?.status?.status === 'Submitted'
+              ? t('carbonIntensity:step2.saveSupplementalChanges')
+              : t('carbonIntensity:step2.saveAndProceed')}
+          </BCButton>
+          {secondaryAction}
+        </Stack>
         {ciApplication?.ciApplicationId && onDelete && (
           <BCButton
             type="button"
@@ -261,7 +272,6 @@ export const ProposedFuelPathwaysStep = ({
             {t('carbonIntensity:step1.deleteDraft')}
           </BCButton>
         )}
-        {secondaryAction}
       </Stack>
     </Box>
   )

--- a/frontend/src/views/CarbonIntensity/components/SignAndSubmitStep.jsx
+++ b/frontend/src/views/CarbonIntensity/components/SignAndSubmitStep.jsx
@@ -262,7 +262,10 @@ export const SignAndSubmitStep = ({
                 onChange={(e) => {
                   setConsultantName(e.target.value)
                   if (errors.consultantName) {
-                    setErrors((prev) => ({ ...prev, consultantName: undefined }))
+                    setErrors((prev) => ({
+                      ...prev,
+                      consultantName: undefined
+                    }))
                   }
                 }}
                 disabled={readOnly}
@@ -283,7 +286,10 @@ export const SignAndSubmitStep = ({
                 onChange={(e) => {
                   setConsultantCompany(e.target.value)
                   if (errors.consultantCompany) {
-                    setErrors((prev) => ({ ...prev, consultantCompany: undefined }))
+                    setErrors((prev) => ({
+                      ...prev,
+                      consultantCompany: undefined
+                    }))
                   }
                 }}
                 disabled={readOnly}
@@ -304,7 +310,10 @@ export const SignAndSubmitStep = ({
                 onChange={(e) => {
                   setConsultantEmail(e.target.value)
                   if (errors.consultantEmail) {
-                    setErrors((prev) => ({ ...prev, consultantEmail: undefined }))
+                    setErrors((prev) => ({
+                      ...prev,
+                      consultantEmail: undefined
+                    }))
                   }
                 }}
                 disabled={readOnly}
@@ -319,7 +328,14 @@ export const SignAndSubmitStep = ({
         )}
       </BCBox>
 
-      <Stack direction="row" spacing={2} sx={{ mt: 2 }} alignItems="center">
+      {/* Delete sits far right, away from the primary action (#4770). */}
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ mt: 2 }}
+        alignItems="center"
+        justifyContent="space-between"
+      >
         <BCButton
           type="button"
           variant="contained"

--- a/frontend/src/views/Organizations/OrganizationView/components/CommentLog/CommentRow.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/CommentLog/CommentRow.jsx
@@ -73,6 +73,7 @@ export const CommentRow = forwardRef(function CommentRow(
     index,
     showInternalBadge,
     isGovernmentUser,
+    allowPublicVisibility = true,
     onEdit,
     isEditPending
   },
@@ -85,7 +86,11 @@ export const CommentRow = forwardRef(function CommentRow(
 
   const startEdit = () => {
     setEditText(comment.comment ?? '')
-    setEditVisibility(comment.visibility ?? 'Internal')
+    // Threads that don't allow public comments stay Internal on save, whatever
+    // the stored value is — they never render the visibility choice.
+    setEditVisibility(
+      allowPublicVisibility ? (comment.visibility ?? 'Internal') : 'Internal'
+    )
     setEditing(true)
   }
 
@@ -339,7 +344,7 @@ export const CommentRow = forwardRef(function CommentRow(
               <BCTypography variant="subtitle2">
                 {t('internalComment:editComment')}
               </BCTypography>
-              {showInternalBadge && (
+              {showInternalBadge && allowPublicVisibility && (
                 <BCBox sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                   <Chip
                     size="small"

--- a/frontend/src/views/Organizations/OrganizationView/components/CompanyOverviewComments.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/CompanyOverviewComments.jsx
@@ -16,6 +16,8 @@ import {
   useEditOrganizationComment
 } from '@/hooks/useOrganizationComments'
 
+const VISIBILITY = 'Internal'
+
 /**
  * Company Overview thread on the Organization dashboard (#4608).
  *
@@ -25,6 +27,10 @@ import {
  * ORGANIZATION-entity internal comments filed under the "Company Overview"
  * category, so they also surface in — and are searchable from — the org
  * Comment Log.
+ *
+ * Company Overview notes are always Internal: there is no public commenting on
+ * this thread, so neither the create box nor the inline editor offers the
+ * visibility choice.
  */
 export const CompanyOverviewComments = ({
   organizationId,
@@ -32,7 +38,6 @@ export const CompanyOverviewComments = ({
 }) => {
   const { t } = useTranslation(['org', 'internalComment'])
   const [commentText, setCommentText] = useState('')
-  const [visibility, setVisibility] = useState('Internal')
 
   const { data, isLoading, isError } =
     useOrganizationCommentThread(organizationId)
@@ -41,16 +46,15 @@ export const CompanyOverviewComments = ({
 
   const comments = data?.comments ?? []
 
-  const handleCreate = async (text, vis) => {
+  const handleCreate = async (text) => {
     const body = (text ?? '').trim()
     if (!body) return
-    await createMutation.mutateAsync({ comment: body, visibility: vis })
+    await createMutation.mutateAsync({ comment: body, visibility: VISIBILITY })
     setCommentText('')
-    setVisibility('Internal')
   }
 
-  const handleEdit = (commentId, comment, vis) => {
-    editMutation.mutate({ commentId, comment, visibility: vis })
+  const handleEdit = (commentId, comment) => {
+    editMutation.mutate({ commentId, comment, visibility: VISIBILITY })
   }
 
   return (
@@ -105,6 +109,7 @@ export const CompanyOverviewComments = ({
                         index={index}
                         showInternalBadge={isGovernmentUser}
                         isGovernmentUser={isGovernmentUser}
+                        allowPublicVisibility={false}
                         onEdit={handleEdit}
                         isEditPending={editMutation.isPending}
                       />
@@ -121,10 +126,8 @@ export const CompanyOverviewComments = ({
                 onCommentChange={setCommentText}
                 onSubmit={handleCreate}
                 isSubmitting={createMutation.isPending}
-                showVisibilityToggle={isGovernmentUser}
-                visibility={visibility}
-                onVisibilityChange={setVisibility}
-                visibilityAlign="left"
+                showVisibilityToggle={false}
+                visibility={VISIBILITY}
               />
             </BCBox>
           </BCBox>

--- a/frontend/src/views/Organizations/OrganizationView/components/__tests__/CompanyOverviewComments.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/__tests__/CompanyOverviewComments.test.jsx
@@ -21,13 +21,20 @@ vi.mock('react-i18next', () => ({
 // Lightweight stubs so the test focuses on wiring, not the WYSIWYG editor.
 vi.mock('@/components/Comments/CommentForm', () => ({
   __esModule: true,
-  default: ({ commentText, onCommentChange, onSubmit, visibility }) => (
+  default: ({
+    commentText,
+    onCommentChange,
+    onSubmit,
+    visibility,
+    showVisibilityToggle
+  }) => (
     <div data-test="comment-form">
       <input
         data-test="comment-input"
         value={commentText}
         onChange={(e) => onCommentChange(e.target.value)}
       />
+      {showVisibilityToggle && <div data-test="visibility-toggle" />}
       <button
         data-test="comment-submit"
         onClick={() => onSubmit(commentText, visibility)}
@@ -39,12 +46,13 @@ vi.mock('@/components/Comments/CommentForm', () => ({
 }))
 
 vi.mock('../CommentLog/CommentRow', () => ({
-  CommentRow: ({ comment, onEdit }) => (
+  CommentRow: ({ comment, onEdit, allowPublicVisibility }) => (
     <div data-test="comment-row">
       <span>{comment.comment}</span>
+      {allowPublicVisibility && <div data-test="row-visibility-toggle" />}
       <button
         data-test={`edit-${comment.internalCommentId}`}
-        onClick={() => onEdit(comment.internalCommentId, 'edited', 'Internal')}
+        onClick={() => onEdit(comment.internalCommentId, 'edited', 'Public')}
       >
         edit
       </button>
@@ -128,6 +136,31 @@ describe('CompanyOverviewComments (#4608)', () => {
     renderCard(<CompanyOverviewComments organizationId={7} />)
     fireEvent.click(screen.getByTestId('comment-submit'))
     expect(createMutate).not.toHaveBeenCalled()
+  })
+
+  it('offers no public option on the create box, even for IDIR users', () => {
+    renderCard(
+      <CompanyOverviewComments organizationId={7} isGovernmentUser={true} />
+    )
+    expect(screen.queryByTestId('visibility-toggle')).not.toBeInTheDocument()
+  })
+
+  it('offers no public option when editing an existing comment', () => {
+    mockThread.mockReturnValue({
+      data: {
+        comments: [
+          { internalCommentId: 5, comment: '<p>Gamma</p>', canEdit: true }
+        ]
+      },
+      isLoading: false,
+      isError: false
+    })
+    renderCard(
+      <CompanyOverviewComments organizationId={7} isGovernmentUser={true} />
+    )
+    expect(
+      screen.queryByTestId('row-visibility-toggle')
+    ).not.toBeInTheDocument()
   })
 
   it('edits a comment via the edit mutation', () => {


### PR DESCRIPTION
Two org-dashboard fixes: the CI draft delete button (#4770) and internal-only Company Overview comments.

## Move the delete draft button to the far right (#4770)

`Delete draft application` sat immediately beside the primary action on every step of the draft application, so a destructive action read as prominently as Save. The button row now splits the two to opposite ends via `justifyContent="space-between"`.

Applied to all four steps: application information, proposed fuel pathways, documents and modelling, and sign and submit.

The pathways step needed more than the alignment change. It also renders a `secondaryAction` slot, which the summary view fills with a **Cancel** button when editing pathways inline — a plain `space-between` would have flung Cancel to the right edge next to Delete. That row now groups Save and `secondaryAction` on the left, leaving Delete alone on the right. Where Delete is hidden (new applications, read-only views) the left group simply sits left as before.

## No public commenting on Company Overview

Company Overview notes are internal working notes, but the thread offered an Internal/Public choice. Removed, and the visibility is now pinned at both layers.

**Frontend.** The choice appeared in two places — the create box and the inline editor on each existing comment — so removing only the first would still have let you create a note as Internal and then flip it to Public by editing. `CommentRow` gains an `allowPublicVisibility` flag rather than losing its toggle outright, since the org Comment Log and the compliance report threads still need it; Company Overview is the only caller opting out. It also pins the visibility it sends on both create and edit.

**Backend.** The UI change alone left the API accepting `visibility: "Public"` for ORGANIZATION comments, so the service now enforces it:

- On create, an ORGANIZATION-entity comment is forced to Internal before the audience-scope rules run, so it still picks up a scope from the author's role.
- On update, the payload carries no entity type, so a new `is_organization_comment` repo lookup identifies the note by its `organization_internal_comment` association row and forces the visibility back to Internal.

## Testing

- **Frontend:** 354 tests pass across `views/Organizations` and `components/Comments`, plus 187 across `views/CarbonIntensity`. New tests assert the visibility choice is absent from both the create box and the edit row for IDIR users; the existing edit test now fires `Public` at the handler to prove the component overrides it.
- **Backend:** 98 comment-related tests pass against a real Postgres, including the 42 integration tests that exercise the endpoints. Two new service tests cover the forced-Internal create and the blocked flip-to-public edit.

Not yet exercised in a running stack. Worth an eyeball on the pathways step in summary-edit mode, since that is the one case where three buttons share the row.

## Notes for a follow-up, not addressed here

- `docker-compose-db-only.yml` pins `postgres:14.2`, but the shared `postgres_data` volume is initialized by Postgres 17, so that file cannot start the database (`database files are incompatible with server`). The `db` service in the main compose file works.
- `black` and `isort` already fail on `internal_comment/repo.py` on `develop`. Left alone rather than reformatting the file; the additions here are `black`-clean.
