### PR TITLE
Fix: Investigate bug in summary section of report 2772

### DIFF
--- a/backend/lcfs/tests/compliance_report/test_summary_service.py
+++ b/backend/lcfs/tests/compliance_report/test_summary_service.py
@@ -3103,6 +3103,53 @@ async def test_line_15_16_zero_when_no_assessed_report_for_supplemental(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("compliance_year", ["2024", "2025"])
+async def test_locked_supplemental_summary_recomputes_carry_forward_when_no_assessed_report(
+    compliance_report_summary_service,
+    mock_repo,
+    compliance_year,
+):
+    """
+    Locked supplemental reports without an assessed same-period baseline should
+    not display previous-version issued units as Line 15/16 carry-forward.
+
+    This covers historical/migrated records such as CR2772 where the final
+    transaction was created for the correct issuance, but the stored summary
+    still showed Line 15 = current issuance and Line 20 = 0.
+    """
+    summary = make_summary(locked=True)
+    summary.summary_id = 1
+    summary.compliance_report_id = 2772
+    summary.line_15_banked_units_used = 212
+    summary.line_16_banked_units_remaining = 0
+    summary.line_17_non_banked_units_used = 1000
+    summary.line_18_units_to_be_banked = 212
+    summary.line_19_units_to_be_exported = 0
+    summary.line_20_surplus_deficit_units = 0
+    summary.line_21_non_compliance_penalty_payable = 0
+    summary.line_22_compliance_units_issued = 1000
+
+    report = make_report(1, ComplianceReportStatusEnum.Assessed, compliance_year)
+    report.summary = summary
+    report.compliance_report_id = 2772
+
+    mock_repo.get_compliance_report_by_id = AsyncMock(return_value=report)
+    mock_repo.get_assessed_compliance_report_by_period = AsyncMock(return_value=None)
+
+    result = (
+        await compliance_report_summary_service.calculate_compliance_report_summary(
+            report_id=2772
+        )
+    )
+
+    line_values = _get_line_values(result.low_carbon_fuel_target_summary)
+    assert line_values[15] == 0
+    assert line_values[16] == 0
+    assert line_values[20] == 212
+    assert line_values[22] == 1212
+
+
+@pytest.mark.anyio
 async def test_line_15_16_uses_assessed_report_values(
     compliance_report_summary_service,
     mock_repo,

--- a/backend/lcfs/web/api/compliance_report/summary_service.py
+++ b/backend/lcfs/web/api/compliance_report/summary_service.py
@@ -162,6 +162,67 @@ class ComplianceReportSummaryService:
         )
         return prev_compliance_report is not None
 
+    async def _normalize_locked_supplemental_without_assessed_baseline(
+        self,
+        summary: ComplianceReportSummarySchema,
+        compliance_report: ComplianceReport,
+    ) -> None:
+        """Correct stale low-carbon carry-forward rows for locked supplementals.
+
+        Some historical/government-initiated supplementals can exist even when
+        the original same-period report was never assessed. In that case there
+        are no previously issued units to carry forward, so stored Line 15/16
+        values from the prior submitted version must not affect the displayed
+        balance.
+        """
+        report_version = getattr(compliance_report, "version", None)
+        if not isinstance(report_version, int) or report_version <= 0:
+            return
+
+        assessed_report = await self.cr_repo.get_assessed_compliance_report_by_period(
+            compliance_report.organization_id,
+            int(compliance_report.compliance_period.description),
+            compliance_report.compliance_report_id,
+        )
+        if assessed_report:
+            return
+
+        rows_by_line = {
+            int(row.line): row
+            for row in summary.low_carbon_fuel_target_summary or []
+            if row.line is not None
+        }
+        if not rows_by_line:
+            return
+
+        line_17 = rows_by_line.get(17).value if rows_by_line.get(17) else 0
+        line_18 = rows_by_line.get(18).value if rows_by_line.get(18) else 0
+        line_19 = rows_by_line.get(19).value if rows_by_line.get(19) else 0
+        line_20 = int(line_18 or 0) + int(line_19 or 0)
+        line_22 = max(int(line_17 or 0) + line_20, 0)
+
+        for line, value in ((15, 0), (16, 0), (20, line_20), (22, line_22)):
+            if line in rows_by_line:
+                rows_by_line[line].value = value
+
+        if 21 in rows_by_line:
+            penalty_units = min(int(line_17 or 0) + line_20, 0)
+            penalty_rate = get_low_carbon_penalty_rate(
+                int(compliance_report.compliance_period.description)
+            )
+            rows_by_line[21].value = (
+                int(
+                    (Decimal(str(penalty_units)) * Decimal(str(-penalty_rate))).max(
+                        Decimal("0")
+                    )
+                )
+                if penalty_units < 0
+                else 0
+            )
+            rows_by_line[21].description = LOW_CARBON_FUEL_TARGET_DESCRIPTIONS[21][
+                "description"
+            ].format(units="{:,}".format(penalty_units * -1), rate=penalty_rate)
+
     def convert_summary_to_dict(
         self,
         summary_obj: ComplianceReportSummary,
@@ -603,6 +664,10 @@ class ComplianceReportSummaryService:
                 locked_summary.lines_7_and_9_locked
                 or await self._should_lock_lines_7_and_9(compliance_report)
             )
+            await self._normalize_locked_supplemental_without_assessed_baseline(
+                locked_summary, compliance_report
+            )
+            self._apply_exemption_overrides(locked_summary, compliance_report)
             locked_summary.lines_6_and_8_locked = True
             return locked_summary
 


### PR DESCRIPTION
Fixes #4866

For historical/government-initiated supplementals when the original same-period report was never assessed and if there are no previously issued units to carry forward, stored Line 15/16 values from the prior submitted version will be turned 0.