### PR TITLE
Fix credit ledger transaction ID prefixes by type

### DIFF
--- a/frontend/src/utils/__tests__/formatters.test.jsx
+++ b/frontend/src/utils/__tests__/formatters.test.jsx
@@ -14,7 +14,9 @@ import {
   formatNumberWithCommas,
   spacesFormatter,
   timezoneFormatter,
-  convertObjectKeys
+  convertObjectKeys,
+  formatTransactionId,
+  parseTransactionIdNumber
 } from '@/utils/formatters'
 import { roles } from '@/constants/roles'
 
@@ -409,5 +411,54 @@ describe('dateToLongString', () => {
     expect(dateToLongString(undefined)).toBe('')
     expect(dateToLongString('')).toBe('')
     expect(dateToLongString('not a date')).toBe('Invalid Date')
+  })
+})
+
+describe('formatTransactionId', () => {
+  it('should prefix each transaction type with its own code', () => {
+    expect(formatTransactionId('Transfer', 4825)).toBe('CT4825')
+    expect(formatTransactionId('InitiativeAgreement', 3113)).toBe('IA3113')
+    expect(formatTransactionId('AdminAdjustment', 70)).toBe('AA70')
+    expect(formatTransactionId('ComplianceReport', 3798)).toBe('CR3798')
+    expect(formatTransactionId('AggregatorIssuance', 12)).toBe('AG12')
+  })
+
+  it('should return the bare id for types without a user-facing prefix', () => {
+    expect(formatTransactionId('StandaloneTransaction', 91)).toBe('91')
+    expect(formatTransactionId('SomethingNew', 5)).toBe('5')
+  })
+
+  it('should handle missing type or id', () => {
+    expect(formatTransactionId(null, 7)).toBe('7')
+    expect(formatTransactionId(undefined, 7)).toBe('7')
+    expect(formatTransactionId('Transfer', null)).toBe('CT')
+  })
+})
+
+describe('parseTransactionIdNumber', () => {
+  it('should strip the prefix and return the number', () => {
+    expect(parseTransactionIdNumber('CT4825')).toBe(4825)
+    expect(parseTransactionIdNumber('IA3113')).toBe(3113)
+    expect(parseTransactionIdNumber('AA70')).toBe(70)
+    expect(parseTransactionIdNumber('CR3798')).toBe(3798)
+  })
+
+  it('should handle ids with no prefix', () => {
+    expect(parseTransactionIdNumber('91')).toBe(91)
+    expect(parseTransactionIdNumber(91)).toBe(91)
+  })
+
+  it('should return 0 for unparseable input', () => {
+    expect(parseTransactionIdNumber('')).toBe(0)
+    expect(parseTransactionIdNumber('CT')).toBe(0)
+    expect(parseTransactionIdNumber(null)).toBe(0)
+    expect(parseTransactionIdNumber(undefined)).toBe(0)
+  })
+
+  it('should order mixed-prefix ids numerically, not lexically', () => {
+    const sorted = ['CT9', 'IA100', 'AA70'].sort(
+      (a, b) => parseTransactionIdNumber(a) - parseTransactionIdNumber(b)
+    )
+    expect(sorted).toEqual(['CT9', 'AA70', 'IA100'])
   })
 })

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -4,9 +4,7 @@ import dayjs from 'dayjs'
 type ValueParam = { value?: unknown } | number | string | null | undefined
 type FormatterParam = ValueParam | Record<string, unknown>
 
-const hasValue = (
-  obj: unknown
-): obj is { value: unknown } =>
+const hasValue = (obj: unknown): obj is { value: unknown } =>
   typeof obj === 'object' &&
   obj !== null &&
   Object.prototype.hasOwnProperty.call(obj, 'value')
@@ -22,7 +20,8 @@ export const numberFormatter = (
 ): string => {
   if (
     params == null ||
-    (typeof params === 'object' && (params as { value?: unknown }).value == null)
+    (typeof params === 'object' &&
+      (params as { value?: unknown }).value == null)
   )
     return ''
 
@@ -122,9 +121,7 @@ export const dateToLongString = (
 /**
  * Formats a phone number to (123) 456-7890 format.
  */
-export const phoneNumberFormatter = (params: {
-  value?: unknown
-}): string => {
+export const phoneNumberFormatter = (params: { value?: unknown }): string => {
   const phoneNumber = params?.value?.toString().replace(/\D/g, '') || ''
   if (!phoneNumber) {
     return ''
@@ -244,6 +241,43 @@ export const spacesFormatter = (params: {
 }
 
 /**
+ * User-facing ID prefix for each transaction type. The number that follows is
+ * the type's own id (transfer_id, initiative_agreement_id, ...), not a shared
+ * sequence, so the prefix is what makes the id unambiguous.
+ *
+ * StandaloneTransaction ("Legacy Transaction") is deliberately absent — those
+ * rows carry a raw transaction table id with no user-facing prefix.
+ */
+export const TRANSACTION_ID_PREFIXES: Record<string, string> = {
+  Transfer: 'CT',
+  AdminAdjustment: 'AA',
+  InitiativeAgreement: 'IA',
+  ComplianceReport: 'CR',
+  AggregatorIssuance: 'AG'
+}
+
+/**
+ * Formats a transaction id for display, e.g. ('InitiativeAgreement', 3113) -> 'IA3113'.
+ */
+export const formatTransactionId = (
+  transactionType: string | null | undefined,
+  transactionId: string | number | null | undefined
+): string =>
+  `${TRANSACTION_ID_PREFIXES[transactionType ?? ''] ?? ''}${transactionId ?? ''}`
+
+/**
+ * Extracts the numeric part of a display transaction id, e.g. 'IA3113' -> 3113.
+ * Strips a prefix of any length (or none at all, for legacy transactions), so
+ * sorting stays numeric rather than lexical. Unparseable ids sort as 0.
+ */
+export const parseTransactionIdNumber = (
+  displayId: string | number | null | undefined
+): number => {
+  const parsed = parseInt(String(displayId ?? '').replace(/^\D+/, ''), 10)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+/**
  * Removes entries with empty string values from an object.
  */
 export const cleanEmptyStringValues = <T extends Record<string, unknown>>(
@@ -267,7 +301,9 @@ export const formatNumberWithCommas = ({
   if (!value) return 0
   const [integerPart, decimalPart] = value.toString().split('.')
 
-  let number = new Intl.NumberFormat('en-CA').format(integerPart as unknown as number)
+  let number = new Intl.NumberFormat('en-CA').format(
+    integerPart as unknown as number
+  )
 
   if (decimalPart !== undefined) {
     number = number + '.' + decimalPart

--- a/frontend/src/views/Organizations/OrganizationView/CreditLedgerPeriod.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/CreditLedgerPeriod.jsx
@@ -28,7 +28,7 @@ import {
   useCreditLedgerYears
 } from '@/hooks/useCreditLedger'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
-import { dateFormatter } from '@/utils/formatters'
+import { dateFormatter, formatTransactionId } from '@/utils/formatters'
 
 const TYPE_LABELS = {
   Transfer: 'Transfer',
@@ -263,9 +263,10 @@ export const CreditLedgerPeriod = ({ organizationId }) => {
                     sx={bodyRowSx}
                   >
                     <TableCell sx={cellSx}>
-                      {txn.transactionType === 'ComplianceReport'
-                        ? `CR${txn.transactionId}`
-                        : `CT${txn.transactionId}`}
+                      {formatTransactionId(
+                        txn.transactionType,
+                        txn.transactionId
+                      )}
                     </TableCell>
                     <TableCell sx={cellSx}>
                       {formatDate(txn.effectiveDate)}
@@ -307,9 +308,10 @@ export const CreditLedgerPeriod = ({ organizationId }) => {
                           sx={bodyRowSx}
                         >
                           <TableCell sx={cellSx}>
-                            {txn.transactionType === 'ComplianceReport'
-                              ? `CR${txn.transactionId}`
-                              : `CT${txn.transactionId}`}
+                            {formatTransactionId(
+                              txn.transactionType,
+                              txn.transactionId
+                            )}
                           </TableCell>
                           <TableCell sx={cellSx}>
                             {formatDate(txn.effectiveDate)}

--- a/frontend/src/views/Organizations/OrganizationView/__tests__/CreditLedgerPeriod.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/__tests__/CreditLedgerPeriod.test.jsx
@@ -24,7 +24,10 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
-vi.mock('@/utils/formatters', () => ({
+// Only dateFormatter is stubbed (identity, so raw ISO strings stay assertable);
+// formatTransactionId is kept real so the id prefixes are exercised for real.
+vi.mock('@/utils/formatters', async (importOriginal) => ({
+  ...(await importOriginal()),
   dateFormatter: ({ value }) => value
 }))
 
@@ -161,6 +164,21 @@ describe('CreditLedgerPeriod (compliance-period ledger #4714)', () => {
     expect(balances[0]).toHaveTextContent('10,000')
     // Negative running balance rendered (styling handled by NumberCell)
     expect(balances[1]).toHaveTextContent('-1,500')
+  })
+
+  // Regression: every non-ComplianceReport type used to fall back to the "CT"
+  // transfer prefix, so initiative agreements and admin adjustments displayed
+  // a correct number under the wrong prefix.
+  it('prefixes transaction ids by type in both the list and totals views', () => {
+    renderComponent({ organizationId: 999 })
+    expect(screen.getByText('IA43')).toBeInTheDocument()
+    expect(screen.getByText('CT444')).toBeInTheDocument()
+    expect(screen.queryByText('CT43')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('toggle-show-totals'))
+    expect(screen.getByText('IA43')).toBeInTheDocument()
+    expect(screen.getByText('CT444')).toBeInTheDocument()
+    expect(screen.queryByText('CT43')).not.toBeInTheDocument()
   })
 
   it('switches to grouped totals view with per-type and grand totals', () => {

--- a/frontend/src/views/Transactions/__tests__/_schema.test.js
+++ b/frontend/src/views/Transactions/__tests__/_schema.test.js
@@ -1,1 +1,42 @@
-describe.todo()
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/hooks/useTransactions', () => ({
+  useTransactionStatuses: vi.fn()
+}))
+
+import { transactionsColDefs } from '../_schema'
+
+const colDefs = transactionsColDefs((key) => key)
+const txnIdCol = colDefs.find((col) => col.colId === 'transactionId')
+
+const row = (transactionType, transactionId) => ({
+  data: { transactionType, transactionId }
+})
+
+describe('transactionsColDefs — transactionId column', () => {
+  it('prefixes the id with the code for its transaction type', () => {
+    expect(txnIdCol.valueGetter(row('Transfer', 4825))).toBe('CT4825')
+    expect(txnIdCol.valueGetter(row('InitiativeAgreement', 3113))).toBe(
+      'IA3113'
+    )
+    expect(txnIdCol.valueGetter(row('AdminAdjustment', 70))).toBe('AA70')
+    expect(txnIdCol.valueGetter(row('ComplianceReport', 3798))).toBe('CR3798')
+    expect(txnIdCol.valueGetter(row('AggregatorIssuance', 12))).toBe('AG12')
+  })
+
+  it('leaves legacy transactions unprefixed', () => {
+    expect(txnIdCol.valueGetter(row('StandaloneTransaction', 91))).toBe('91')
+  })
+
+  // Regression: the comparator used to slice a single character off a
+  // two-character prefix, so every comparison was NaN and the column never
+  // actually sorted.
+  it('sorts descending by the numeric part regardless of prefix length', () => {
+    expect(txnIdCol.comparator('CT100', 'CT9')).toBeLessThan(0)
+    expect(txnIdCol.comparator('CT9', 'IA100')).toBeGreaterThan(0)
+    expect(txnIdCol.comparator('AA70', 'AA70')).toBe(0)
+
+    const sorted = ['CT9', 'IA100', 'AA70', '91'].sort(txnIdCol.comparator)
+    expect(sorted).toEqual(['IA100', '91', 'AA70', 'CT9'])
+  })
+})

--- a/frontend/src/views/Transactions/_schema.js
+++ b/frontend/src/views/Transactions/_schema.js
@@ -2,7 +2,9 @@ import {
   numberFormatter,
   currencyFormatter,
   dateFormatter,
-  spacesFormatter
+  spacesFormatter,
+  formatTransactionId,
+  parseTransactionIdNumber
 } from '@/utils/formatters'
 import { TransactionStatusRenderer } from '@/utils/grid/cellRenderers'
 import {
@@ -10,14 +12,6 @@ import {
   BCDateFloatingFilter
 } from '@/components/BCDataGrid/components'
 import { useTransactionStatuses } from '@/hooks/useTransactions'
-
-const prefixMap = {
-  Transfer: 'CT',
-  AdminAdjustment: 'AA',
-  InitiativeAgreement: 'IA',
-  ComplianceReport: 'CR',
-  AggregatorIssuance: 'AG'
-}
 
 export const transactionsColDefs = (t) => [
   {
@@ -57,20 +51,16 @@ export const transactionsColDefs = (t) => [
     field: 'transactionId',
     headerName: t('txn:txnColLabels.txnId'),
     minWidth: 130,
-    valueGetter: (params) => {
-      const transactionType = params.data.transactionType
-      const prefix = prefixMap[transactionType] || ''
-      return `${prefix}${params.data.transactionId}`
-    },
+    valueGetter: (params) =>
+      formatTransactionId(
+        params.data.transactionType,
+        params.data.transactionId
+      ),
     filterParams: {
       buttons: ['clear']
     },
-    comparator: (valueA, valueB) => {
-      const numberA = parseInt(valueA.slice(1), 10)
-      const numberB = parseInt(valueB.slice(1), 10)
-
-      return numberB - numberA
-    }
+    comparator: (valueA, valueB) =>
+      parseTransactionIdNumber(valueB) - parseTransactionIdNumber(valueA)
   },
   {
     colId: 'compliancePeriod',
@@ -124,8 +114,14 @@ export const transactionsColDefs = (t) => [
           { transactionType: 'Compliance Report', type: 'ComplianceReport' },
           { transactionType: 'Admin Adjustment', type: 'AdminAdjustment' },
           { transactionType: 'Transfer', type: 'Transfer' },
-          { transactionType: 'Initiative Agreement', type: 'InitiativeAgreement' },
-          { transactionType: 'Legacy Transaction', type: 'StandaloneTransaction' },
+          {
+            transactionType: 'Initiative Agreement',
+            type: 'InitiativeAgreement'
+          },
+          {
+            transactionType: 'Legacy Transaction',
+            type: 'StandaloneTransaction'
+          },
           { transactionType: 'Aggregator Issuance', type: 'AggregatorIssuance' }
         ],
         isLoading: false


### PR DESCRIPTION
## Problem

The compliance-period credit ledger rendered transaction IDs with a two-way ternary — `CR` for compliance reports, `CT` for everything else. Initiative agreements and administrative adjustments therefore displayed a **correct number under the transfer prefix** (e.g. `CT3113` where it should read `IA3113`).

The numbers themselves were never wrong: `mv_credit_ledger` selects each type's own id (`initiative_agreement_id`, `admin_adjustment_id`, …), so only the prefix was incorrect. The bug was duplicated at both render sites — the transaction list and the grouped-totals view.

## Fix

The correct prefix map already existed, but was private to the transactions grid — which is precisely how the ledger drifted from it. Moved it to `utils/formatters` as `TRANSACTION_ID_PREFIXES` + `formatTransactionId()`, and pointed both consumers at it so they cannot diverge again.

| Type | Prefix |
| --- | --- |
| Transfer | `CT` |
| InitiativeAgreement | `IA` |
| AdminAdjustment | `AA` |
| ComplianceReport | `CR` |
| AggregatorIssuance | `AG` |
| StandaloneTransaction | *(none)* |

Legacy (standalone) transactions stay unprefixed, matching the transactions grid — they carry a raw `transaction` table id rather than a domain id, so the previous code was labelling those `CT` as well.

## Also fixed

The transactions grid sort comparator sliced a **single** character off a **two**-character prefix (`parseInt(value.slice(1), 10)`), so every comparison evaluated to `NaN` and the ID column never actually sorted. Now uses a shared `parseTransactionIdNumber()` that strips a prefix of any length — or none — and falls back to `0` rather than `NaN`.

## Tests

- `_schema.test.js` was a bare `describe.todo()`; it now covers the transaction ID column — prefix per type, unprefixed legacy rows, and a descending-sort assertion that fails against the old comparator.
- `CreditLedgerPeriod.test.jsx` stubbed the entire formatters module, so it would have passed a broken prefix silently. Switched to `importOriginal` so only `dateFormatter` is stubbed, plus assertions that `IA43`/`CT444` render and `CT43` does not — in both the list and totals views.
- Unit tests for both new helpers.

87 passing across the three affected test files; full `views/Transactions` suite at 338 (up from 335). `type-check` clean for all changed files.

Verified via tests rather than a running stack — the assertions cover the exact rendered cell text, which is what was wrong.

## Related

The same fix is proposed against `develop` in #4822 (byte-identical diff, cherry-picked).