### PR TITLE
ix: Investigate bug in summary section of report 2772- #4935

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -3103,6 +3103,53 @@ async def test_line_15_16_zero_when_no_assessed_report_for_supplemental(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("compliance_year", ["2024", "2025"])
+async def test_locked_supplemental_summary_recomputes_carry_forward_when_no_assessed_report(
+    compliance_report_summary_service,
+    mock_repo,
+    compliance_year,
+):
+    """
+    Locked supplemental reports without an assessed same-period baseline should
+    not display previous-version issued units as Line 15/16 carry-forward.
+
+    This covers historical/migrated records such as CR2772 where the final
+    transaction was created for the correct issuance, but the stored summary
+    still showed Line 15 = current issuance and Line 20 = 0.
+    """
+    summary = make_summary(locked=True)
+    summary.summary_id = 1
+    summary.compliance_report_id = 2772
+    summary.line_15_banked_units_used = 212
+    summary.line_16_banked_units_remaining = 0
+    summary.line_17_non_banked_units_used = 1000
+    summary.line_18_units_to_be_banked = 212
+    summary.line_19_units_to_be_exported = 0
+    summary.line_20_surplus_deficit_units = 0
+    summary.line_21_non_compliance_penalty_payable = 0
+    summary.line_22_compliance_units_issued = 1000
+
+    report = make_report(1, ComplianceReportStatusEnum.Assessed, compliance_year)
+    report.summary = summary
+    report.compliance_report_id = 2772
+
+    mock_repo.get_compliance_report_by_id = AsyncMock(return_value=report)
+    mock_repo.get_assessed_compliance_report_by_period = AsyncMock(return_value=None)
+
+    result = (
+        await compliance_report_summary_service.calculate_compliance_report_summary(
+            report_id=2772
+        )
+    )
+
+    line_values = _get_line_values(result.low_carbon_fuel_target_summary)
+    assert line_values[15] == 0
+    assert line_values[16] == 0
+    assert line_values[20] == 212
+    assert line_values[22] == 1212
+
+
+@pytest.mark.anyio
 async def test_line_15_16_uses_assessed_report_values(
     compliance_report_summary_service,
     mock_repo,

--- a/backend/lcfs/tests/internal_comment/test_company_overview_comments.py
+++ b/backend/lcfs/tests/internal_comment/test_company_overview_comments.py
@@ -13,6 +13,10 @@ from fastapi import FastAPI, status
 from httpx import AsyncClient
 
 from lcfs.db.models import UserProfile
+from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.comment.OrganizationInternalComment import (
+    OrganizationInternalComment,
+)
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.internal_comment.schema import EntityTypeEnum, AudienceScopeEnum
 
@@ -106,9 +110,7 @@ async def test_company_overview_comment_appears_in_org_comment_log(
     response = await client.get(url)
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    match = [
-        c for c in data["comments"] if c["comment"] == "<p>Overview alpha</p>"
-    ]
+    match = [c for c in data["comments"] if c["comment"] == "<p>Overview alpha</p>"]
     assert len(match) == 1
     record = match[0]
     assert record["entityType"] == EntityTypeEnum.ORGANIZATION.value
@@ -120,9 +122,7 @@ async def test_company_overview_comment_appears_in_org_comment_log(
     filtered = await client.get(url, params={"category": "Company Overview"})
     assert filtered.status_code == status.HTTP_200_OK
     assert filtered.json()["pagination"]["total"] >= 1
-    assert all(
-        c["category"] == "Company Overview" for c in filtered.json()["comments"]
-    )
+    assert all(c["category"] == "Company Overview" for c in filtered.json()["comments"])
 
     # Excluded when filtering by an unrelated category.
     other = await client.get(url, params={"category": "Transfer notes"})
@@ -160,6 +160,53 @@ async def test_company_overview_comment_searchable_in_org_comment_log(
     url = fastapi_app.url_path_for("get_organization_comments", organization_id=1)
     hit = await client.get(url, params={"search": "aggregator"})
     assert hit.status_code == status.HTTP_200_OK
-    assert any(
-        "aggregator" in (c["comment"] or "") for c in hit.json()["comments"]
+    assert any("aggregator" in (c["comment"] or "") for c in hit.json()["comments"])
+
+
+@pytest.mark.anyio
+async def test_gov_analyst_can_edit_company_overview_created_by_another_analyst(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Company Overview is a shared org statement, not author-locked."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.GOVERNMENT, RoleEnum.ANALYST],
+        user_details={"keycloak_username": "SECOND_ANALYST"},
     )
+    await add_models(
+        [
+            UserProfile(
+                keycloak_username="FIRST_ANALYST",
+                first_name="First",
+                last_name="Analyst",
+            ),
+            UserProfile(
+                keycloak_username="SECOND_ANALYST",
+                first_name="Second",
+                last_name="Analyst",
+            ),
+            InternalComment(
+                internal_comment_id=4608,
+                comment="<p>Original shared overview</p>",
+                audience_scope=AudienceScopeEnum.ANALYST.value,
+                create_user="FIRST_ANALYST",
+            ),
+            OrganizationInternalComment(
+                organization_id=1,
+                internal_comment_id=4608,
+            ),
+        ]
+    )
+
+    url = fastapi_app.url_path_for("update_comment", internal_comment_id=4608)
+    response = await client.put(url, json={"comment": "<p>Updated shared overview</p>"})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["comment"] == "<p>Updated shared overview</p>"
+    assert data["createUser"] == "FIRST_ANALYST"
+    assert data["updateUser"] == "SECOND_ANALYST"
+    assert data["updateFullName"] == "Second Analyst"

--- a/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
@@ -373,6 +373,7 @@ def _build_service_with_user_roles(role_names):
     service.repo.get_category_id_by_name = AsyncMock(return_value=99)
     service.repo.get_entity_org_and_year = AsyncMock(return_value=(7, 2025))
     service.repo.get_comments_for_organization = AsyncMock()
+    service.repo.get_latest_organization_comment_id = AsyncMock(return_value=None)
     # Most comments are not Company Overview notes; tests that need the
     # organization-comment path override this.
     service.repo.is_organization_comment = AsyncMock(return_value=False)
@@ -572,6 +573,38 @@ async def test_create_organization_comment_is_forced_internal():
     assert created_comment_arg.visibility == CommentVisibilityEnum.INTERNAL
     # Internal comments still need an audience scope, resolved from the role.
     assert created_comment_arg.audience_scope == AudienceScopeEnum.ANALYST
+
+
+@pytest.mark.anyio
+async def test_create_organization_comment_updates_existing_shared_statement():
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT])
+    service.repo.get_latest_organization_comment_id.return_value = 101
+    service.repo.update_internal_comment.return_value = SimpleNamespace(
+        internal_comment_id=101,
+        comment="Updated overview",
+        audience_scope="Analyst",
+        visibility="Internal",
+        create_user="firstuser",
+        create_date=None,
+        update_date=None,
+        update_user="mockuser",
+        update_full_name="Mock User",
+        full_name="First User",
+        documents=[],
+    )
+    payload = InternalCommentCreateSchema(
+        entity_type=EntityTypeEnum.ORGANIZATION,
+        entity_id=7,
+        comment="Updated overview",
+        visibility=CommentVisibilityEnum.INTERNAL,
+    )
+
+    result = await service.create_internal_comment(payload)
+
+    service.repo.create_internal_comment.assert_not_called()
+    service.repo.update_internal_comment.assert_awaited_once()
+    assert result.internal_comment_id == 101
+    assert result.comment == "Updated overview"
 
 
 @pytest.mark.anyio
@@ -931,6 +964,34 @@ async def test_get_organization_comments_can_edit_false_for_other_user():
 
     result = await service.get_organization_comments(organization_id=5)
     assert result.comments[0].can_edit is False
+
+
+@pytest.mark.anyio
+async def test_get_organization_comments_can_edit_true_for_shared_company_overview():
+    service = _build_service_with_user_roles([RoleEnum.GOVERNMENT, RoleEnum.ANALYST])
+    row = {
+        "internal_comment_id": 3,
+        "comment": "x",
+        "plain_text_comment": "x",
+        "organization_id": 5,
+        "organization_name": "Org",
+        "compliance_year": None,
+        "visibility": "Internal",
+        "audience_scope": "Analyst",
+        "create_user": "someone-else",
+        "create_date": None,
+        "update_date": None,
+        "update_user": None,
+        "update_full_name": None,
+        "category": "Company Overview",
+        "full_name": "Other User",
+        "entity_type": "Organization",
+        "entity_id": 5,
+    }
+    service.repo.get_comments_for_organization.return_value = ([row], 1)
+
+    result = await service.get_organization_comments(organization_id=5)
+    assert result.comments[0].can_edit is True
 
 
 # ======================================================================

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -162,6 +162,67 @@ class ComplianceReportSummaryService:
         )
         return prev_compliance_report is not None
 
+    async def _normalize_locked_supplemental_without_assessed_baseline(
+        self,
+        summary: ComplianceReportSummarySchema,
+        compliance_report: ComplianceReport,
+    ) -> None:
+        """Correct stale low-carbon carry-forward rows for locked supplementals.
+
+        Some historical/government-initiated supplementals can exist even when
+        the original same-period report was never assessed. In that case there
+        are no previously issued units to carry forward, so stored Line 15/16
+        values from the prior submitted version must not affect the displayed
+        balance.
+        """
+        report_version = getattr(compliance_report, "version", None)
+        if not isinstance(report_version, int) or report_version <= 0:
+            return
+
+        assessed_report = await self.cr_repo.get_assessed_compliance_report_by_period(
+            compliance_report.organization_id,
+            int(compliance_report.compliance_period.description),
+            compliance_report.compliance_report_id,
+        )
+        if assessed_report:
+            return
+
+        rows_by_line = {
+            int(row.line): row
+            for row in summary.low_carbon_fuel_target_summary or []
+            if row.line is not None
+        }
+        if not rows_by_line:
+            return
+
+        line_17 = rows_by_line.get(17).value if rows_by_line.get(17) else 0
+        line_18 = rows_by_line.get(18).value if rows_by_line.get(18) else 0
+        line_19 = rows_by_line.get(19).value if rows_by_line.get(19) else 0
+        line_20 = int(line_18 or 0) + int(line_19 or 0)
+        line_22 = max(int(line_17 or 0) + line_20, 0)
+
+        for line, value in ((15, 0), (16, 0), (20, line_20), (22, line_22)):
+            if line in rows_by_line:
+                rows_by_line[line].value = value
+
+        if 21 in rows_by_line:
+            penalty_units = min(int(line_17 or 0) + line_20, 0)
+            penalty_rate = get_low_carbon_penalty_rate(
+                int(compliance_report.compliance_period.description)
+            )
+            rows_by_line[21].value = (
+                int(
+                    (Decimal(str(penalty_units)) * Decimal(str(-penalty_rate))).max(
+                        Decimal("0")
+                    )
+                )
+                if penalty_units < 0
+                else 0
+            )
+            rows_by_line[21].description = LOW_CARBON_FUEL_TARGET_DESCRIPTIONS[21][
+                "description"
+            ].format(units="{:,}".format(penalty_units * -1), rate=penalty_rate)
+
     def convert_summary_to_dict(
         self,
         summary_obj: ComplianceReportSummary,
@@ -603,6 +664,10 @@ class ComplianceReportSummaryService:
                 locked_summary.lines_7_and_9_locked
                 or await self._should_lock_lines_7_and_9(compliance_report)
             )
+            await self._normalize_locked_supplemental_without_assessed_baseline(
+                locked_summary, compliance_report
+            )
+            self._apply_exemption_overrides(locked_summary, compliance_report)
             locked_summary.lines_6_and_8_locked = True
             return locked_summary
 

--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -502,6 +502,42 @@ class InternalCommentRepository:
         return result.scalar_one_or_none() is not None
 
     @repo_handler
+    async def get_latest_organization_comment_id(
+        self, organization_id: int, category_display_name: str
+    ) -> Optional[int]:
+        """
+        Return the current shared organization comment for a category, choosing
+        the most recently edited/created record when historical records exist.
+        """
+        result = await self.db.execute(
+            select(InternalComment.internal_comment_id)
+            .join(
+                OrganizationInternalComment,
+                OrganizationInternalComment.internal_comment_id
+                == InternalComment.internal_comment_id,
+            )
+            .outerjoin(
+                CommentCategory,
+                CommentCategory.comment_category_id
+                == InternalComment.comment_category_id,
+            )
+            .where(
+                OrganizationInternalComment.organization_id == organization_id,
+                CommentCategory.display_name == category_display_name,
+            )
+            .order_by(
+                desc(
+                    func.coalesce(
+                        InternalComment.update_date, InternalComment.create_date
+                    )
+                ),
+                desc(InternalComment.internal_comment_id),
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    @repo_handler
     async def get_entity_org_and_year(
         self, entity_type: EntityTypeEnum, entity_id: int
     ) -> Tuple[Optional[int], Optional[int]]:
@@ -793,7 +829,7 @@ class InternalCommentRepository:
 
             ilike_term = f"%{search_term}%"
             normalized_search = _SEARCH_NORMALIZE_RE.sub("", search_term).lower()
-            
+
             stripped_comment = func.regexp_replace(
                 func.coalesce(InternalComment.comment, ""),
                 r"<[^>]*>",
@@ -878,6 +914,7 @@ class InternalCommentRepository:
                 InternalComment.create_user,
                 InternalComment.create_date,
                 InternalComment.update_date,
+                InternalComment.update_user,
                 Organization.name.label("organization_name"),
                 CommentCategory.display_name.label("category"),
                 full_name_col,
@@ -932,6 +969,7 @@ class InternalCommentRepository:
                 inner_q.c.create_user,
                 inner_q.c.create_date,
                 inner_q.c.update_date,
+                inner_q.c.update_user,
                 inner_q.c.organization_name,
                 inner_q.c.category,
                 inner_q.c.full_name,
@@ -953,4 +991,28 @@ class InternalCommentRepository:
         )
 
         rows = (await self.db.execute(query)).mappings().all()
-        return ([dict(r) for r in rows], int(total))
+        comments = [dict(r) for r in rows]
+        update_usernames = {c["update_user"] for c in comments if c.get("update_user")}
+        if update_usernames:
+            update_users_result = await self.db.execute(
+                select(
+                    UserProfile.keycloak_username,
+                    (UserProfile.first_name + " " + UserProfile.last_name).label(
+                        "full_name"
+                    ),
+                ).where(UserProfile.keycloak_username.in_(update_usernames))
+            )
+            full_name_by_username = {
+                row.keycloak_username: row.full_name
+                for row in update_users_result.all()
+            }
+            for comment in comments:
+                username = comment.get("update_user")
+                comment["update_full_name"] = (
+                    full_name_by_username.get(username) if username else None
+                )
+        else:
+            for comment in comments:
+                comment["update_full_name"] = None
+
+        return (comments, int(total))

--- a/backend/lcfs/web/api/internal_comment/schema.py
+++ b/backend/lcfs/web/api/internal_comment/schema.py
@@ -82,6 +82,8 @@ class OrganizationCommentRecordSchema(BaseSchema):
     full_name: Optional[str] = None
     create_date: Optional[datetime] = None
     update_date: Optional[datetime] = None
+    update_user: Optional[str] = None
+    update_full_name: Optional[str] = None
     can_edit: bool = False
 
 

--- a/backend/lcfs/web/api/internal_comment/services.py
+++ b/backend/lcfs/web/api/internal_comment/services.py
@@ -219,6 +219,38 @@ class InternalCommentService:
                 )
 
         username = self.request.user.keycloak_username
+
+        if data.entity_type == EntityTypeEnum.ORGANIZATION:
+            category_name = (
+                data.comment_category
+                or DEFAULT_CATEGORY_BY_ENTITY[EntityTypeEnum.ORGANIZATION]
+            )
+            existing_comment_id = await self.repo.get_latest_organization_comment_id(
+                data.entity_id, category_name
+            )
+            if existing_comment_id is not None:
+                transient = InternalComment(comment=data.comment)
+                await self._populate_comment_metadata(
+                    transient,
+                    entity_type=None,
+                    entity_id=None,
+                    category_display_name=category_name,
+                )
+                updated_comment = await self.repo.update_internal_comment(
+                    internal_comment_id=existing_comment_id,
+                    new_comment_text=data.comment,
+                    visibility=CommentVisibilityEnum.INTERNAL.value,
+                    audience_scope=(
+                        data.audience_scope.value
+                        if data.audience_scope is not None
+                        else None
+                    ),
+                    comment_category_id=transient.comment_category_id,
+                    comment_search_text=transient.comment_search_text,
+                    comment_search_vector=transient.comment_search_vector,
+                )
+                return InternalCommentResponseSchema.model_validate(updated_comment)
+
         comment = InternalComment(
             comment=data.comment,
             audience_scope=data.audience_scope,
@@ -235,17 +267,16 @@ class InternalCommentService:
             comment, data.entity_type, data.entity_id
         )
 
-        if (
-            not is_government_user
-            and data.entity_type == EntityTypeEnum.CI_APPLICATION
-        ):
+        if not is_government_user and data.entity_type == EntityTypeEnum.CI_APPLICATION:
             await self._send_ci_comment_notification(
                 data.entity_id,
                 "applicant_activity",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
             )
         elif (
             is_government_user
@@ -256,9 +287,11 @@ class InternalCommentService:
                 data.entity_id,
                 "government_action",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
                 related_organization_id=created_comment.organization_id,
             )
 
@@ -513,7 +546,18 @@ class InternalCommentService:
                 full_name=row["full_name"],
                 create_date=row["create_date"],
                 update_date=row["update_date"],
-                can_edit=bool(username is not None and row["create_user"] == username),
+                update_user=row.get("update_user"),
+                update_full_name=row.get("update_full_name"),
+                can_edit=bool(
+                    username is not None
+                    and (
+                        row["create_user"] == username
+                        or (
+                            is_government_user
+                            and row["entity_type"] == EntityTypeEnum.ORGANIZATION.value
+                        )
+                    )
+                ),
             )
             for row in rows
         ]

--- a/backend/lcfs/web/api/internal_comment/views.py
+++ b/backend/lcfs/web/api/internal_comment/views.py
@@ -183,10 +183,20 @@ async def update_comment(
         raise HTTPException(status_code=404, detail="Internal comment not found.")
 
     current_username = request.user.keycloak_username
-    # Administrators may edit any comment; everyone else only their own.
+    # Administrators may edit any comment; Company Overview is a shared
+    # organization statement editable by government analysts; everyone else
+    # only edits their own comments.
     user_role_names = request.user.role_names
     is_admin = RoleEnum.ADMINISTRATOR in user_role_names
-    if existing_comment.create_user != current_username and not is_admin:
+    is_shared_company_overview = (
+        RoleEnum.GOVERNMENT in user_role_names
+        and await service.repo.is_organization_comment(internal_comment_id)
+    )
+    if (
+        existing_comment.create_user != current_username
+        and not is_admin
+        and not is_shared_company_overview
+    ):
         raise HTTPException(
             status_code=403, detail="User is not the creator of the comment."
         )

--- a/frontend/src/assets/locales/en/organization.json
+++ b/frontend/src/assets/locales/en/organization.json
@@ -72,9 +72,9 @@
   "sections": {
     "companyOverview": {
       "title": "Company overview",
-      "description": "Internal notes about this organization. Comments are searchable in the Comment log.",
-      "empty": "No company overview comments yet.",
-      "addTitle": "Add a company overview comment"
+      "description": "Internal shared overview for this organization. Previous overview comments remain searchable in the Comment log.",
+      "empty": "No company overview statement yet.",
+      "addTitle": "Add company overview"
     },
     "penaltyLog": {
       "title": "Penalty log",

--- a/frontend/src/components/Comments/CommentForm.jsx
+++ b/frontend/src/components/Comments/CommentForm.jsx
@@ -188,7 +188,10 @@ const CommentForm = ({
   // Toolbar config is memoized so Quill doesn't reinitialize each render. The
   // custom "attach" button triggers the hidden file input via its handler.
   const quillModules = useMemo(() => {
-    const container = [['bold', 'italic'], [{ list: 'bullet' }, { list: 'ordered' }]]
+    const container = [
+      ['bold', 'italic'],
+      [{ list: 'bullet' }, { list: 'ordered' }]
+    ]
     if (attachmentsEnabled) {
       container.push(['attach'])
     }
@@ -206,7 +209,8 @@ const CommentForm = ({
   }, [attachmentsEnabled])
 
   const isCommentEmpty = !commentText || commentText.trim() === ''
-  const showVisibilityUnderTitle = showVisibilityToggle && visibilityAlign === 'left'
+  const showVisibilityUnderTitle =
+    showVisibilityToggle && visibilityAlign === 'left'
 
   return (
     <>
@@ -214,7 +218,9 @@ const CommentForm = ({
         styles={{
           '.ql-editor': {
             minHeight: '75px',
-            backgroundColor: '#fff'
+            backgroundColor: '#fff',
+            fontSize: '1rem',
+            lineHeight: 1.5
           },
           '.ql-toolbar.ql-snow': {
             border: 'none !important',

--- a/frontend/src/components/Comments/CommentList.jsx
+++ b/frontend/src/components/Comments/CommentList.jsx
@@ -247,7 +247,7 @@ const CommentList = ({
             paddingLeft: '35px',
             marginTop: '0'
           },
-          'comment-content li': {
+          '.comment-content li': {
             lineHeight: '1.6'
           }
         }}

--- a/frontend/src/hooks/useOrganizationComments.ts
+++ b/frontend/src/hooks/useOrganizationComments.ts
@@ -32,6 +32,8 @@ export interface OrganizationCommentRecord {
   fullName: string | null
   createDate: string | null
   updateDate: string | null
+  updateUser: string | null
+  updateFullName: string | null
   canEdit: boolean
 }
 

--- a/frontend/src/views/Organizations/OrganizationView/components/CommentLog/CommentRow.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/CommentLog/CommentRow.jsx
@@ -74,6 +74,7 @@ export const CommentRow = forwardRef(function CommentRow(
     showInternalBadge,
     isGovernmentUser,
     allowPublicVisibility = true,
+    useLatestAttribution = false,
     searchQuery = '',
     onEdit,
     isEditPending
@@ -108,6 +109,14 @@ export const CommentRow = forwardRef(function CommentRow(
   )
 
   const edited = isCommentEdited(comment.createDate, comment.updateDate)
+  const displayName =
+    useLatestAttribution && edited
+      ? comment.updateFullName || comment.updateUser || comment.fullName
+      : comment.fullName
+  const displayUser =
+    useLatestAttribution && edited ? comment.updateUser : comment.createUser
+  const displayDate =
+    useLatestAttribution && edited ? comment.updateDate : comment.createDate
   const isInternal = comment.visibility === 'Internal'
   const renderVisibilityChip =
     !!comment.visibility && (showInternalBadge || !isInternal)
@@ -140,7 +149,7 @@ export const CommentRow = forwardRef(function CommentRow(
         }
       }}
     >
-      <Tooltip title={comment.fullName || ''} arrow>
+      <Tooltip title={displayName || ''} arrow>
         <Avatar
           sx={{
             width: 32,
@@ -151,10 +160,10 @@ export const CommentRow = forwardRef(function CommentRow(
             mt: 2.5,
             mr: 2
           }}
-          aria-label={`Comment by ${comment.fullName || comment.createUser || ''}`}
+          aria-label={`Comment by ${displayName || displayUser || ''}`}
           role="img"
         >
-          {getInitials(comment.fullName) || '?'}
+          {getInitials(displayName) || '?'}
         </Avatar>
       </Tooltip>
       <BCBox
@@ -205,12 +214,12 @@ export const CommentRow = forwardRef(function CommentRow(
               />
             )}
             <BCTypography variant="body2" color="text" component="span">
-              <strong>{comment.fullName || comment.createUser || '—'}</strong>
-              {comment.createDate && (
+              <strong>{displayName || displayUser || '—'}</strong>
+              {displayDate && (
                 <>
                   {', '}
-                  <time dateTime={comment.createDate}>
-                    {formatCommentDateTime(comment.createDate)}
+                  <time dateTime={displayDate}>
+                    {formatCommentDateTime(displayDate)}
                   </time>
                 </>
               )}
@@ -326,9 +335,22 @@ export const CommentRow = forwardRef(function CommentRow(
             )}
           </BCBox>
         </BCBox>
-        <div
+        <BCBox
           className="comment-content"
           data-test="comment-body"
+          sx={{
+            wordBreak: 'break-word',
+            fontSize: '1rem',
+            lineHeight: 1.5,
+            '& p': { margin: '0.25rem 0' },
+            '& ul, & ol': {
+              paddingLeft: '1.5rem',
+              margin: '0.25rem 0'
+            },
+            '& li': {
+              lineHeight: 1.6
+            }
+          }}
           dangerouslySetInnerHTML={{ __html: renderedHtml }}
         />
         {editing && (

--- a/frontend/src/views/Organizations/OrganizationView/components/CompanyOverviewComments.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/CompanyOverviewComments.jsx
@@ -45,6 +45,12 @@ export const CompanyOverviewComments = ({
   const editMutation = useEditOrganizationComment(organizationId)
 
   const comments = data?.comments ?? []
+  const overviewComment = comments.reduce((latest, comment) => {
+    if (!latest) return comment
+    const latestDate = latest.updateDate ?? latest.createDate ?? ''
+    const commentDate = comment.updateDate ?? comment.createDate ?? ''
+    return commentDate > latestDate ? comment : latest
+  }, null)
 
   const handleCreate = async (text) => {
     const body = (text ?? '').trim()
@@ -79,7 +85,7 @@ export const CompanyOverviewComments = ({
 
             {isLoading ? (
               <Loading />
-            ) : comments.length === 0 ? (
+            ) : !overviewComment ? (
               <Alert
                 severity="info"
                 icon={false}
@@ -88,9 +94,6 @@ export const CompanyOverviewComments = ({
                 {t('org:sections.companyOverview.empty')}
               </Alert>
             ) : (
-              // Same container structure as the org Comment Log so the shared
-              // CommentRow renders identically in both places (bordered white
-              // panel + semantic list).
               <BCBox
                 variant="bordered"
                 borderRadius="sm"
@@ -98,38 +101,39 @@ export const CompanyOverviewComments = ({
                 sx={{ p: 2, backgroundColor: '#ffffff' }}
               >
                 <Box component="ul" sx={{ listStyle: 'none', p: 0, m: 0 }}>
-                  {comments.map((comment, index) => (
-                    <Box
-                      key={comment.internalCommentId}
-                      component="li"
-                      sx={{ listStyle: 'none' }}
-                    >
-                      <CommentRow
-                        comment={comment}
-                        index={index}
-                        showInternalBadge={isGovernmentUser}
-                        isGovernmentUser={isGovernmentUser}
-                        allowPublicVisibility={false}
-                        onEdit={handleEdit}
-                        isEditPending={editMutation.isPending}
-                      />
-                    </Box>
-                  ))}
+                  <Box
+                    key={overviewComment.internalCommentId}
+                    component="li"
+                    sx={{ listStyle: 'none' }}
+                  >
+                    <CommentRow
+                      comment={overviewComment}
+                      index={0}
+                      showInternalBadge={isGovernmentUser}
+                      isGovernmentUser={isGovernmentUser}
+                      allowPublicVisibility={false}
+                      useLatestAttribution
+                      onEdit={handleEdit}
+                      isEditPending={editMutation.isPending}
+                    />
+                  </Box>
                 </Box>
               </BCBox>
             )}
 
-            <BCBox sx={{ mt: 2 }} data-test="company-overview-add">
-              <CommentForm
-                title={t('org:sections.companyOverview.addTitle')}
-                commentText={commentText}
-                onCommentChange={setCommentText}
-                onSubmit={handleCreate}
-                isSubmitting={createMutation.isPending}
-                showVisibilityToggle={false}
-                visibility={VISIBILITY}
-              />
-            </BCBox>
+            {!overviewComment && (
+              <BCBox sx={{ mt: 2 }} data-test="company-overview-add">
+                <CommentForm
+                  title={t('org:sections.companyOverview.addTitle')}
+                  commentText={commentText}
+                  onCommentChange={setCommentText}
+                  onSubmit={handleCreate}
+                  isSubmitting={createMutation.isPending}
+                  showVisibilityToggle={false}
+                  visibility={VISIBILITY}
+                />
+              </BCBox>
+            )}
           </BCBox>
         }
       />

--- a/frontend/src/views/Organizations/OrganizationView/components/__tests__/CompanyOverviewComments.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/__tests__/CompanyOverviewComments.test.jsx
@@ -46,9 +46,16 @@ vi.mock('@/components/Comments/CommentForm', () => ({
 }))
 
 vi.mock('../CommentLog/CommentRow', () => ({
-  CommentRow: ({ comment, onEdit, allowPublicVisibility }) => (
+  CommentRow: ({
+    comment,
+    onEdit,
+    allowPublicVisibility,
+    useLatestAttribution
+  }) => (
     <div data-test="comment-row">
+      <span data-test="comment-id">{comment.internalCommentId}</span>
       <span>{comment.comment}</span>
+      {useLatestAttribution && <div data-test="latest-attribution" />}
       {allowPublicVisibility && <div data-test="row-visibility-toggle" />}
       <button
         data-test={`edit-${comment.internalCommentId}`}
@@ -102,12 +109,24 @@ describe('CompanyOverviewComments (#4608)', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('renders existing comments through CommentRow', () => {
+  it('renders the most recently touched overview comment as the shared statement', () => {
     mockThread.mockReturnValue({
       data: {
         comments: [
-          { internalCommentId: 1, comment: '<p>Alpha</p>', canEdit: true },
-          { internalCommentId: 2, comment: '<p>Beta</p>', canEdit: false }
+          {
+            internalCommentId: 1,
+            comment: '<p>Alpha</p>',
+            canEdit: true,
+            createDate: '2026-01-01T00:00:00Z',
+            updateDate: null
+          },
+          {
+            internalCommentId: 2,
+            comment: '<p>Beta</p>',
+            canEdit: true,
+            createDate: '2026-01-02T00:00:00Z',
+            updateDate: '2026-01-03T00:00:00Z'
+          }
         ]
       },
       isLoading: false,
@@ -115,7 +134,10 @@ describe('CompanyOverviewComments (#4608)', () => {
     })
     renderCard(<CompanyOverviewComments organizationId={7} />)
     expect(screen.getByTestId('company-overview-list')).toBeInTheDocument()
-    expect(screen.getAllByTestId('comment-row')).toHaveLength(2)
+    expect(screen.getAllByTestId('comment-row')).toHaveLength(1)
+    expect(screen.getByTestId('comment-id')).toHaveTextContent('2')
+    expect(screen.getByTestId('latest-attribution')).toBeInTheDocument()
+    expect(screen.queryByTestId('company-overview-add')).not.toBeInTheDocument()
   })
 
   it('creates a comment via the create mutation', async () => {


### PR DESCRIPTION
Fixes #4866 

For historical/government-initiated supplementals when the original same-period report was never assessed and if there are no previously issued units to carry forward, stored Line 15/16 values from the prior submitted version will be turned 0.