### PR TITLE
Feat: IDIR Initiative Agreement information display - 4839

### DIFF
--- a/backend/lcfs/db/seeders/dev/initiative_agreement_seeder.py
+++ b/backend/lcfs/db/seeders/dev/initiative_agreement_seeder.py
@@ -1,0 +1,173 @@
+import structlog
+from datetime import date
+
+from sqlalchemy import select
+
+from lcfs.db.models.initiative_agreement.DesignatedAction import DesignatedAction
+from lcfs.db.models.initiative_agreement.DesignatedActionStatus import (
+    DesignatedActionStatus,
+)
+from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
+    RECORD_KIND_AGREEMENT,
+    InitiativeAgreement,
+)
+from lcfs.db.models.initiative_agreement.InitiativeAgreementLifecycleStatus import (
+    InitiativeAgreementLifecycleStatus,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+async def _lifecycle_status_id(session, status):
+    return (
+        await session.execute(
+            select(
+                InitiativeAgreementLifecycleStatus.initiative_agreement_lifecycle_status_id
+            ).where(InitiativeAgreementLifecycleStatus.status == status)
+        )
+    ).scalar_one()
+
+
+async def _action_status_id(session, status):
+    return (
+        await session.execute(
+            select(DesignatedActionStatus.designated_action_status_id).where(
+                DesignatedActionStatus.status == status
+            )
+        )
+    ).scalar_one()
+
+
+async def seed_initiative_agreements(session):
+    """
+    Seeds agreement-kind initiative agreements with designated actions, if
+    they do not already exist. Legacy award rows are untouched; these rows
+    carry record_kind='agreement' so the module's grids can render locally
+    before the consolidation backfill runs.
+    """
+
+    agreements_to_seed = [
+        {
+            "ia_code": "IA-26DEV1",
+            "to_organization_id": 1,
+            "record_kind": RECORD_KIND_AGREEMENT,
+            "lifecycle_status": "Underway",
+            "title": "Hydrogen fueling network expansion",
+            "project_description": (
+                "Construction and commissioning of hydrogen fueling stations "
+                "in the Lower Mainland with associated production capacity."
+            ),
+            "entry_date": date(2026, 1, 15),
+            "agreement_start_date": date(2026, 6, 19),
+            "agreement_end_date": date(2027, 5, 3),
+            "total_credits_allocated": 30234,
+            "actions": [
+                {
+                    "action_number": 1,
+                    "name": "Commission first fueling station",
+                    "credit_allocation": 1850,
+                    "status": "Underway",
+                    "specified_date": date(2026, 9, 30),
+                },
+                {
+                    "action_number": 2,
+                    "name": "Commission second fueling station",
+                    "credit_allocation": 1075,
+                    "status": "Not started",
+                    "specified_date": date(2027, 1, 31),
+                },
+                {
+                    "action_number": 3,
+                    "name": "Commission electrolysis production facility",
+                    "credit_allocation": 27309,
+                    "status": "Not started",
+                    "specified_date": date(2027, 4, 30),
+                },
+            ],
+        },
+        {
+            "ia_code": "IA-26DEV2",
+            "to_organization_id": 2,
+            "record_kind": RECORD_KIND_AGREEMENT,
+            "lifecycle_status": "Draft",
+            "title": "Renewable diesel co-processing upgrade",
+            "project_description": (
+                "Refinery upgrades enabling co-processing of renewable "
+                "feedstock. Agreement drafting is underway."
+            ),
+            "entry_date": date(2026, 3, 2),
+            "total_credits_allocated": 12000,
+            "actions": [],
+        },
+        {
+            "ia_code": "IA-25DEV3",
+            "to_organization_id": 3,
+            "record_kind": RECORD_KIND_AGREEMENT,
+            "lifecycle_status": "Completed",
+            "title": "Public DC fast-charging corridor",
+            "project_description": (
+                "Deployment of DC fast-charging sites along Highway 97, "
+                "completed and verified."
+            ),
+            "entry_date": date(2025, 2, 10),
+            "agreement_start_date": date(2025, 4, 1),
+            "agreement_end_date": date(2026, 3, 31),
+            "total_credits_allocated": 5400,
+            "total_credits_issued": 5400,
+            "actions": [
+                {
+                    "action_number": 1,
+                    "name": "Energize all corridor sites",
+                    "credit_allocation": 5400,
+                    "status": "Approved",
+                    "specified_date": date(2026, 1, 31),
+                    "completed_date": date(2026, 1, 20),
+                    "determination": "Compliant",
+                    "determination_date": date(2026, 2, 14),
+                },
+            ],
+        },
+    ]
+
+    try:
+        for agreement_data in agreements_to_seed:
+            exists = (
+                (
+                    await session.execute(
+                        select(InitiativeAgreement).where(
+                            InitiativeAgreement.ia_code == agreement_data["ia_code"]
+                        )
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if exists:
+                continue
+
+            actions = agreement_data.pop("actions")
+            lifecycle_status = agreement_data.pop("lifecycle_status")
+            agreement = InitiativeAgreement(
+                **agreement_data,
+                lifecycle_status_id=await _lifecycle_status_id(
+                    session, lifecycle_status
+                ),
+            )
+            session.add(agreement)
+            await session.flush()
+
+            for action_data in actions:
+                action_status = action_data.pop("status")
+                session.add(
+                    DesignatedAction(
+                        **action_data,
+                        initiative_agreement_id=agreement.initiative_agreement_id,
+                        current_status_id=await _action_status_id(
+                            session, action_status
+                        ),
+                    )
+                )
+        await session.flush()
+    except Exception as e:
+        logger.error("Error occurred while seeding initiative agreements: %s", e)
+        raise

--- a/backend/lcfs/db/seeders/dev_seeder.py
+++ b/backend/lcfs/db/seeders/dev_seeder.py
@@ -14,6 +14,9 @@ from lcfs.db.seeders.dev.organization_early_issuance_seeder import (
     seed_organization_early_issuance,
 )
 from lcfs.db.seeders.dev.admin_adjustment_seeder import seed_admin_adjustments
+from lcfs.db.seeders.dev.initiative_agreement_seeder import (
+    seed_initiative_agreements,
+)
 from lcfs.db.seeders.dev.admin_adjustment_history_seeder import (
     seed_admin_adjustment_history,
 )
@@ -116,13 +119,14 @@ async def seed_dev(session: AsyncSession):
     await seed_organization_attorney_addresses(session)
     await seed_organizations(session)
     await seed_organization_early_issuance(session)
-    
+
     # Seed user-related entities
     await seed_user_profiles(session)
     await seed_user_roles(session)
     # seed transactions and adjustments
     await seed_test_transactions(session)
     await seed_admin_adjustments(session)
+    await seed_initiative_agreements(session)
     # Seed fuel codes
     await seed_test_fuel_codes(session)
     # Seed compliance-related entities
@@ -137,7 +141,7 @@ async def seed_dev(session: AsyncSession):
     await seed_test_charging_sites(session)
     await seed_test_charging_equipment(session)
     await seed_test_compliance_report_history(session)
-    
+
     # Seed documents after compliance reports (dependency)
     await seed_test_documents(session)
 
@@ -145,7 +149,7 @@ async def seed_dev(session: AsyncSession):
     await seed_test_transfers(session)
     await seed_test_transfer_history(session)
 
-    # Seed remaining 
+    # Seed remaining
     await seed_finished_fuel_transfer_modes(session)
     await seed_feedstock_fuel_transfer_modes(session)
     await seed_charging_power_output(session)

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -32,6 +32,8 @@ from lcfs.db.models.ci_application.CIApplication import (
     ci_application_document_association,
 )
 from lcfs.db.models.document import Document
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.db.models.comment.InternalComment import (
     InternalComment,
     internal_comment_document_association,
@@ -597,6 +599,25 @@ class DocumentService:
         )
         result = await self.db.execute(stmt)
         return result.scalars().all()
+
+    async def get_uploading_organization_codes(self, usernames):
+        """Map uploader usernames to their organization's code.
+
+        Government (IDIR) users carry no organization, so they are absent
+        from the result and their uploads render as government files.
+        """
+        if not usernames:
+            return {}
+        stmt = (
+            select(UserProfile.keycloak_username, Organization.organization_code)
+            .join(
+                Organization,
+                UserProfile.organization_id == Organization.organization_id,
+            )
+            .where(UserProfile.keycloak_username.in_(usernames))
+        )
+        result = await self.db.execute(stmt)
+        return {username: code for username, code in result.all()}
 
     @repo_handler
     async def get_object(self, document_id: int):

--- a/backend/lcfs/services/s3/schema.py
+++ b/backend/lcfs/services/s3/schema.py
@@ -11,6 +11,9 @@ class FileResponseSchema(BaseSchema):
     # Step 3 categorisation; only populated for ci_application uploads.
     document_category: str | None = None
     display_name: str | None = None
+    # Code of the uploading user's organization; None for government
+    # (IDIR) uploads. Populated by the document list endpoint only.
+    uploading_organization_code: str | None = None
 
     class Config:
         from_attributes = True

--- a/backend/lcfs/tests/document/test_document_view.py
+++ b/backend/lcfs/tests/document/test_document_view.py
@@ -48,6 +48,10 @@ class FakeDocumentService:
             "create_user": "tester",
         }
 
+    async def get_uploading_organization_codes(self, usernames):
+        # tester belongs to a supplier organization in these fixtures.
+        return {"tester": "ABCD"} if "tester" in usernames else {}
+
     async def get_object(self, document_id: int):
         file = {
             "ContentLength": 789,
@@ -144,6 +148,7 @@ async def test_get_all_documents(fastapi_app, client):
     assert doc["fileSize"] == 123
     assert doc["createDate"] == "2024-01-01T00:00:00Z"
     assert doc["createUser"] == "tester"
+    assert doc["uploadingOrganizationCode"] == "ABCD"
 
 
 @pytest.mark.anyio
@@ -183,7 +188,7 @@ async def test_stream_document_compliance_report(fastapi_app, client):
     assert response.status_code == status.HTTP_200_OK
 
     cd = response.headers.get("Content-Disposition")
-    assert cd == 'attachment; filename="document.pdf"; filename*=UTF-8\'\'document.pdf'
+    assert cd == "attachment; filename=\"document.pdf\"; filename*=UTF-8''document.pdf"
     cl = response.headers.get("content-length")
     assert cl == "789"
 
@@ -203,7 +208,7 @@ async def test_stream_document_initiative_agreement(fastapi_app, client):
     assert response.status_code == status.HTTP_200_OK
 
     cd = response.headers.get("Content-Disposition")
-    assert cd == 'attachment; filename="document.pdf"; filename*=UTF-8\'\'document.pdf'
+    assert cd == "attachment; filename=\"document.pdf\"; filename*=UTF-8''document.pdf"
     cl = response.headers.get("content-length")
     assert cl == "789"
 
@@ -253,7 +258,7 @@ async def test_stream_document_admin_adjustment(fastapi_app, client):
     assert response.status_code == status.HTTP_200_OK
 
     cd = response.headers.get("Content-Disposition")
-    assert cd == 'attachment; filename="document.pdf"; filename*=UTF-8\'\'document.pdf'
+    assert cd == "attachment; filename=\"document.pdf\"; filename*=UTF-8''document.pdf"
     cl = response.headers.get("content-length")
     assert cl == "789"
 

--- a/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
@@ -495,21 +495,29 @@ async def test_profile_returns_the_organization_address_block(
     client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
 ):
     """The detail card renders the organization's address, phone and email."""
-    from lcfs.db.models.organization.Organization import Organization
+    from lcfs.db.models.organization.OrganizationAddress import OrganizationAddress
 
-    org = (
-        (
-            await dbsession.execute(
-                select(Organization)
-                .where(Organization.organization_address_id.is_not(None))
-                .limit(1)
-            )
-        )
-        .scalars()
-        .first()
+    address = OrganizationAddress(
+        name="Addressed Fuels",
+        street_address="697 Burrard Street",
+        city="Vancouver",
+        province_state="BC",
+        country="Canada",
+        postalCode_zipCode="V6G 2P3",
     )
-    if org is None:
-        pytest.skip("no seeded organization with an address")
+    dbsession.add(address)
+    await dbsession.flush()
+    org = Organization(
+        name="Addressed Fuels",
+        operating_name="Addressed Fuels",
+        organization_status_id=2,
+        organization_type_id=1,
+        organization_address_id=address.organization_address_id,
+        phone="604-555-0100",
+        email="contact@example.com",
+    )
+    dbsession.add(org)
+    await dbsession.flush()
 
     agreement = await _seed_agreement(dbsession, org.organization_id, "IA-26ADDR")
     set_mock_user(fastapi_app, IDIR_IA_ANALYST)
@@ -523,10 +531,11 @@ async def test_profile_returns_the_organization_address_block(
     assert response.status_code == status.HTTP_200_OK
     organization = response.json()["organization"]
     assert organization["organizationId"] == org.organization_id
-    assert organization["name"] == org.name
+    assert organization["name"] == "Addressed Fuels"
     assert "organizationCode" in organization
-    assert organization["orgAddress"] is not None
-    assert "streetAddress" in organization["orgAddress"]
+    assert organization["phone"] == "604-555-0100"
+    assert organization["orgAddress"]["streetAddress"] == "697 Burrard Street"
+    assert organization["orgAddress"]["city"] == "Vancouver"
 
 
 @pytest.mark.anyio
@@ -534,21 +543,14 @@ async def test_profile_tolerates_an_organization_without_an_address(
     client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
 ):
     """An address gap must render an incomplete card, not fail the request."""
-    from lcfs.db.models.organization.Organization import Organization
-
-    org = (
-        (
-            await dbsession.execute(
-                select(Organization)
-                .where(Organization.organization_address_id.is_(None))
-                .limit(1)
-            )
-        )
-        .scalars()
-        .first()
+    org = Organization(
+        name="No Address Holdings",
+        operating_name="No Address Holdings",
+        organization_status_id=2,
+        organization_type_id=1,
     )
-    if org is None:
-        pytest.skip("every seeded organization has an address")
+    dbsession.add(org)
+    await dbsession.flush()
 
     agreement = await _seed_agreement(dbsession, org.organization_id, "IA-26NOADDR")
     set_mock_user(fastapi_app, IDIR_IA_ANALYST)
@@ -561,3 +563,73 @@ async def test_profile_tolerates_an_organization_without_an_address(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["organization"]["orgAddress"] is None
+
+
+@pytest.mark.anyio
+async def test_agreement_documents_carry_the_uploading_organization_code(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The documents card shows which organization supplied each file;
+    government uploads carry no code."""
+    from lcfs.db.models.document import Document
+    from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
+        initiative_agreement_document_association,
+    )
+    from lcfs.db.models.user.UserProfile import UserProfile
+
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DOCS")
+
+    supplier = (
+        (
+            await dbsession.execute(
+                select(UserProfile)
+                .where(UserProfile.organization_id.isnot(None))
+                .limit(1)
+            )
+        )
+        .scalars()
+        .one()
+    )
+    org_code = (
+        await dbsession.execute(
+            select(Organization.organization_code).where(
+                Organization.organization_id == supplier.organization_id
+            )
+        )
+    ).scalar_one()
+
+    for name, uploader in (
+        ("signed-agreement.pdf", supplier.keycloak_username),
+        # No IDIR user carries an organization, so any government username
+        # exercises the None branch.
+        ("award-letter.pdf", "IDIRSTAFF"),
+    ):
+        document = Document(
+            file_key=f"ia/{name}",
+            file_name=name,
+            file_size=2048,
+            mime_type="application/pdf",
+        )
+        document.create_user = uploader
+        dbsession.add(document)
+        await dbsession.flush()
+        await dbsession.execute(
+            initiative_agreement_document_association.insert().values(
+                initiative_agreement_id=agreement.initiative_agreement_id,
+                document_id=document.document_id,
+            )
+        )
+
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    url = fastapi_app.url_path_for(
+        "get_all_documents",
+        parent_type="initiativeAgreement",
+        parent_id=agreement.initiative_agreement_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    by_name = {row["fileName"]: row for row in response.json()}
+    assert by_name["signed-agreement.pdf"]["uploadingOrganizationCode"] == org_code
+    assert by_name["award-letter.pdf"]["uploadingOrganizationCode"] is None

--- a/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
@@ -488,3 +488,76 @@ async def test_last_comment_is_plain_text(
     )
     assert row["lastComment"]["comment"] == "plain words"
     assert "<p>" not in row["lastComment"]["comment"]
+
+
+@pytest.mark.anyio
+async def test_profile_returns_the_organization_address_block(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The detail card renders the organization's address, phone and email."""
+    from lcfs.db.models.organization.Organization import Organization
+
+    org = (
+        (
+            await dbsession.execute(
+                select(Organization)
+                .where(Organization.organization_address_id.is_not(None))
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if org is None:
+        pytest.skip("no seeded organization with an address")
+
+    agreement = await _seed_agreement(dbsession, org.organization_id, "IA-26ADDR")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    url = fastapi_app.url_path_for(
+        "get_initiative_agreement_profile",
+        initiative_agreement_id=agreement.initiative_agreement_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    organization = response.json()["organization"]
+    assert organization["organizationId"] == org.organization_id
+    assert organization["name"] == org.name
+    assert "organizationCode" in organization
+    assert organization["orgAddress"] is not None
+    assert "streetAddress" in organization["orgAddress"]
+
+
+@pytest.mark.anyio
+async def test_profile_tolerates_an_organization_without_an_address(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """An address gap must render an incomplete card, not fail the request."""
+    from lcfs.db.models.organization.Organization import Organization
+
+    org = (
+        (
+            await dbsession.execute(
+                select(Organization)
+                .where(Organization.organization_address_id.is_(None))
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if org is None:
+        pytest.skip("every seeded organization has an address")
+
+    agreement = await _seed_agreement(dbsession, org.organization_id, "IA-26NOADDR")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    url = fastapi_app.url_path_for(
+        "get_initiative_agreement_profile",
+        initiative_agreement_id=agreement.initiative_agreement_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["organization"]["orgAddress"] is None

--- a/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_dev_seeder.py
+++ b/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_dev_seeder.py
@@ -1,0 +1,49 @@
+"""The dev seeder must insert agreement-kind rows and be idempotent —
+seed_database runs it on every startup of a dev stack."""
+
+import pytest
+from sqlalchemy import func, select
+
+from lcfs.db.models.initiative_agreement import DesignatedAction
+from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
+    RECORD_KIND_AGREEMENT,
+    InitiativeAgreement,
+)
+from lcfs.db.seeders.dev.initiative_agreement_seeder import (
+    seed_initiative_agreements,
+)
+
+
+@pytest.mark.anyio
+async def test_dev_seeder_inserts_agreements_and_is_idempotent(dbsession):
+    await seed_initiative_agreements(dbsession)
+    await seed_initiative_agreements(dbsession)
+
+    codes = ("IA-26DEV1", "IA-26DEV2", "IA-25DEV3")
+    agreements = (
+        (
+            await dbsession.execute(
+                select(InitiativeAgreement).where(
+                    InitiativeAgreement.ia_code.in_(codes)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(agreements) == 3
+    assert all(a.record_kind == RECORD_KIND_AGREEMENT for a in agreements)
+    assert all(a.lifecycle_status_id is not None for a in agreements)
+
+    first = next(a for a in agreements if a.ia_code == "IA-26DEV1")
+    action_count = (
+        await dbsession.execute(
+            select(func.count())
+            .select_from(DesignatedAction)
+            .where(
+                DesignatedAction.initiative_agreement_id
+                == first.initiative_agreement_id
+            )
+        )
+    ).scalar_one()
+    assert action_count == 3

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -125,10 +125,17 @@ async def get_all_documents(
     documents = await document_service.get_by_id_and_type(parent_id, parent_type)
 
     file_responses = [
-        (FileResponseSchema.model_validate(document)) for document in documents
+        FileResponseSchema.model_validate(document) for document in documents
     ]
 
-    return file_responses
+    # The IA detail page shows which organization supplied each file, so
+    # resolve uploader usernames to their organization's code in one query.
+    usernames = {f.create_user for f in file_responses if f.create_user}
+    codes = await document_service.get_uploading_organization_codes(usernames)
+    return [
+        f.model_copy(update={"uploading_organization_code": codes.get(f.create_user)})
+        for f in file_responses
+    ]
 
 
 @router.post(

--- a/backend/lcfs/web/api/initiative_agreement/repo.py
+++ b/backend/lcfs/web/api/initiative_agreement/repo.py
@@ -307,7 +307,11 @@ class InitiativeAgreementRepository:
         query = (
             select(InitiativeAgreement)
             .options(
-                selectinload(InitiativeAgreement.to_organization),
+                # The detail card renders the organization's address block, so
+                # it must be eager-loaded; a lazy load raises MissingGreenlet.
+                selectinload(InitiativeAgreement.to_organization).selectinload(
+                    Organization.org_address
+                ),
                 selectinload(InitiativeAgreement.lifecycle_status),
                 selectinload(InitiativeAgreement.designated_actions).selectinload(
                     DesignatedAction.current_status

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -28,6 +28,42 @@ class OrganizationSchema(BaseSchema):
         from_attributes = True
 
 
+class AgreementOrganizationAddressSchema(BaseSchema):
+    """
+    Every field is optional: organization address rows carry gaps, and the
+    agreement detail card must render what exists rather than 500.
+    """
+
+    name: Optional[str] = None
+    street_address: Optional[str] = None
+    address_other: Optional[str] = None
+    city: Optional[str] = None
+    province_state: Optional[str] = None
+    country: Optional[str] = None
+    postalCode_zipCode: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AgreementOrganizationSchema(BaseSchema):
+    """
+    Organization detail for the agreement header card. Kept separate from the
+    lean OrganizationSchema used by the grid and by the legacy award flow,
+    whose queries do not eager-load the address.
+    """
+
+    organization_id: int
+    name: str
+    organization_code: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    org_address: Optional[AgreementOrganizationAddressSchema] = None
+
+    class Config:
+        from_attributes = True
+
+
 class InitiativeAgreementHistorySchema(BaseSchema):
     create_date: datetime
     initiative_agreement_status: InitiativeAgreementStatusSchema
@@ -171,6 +207,8 @@ class InitiativeAgreementsListSchema(BaseSchema):
 
 
 class InitiativeAgreementProfileSchema(InitiativeAgreementListItemSchema):
+    # Overrides the grid's lean organization payload with the detail card's.
+    organization: AgreementOrganizationSchema
     project_description: Optional[str] = None
     contact_email: Optional[str] = None
     contact_phone: Optional[str] = None

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -1,7 +1,7 @@
 {
   "title": "Initiative agreements",
   "initiativeAgreementsPlaceholder": "This section will provide access to Initiative Agreement functionality. Content and features are currently under development.",
-  "initiativeAgreement": "Initiative agreement — ID:",
+  "initiativeAgreement": "Initiative agreement \u2014 ID:",
   "editInitiativeAgreementID": "Edit initiative agreement ID: ",
   "newInitiativeAgreement": "New initiative agreement",
   "actionMsgs": {
@@ -44,6 +44,14 @@
     "initiativeAgreementCode": "Initiative agreement:",
     "startDate": "Start date:",
     "endDate": "End date:",
-    "sectionPlaceholder": "This section is under development and will be populated once the agreement management API is available."
+    "sectionPlaceholder": "This section is under development and will be populated once the agreement management API is available.",
+    "manageDocuments": "Manage documents",
+    "noDocuments": "No documents have been attached to this agreement.",
+    "loadFailMsg": "Failed to load the initiative agreement."
+  },
+  "documents": {
+    "uploadTitle": "Initiative Agreement documents",
+    "documentLabel": "the initiative agreement",
+    "returnButton": "Return to initiative agreement"
   }
 }

--- a/frontend/src/components/Documents/DocumentUploadDialog.jsx
+++ b/frontend/src/components/Documents/DocumentUploadDialog.jsx
@@ -5,7 +5,12 @@ import BCTypography from '@/components/BCTypography'
 import DocumentTable from '@/components/Documents/DocumentTable.jsx'
 
 function DocumentUploadDialog({ open, close, parentType, parentID }) {
-  const { t } = useTranslation(['report', 'chargingSite', 'carbonIntensity'])
+  const { t } = useTranslation([
+    'report',
+    'chargingSite',
+    'carbonIntensity',
+    'initiativeAgreement'
+  ])
   const onClose = () => {
     close()
   }
@@ -23,6 +28,12 @@ function DocumentUploadDialog({ open, close, parentType, parentID }) {
           title: t('carbonIntensity:documents.uploadTitle'),
           documentLabel: t('carbonIntensity:documents.documentLabel'),
           returnButton: t('carbonIntensity:documents.returnButton')
+        }
+      case 'initiativeAgreement':
+        return {
+          title: t('initiativeAgreement:documents.uploadTitle'),
+          documentLabel: t('initiativeAgreement:documents.documentLabel'),
+          returnButton: t('initiativeAgreement:documents.returnButton')
         }
       case 'compliance_report':
       default:

--- a/frontend/src/layouts/MainLayout/components/Crumb.tsx
+++ b/frontend/src/layouts/MainLayout/components/Crumb.tsx
@@ -7,6 +7,7 @@ import { isNumeric } from '@/utils/formatters'
 import { useOrganizationPageStore } from '@/stores/useOrganizationPageStore'
 import useComplianceReportStore from '@/stores/useComplianceReportStore'
 import { useFuelCodePageStore } from '@/stores/useFuelCodePageStore'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 
 type RouteTitleResolver = (args: {
   params: Record<string, string | undefined>
@@ -80,6 +81,9 @@ const Crumb = () => {
     (state) => state.activeTabLabel
   )
   const fuelCodeTitle = useFuelCodePageStore((state) => state.fuelCodeTitle)
+  const initiativeAgreementCrumb = useInitiativeAgreementPageStore(
+    (state) => state.agreementCrumb
+  )
 
   // Get the actual compliance period from the cached report data (not the URL)
   // This prevents URL manipulation from showing incorrect year in breadcrumbs
@@ -253,6 +257,10 @@ const Crumb = () => {
 
           const isFuelCodeViewLast =
             isLast && name === 'view' && pathnames[0] === 'fuel-codes'
+          const isInitiativeAgreementIdLast =
+            isLast &&
+            isNumeric(name) &&
+            pathnames[0] === 'initiative-agreements'
 
           return isLast ? (
             <StyledBreadcrumb
@@ -261,11 +269,13 @@ const Crumb = () => {
               label={
                 isFuelCodeViewLast && fuelCodeTitle
                   ? fuelCodeTitle
-                  : title && title !== ''
-                    ? title
-                    : isNumeric(name)
-                      ? 'ID: ' + name
-                      : displayName
+                  : isInitiativeAgreementIdLast && initiativeAgreementCrumb
+                    ? initiativeAgreementCrumb
+                    : title && title !== ''
+                      ? title
+                      : isNumeric(name)
+                        ? 'ID: ' + name
+                        : displayName
               }
               key={name}
             />

--- a/frontend/src/layouts/MainLayout/components/__tests__/Crumb.test.tsx
+++ b/frontend/src/layouts/MainLayout/components/__tests__/Crumb.test.tsx
@@ -1,9 +1,18 @@
 import { render, screen } from '@testing-library/react'
 import Crumb from '../Crumb'
-import { vi, describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest'
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock
+} from 'vitest'
 import { wrapper } from '@/tests/utils/wrapper'
 import { useLocation, useMatches, useParams } from 'react-router-dom'
 import { useOrganizationPageStore } from '@/stores/useOrganizationPageStore'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 
 // Mock router hooks
 vi.mock('react-router-dom', async () => {
@@ -88,6 +97,32 @@ describe('Crumb', () => {
     expect(screen.getByText('Admin Dashboard')).toBeInTheDocument()
   })
 
+  it('shows the agreement code for an initiative agreement detail path', () => {
+    setupRouterMocks({
+      pathname: '/initiative-agreements/5',
+      matches: [{ handle: { title: 'Initiative agreement' } }]
+    })
+    useInitiativeAgreementPageStore.getState().setAgreementCrumb('IA-26ORG1')
+
+    render(<Crumb />, { wrapper })
+
+    expect(screen.getByText('Initiative agreements')).toBeInTheDocument()
+    expect(screen.getByText('IA-26ORG1')).toBeInTheDocument()
+
+    useInitiativeAgreementPageStore.getState().setAgreementCrumb(null)
+  })
+
+  it('falls back to the route title when no agreement code is set', () => {
+    setupRouterMocks({
+      pathname: '/initiative-agreements/5',
+      matches: [{ handle: { title: 'Initiative agreement' } }]
+    })
+
+    render(<Crumb />, { wrapper })
+
+    expect(screen.getByText('Initiative agreement')).toBeInTheDocument()
+  })
+
   it('displays numeric IDs with ID prefix', () => {
     setupRouterMocks({
       pathname: '/transactions/12345',
@@ -129,12 +164,10 @@ describe('Crumb', () => {
       matches: [{ handle: { title: 'Organization users' } }]
     })
 
-    useOrganizationPageStore
-      .getState()
-      .setOrganizationContext({
-        organizationName: 'LCFS Org 1',
-        activeTabLabel: 'Users'
-      })
+    useOrganizationPageStore.getState().setOrganizationContext({
+      organizationName: 'LCFS Org 1',
+      activeTabLabel: 'Users'
+    })
 
     render(<Crumb />, { wrapper })
 

--- a/frontend/src/stores/useInitiativeAgreementPageStore.ts
+++ b/frontend/src/stores/useInitiativeAgreementPageStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand'
+
+// Feeds the breadcrumb the agreement's code (e.g. "IA-26ORG1") while an
+// initiative agreement detail page is mounted; mirrors useFuelCodePageStore.
+type InitiativeAgreementPageStore = {
+  agreementCrumb: string | null
+  setAgreementCrumb: (title: string | null) => void
+}
+
+export const useInitiativeAgreementPageStore =
+  create<InitiativeAgreementPageStore>((set) => ({
+    agreementCrumb: null,
+    setAgreementCrumb: (title) => set({ agreementCrumb: title })
+  }))

--- a/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
@@ -1,75 +1,249 @@
-import BCBox from '@/components/BCBox'
-import BCTypography from '@/components/BCTypography'
-import { roles } from '@/constants/roles'
-import { ROUTES } from '@/routes/routes'
-import withRole from '@/utils/withRole'
-import { Divider, Paper } from '@mui/material'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
+import { Divider, Paper, Stack } from '@mui/material'
+import Grid2 from '@mui/material/Grid2'
+
+import BCAlert from '@/components/BCAlert'
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
+import Loading from '@/components/Loading'
+import { Role } from '@/components/Role'
+import DocumentUploadDialog from '@/components/Documents/DocumentUploadDialog'
+import { SupportingDocumentSummary } from '@/views/SupportingDocuments/SupportingDocumentSummary'
+import { roles } from '@/constants/roles'
+import { useDocuments } from '@/hooks/useDocuments'
+import { ROUTES } from '@/routes/routes'
+import { constructAddress } from '@/utils/constructAddress'
+import { dateFormatter } from '@/utils/formatters'
+import withRole from '@/utils/withRole'
+
+import { useGetInitiativeAgreement } from '@/hooks/useInitiativeAgreements'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 
-const SectionPlaceholder = ({ titleKey, testId }) => {
-  const { t } = useTranslation(['initiativeAgreement'])
-  return (
-    <Paper variant="outlined" sx={{ p: 3, mb: 3 }} data-test={testId}>
-      <BCTypography variant="h6" color="primary" mb={1}>
-        {t(titleKey)}
-      </BCTypography>
-      <BCTypography variant="body2" color="text.secondary">
-        {t('initiativeAgreement:detail.sectionPlaceholder')}
-      </BCTypography>
-    </Paper>
-  )
-}
+// The shared document machinery keys on this string for initiative agreements.
+const PARENT_TYPE = 'initiativeAgreement'
 
-// Static scaffolding for the initiative agreement detail page. Sections
-// mirror the wireframes; data wiring arrives with the agreement-management
-// API (#4839 detail page, #4840 designated action workflow).
+const LabelValue = ({ label, value }) => (
+  <BCTypography variant="body4">
+    <strong>{label}</strong> {value || '—'}
+  </BCTypography>
+)
+
 const InitiativeAgreementDetailBase = () => {
   const { t } = useTranslation(['common', 'initiativeAgreement'])
   const { initiativeAgreementId } = useParams()
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const {
+    data: agreement,
+    isLoading,
+    isError,
+    error
+  } = useGetInitiativeAgreement(initiativeAgreementId)
+
+  const { data: documents, refetch: refetchDocuments } = useDocuments(
+    PARENT_TYPE,
+    initiativeAgreementId
+  )
+
+  if (isLoading) {
+    return <Loading message={t('initiativeAgreement:loadingText')} />
+  }
+
+  if (isError || !agreement) {
+    return (
+      <BCBox>
+        <InitiativeAgreementTabs />
+        <BCAlert data-test="alert-box" severity="error">
+          {error?.message || t('initiativeAgreement:detail.loadFailMsg')}
+        </BCAlert>
+      </BCBox>
+    )
+  }
+
+  const organization = agreement.organization ?? {}
+  const address = organization.orgAddress
+    ? constructAddress(organization.orgAddress)
+    : null
+  // The wireframe's reference number is the agreement's own identifier.
+  const referenceNumber = `IA${agreement.initiativeAgreementId}`
 
   return (
     <BCBox>
       <InitiativeAgreementTabs />
+
       <BCTypography
         variant="h5"
         color="primary"
         data-test="initiative-agreement-detail-title"
       >
         {t('initiativeAgreement:detail.title')}
-        {initiativeAgreementId ? ` - IA${initiativeAgreementId}` : ''}
+        {agreement.iaCode ? ` - ${agreement.iaCode}` : ''}
       </BCTypography>
       <Divider sx={{ mt: 2, mb: 3 }} />
 
-      {/* Agreement header: organization block, status chip, reference
-          number, IA code and agreement dates */}
-      <SectionPlaceholder
-        titleKey="initiativeAgreement:detail.agreementHeader"
-        testId="initiative-agreement-header-section"
+      <BCWidgetCard
+        title={t('initiativeAgreement:detail.agreementHeader')}
+        color="nav"
+        data-test="initiative-agreement-header-section"
+        content={
+          <BCBox p={1}>
+            <Grid2 container spacing={3}>
+              <Grid2 size={{ xs: 12, md: 6 }}>
+                <Stack spacing={0.5}>
+                  <BCBox
+                    sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}
+                  >
+                    <BCTypography variant="h6" color="primary">
+                      {organization.name}
+                    </BCTypography>
+                    {agreement.lifecycleStatus?.status && (
+                      <BCBox
+                        component="span"
+                        data-test="agreement-status-chip"
+                        sx={{
+                          px: 1.5,
+                          py: 0.25,
+                          borderRadius: 4,
+                          bgcolor: 'success.light',
+                          color: 'success.contrastText',
+                          fontSize: '0.8rem'
+                        }}
+                      >
+                        {agreement.lifecycleStatus.status}
+                      </BCBox>
+                    )}
+                  </BCBox>
+                  {address && (
+                    <BCTypography variant="body4">{address}</BCTypography>
+                  )}
+                  {organization.phone && (
+                    <BCTypography variant="body4">
+                      {organization.phone}
+                    </BCTypography>
+                  )}
+                  {organization.email && (
+                    <BCTypography variant="body4">
+                      {organization.email}
+                    </BCTypography>
+                  )}
+                </Stack>
+              </Grid2>
+
+              <Grid2 size={{ xs: 12, md: 6 }}>
+                <Stack spacing={0.5}>
+                  <LabelValue
+                    label={t('initiativeAgreement:detail.referenceNumber')}
+                    value={referenceNumber}
+                  />
+                  <LabelValue
+                    label={t(
+                      'initiativeAgreement:detail.initiativeAgreementCode'
+                    )}
+                    value={agreement.iaCode}
+                  />
+                  <LabelValue
+                    label={t('initiativeAgreement:detail.startDate')}
+                    value={dateFormatter({
+                      value: agreement.agreementStartDate
+                    })}
+                  />
+                  <LabelValue
+                    label={t('initiativeAgreement:detail.endDate')}
+                    value={dateFormatter({ value: agreement.agreementEndDate })}
+                  />
+                </Stack>
+              </Grid2>
+            </Grid2>
+
+            <BCBox mt={3} data-test="initiative-agreement-brief-section">
+              <BCTypography variant="h6" color="primary" mb={1}>
+                {t('initiativeAgreement:detail.agreementBrief')}
+              </BCTypography>
+              {agreement.title && (
+                <BCTypography variant="body4" component="p">
+                  <strong>{agreement.title}</strong>
+                </BCTypography>
+              )}
+              {agreement.projectDescription && (
+                <BCTypography variant="body4" component="p" mt={1}>
+                  {agreement.projectDescription}
+                </BCTypography>
+              )}
+            </BCBox>
+
+            <Paper
+              variant="outlined"
+              sx={{ p: 2, mt: 3 }}
+              data-test="initiative-agreement-documents-section"
+            >
+              <BCBox
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}
+              >
+                <BCTypography variant="h6" color="primary">
+                  {t('initiativeAgreement:detail.documents')}
+                </BCTypography>
+                {/* Upload is IDIR-only for this story; the shared upload
+                    endpoint's role list is broader than this module. */}
+                <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+                  <BCTypography
+                    component="button"
+                    variant="body4"
+                    color="link"
+                    data-test="upload-documents-button"
+                    onClick={() => setUploadOpen(true)}
+                    sx={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    {t('initiativeAgreement:detail.manageDocuments')}
+                  </BCTypography>
+                </Role>
+              </BCBox>
+              {documents?.length ? (
+                <SupportingDocumentSummary
+                  parentID={initiativeAgreementId}
+                  parentType={PARENT_TYPE}
+                  data={documents}
+                />
+              ) : (
+                <BCTypography variant="body4" color="text.secondary">
+                  {t('initiativeAgreement:detail.noDocuments')}
+                </BCTypography>
+              )}
+            </Paper>
+          </BCBox>
+        }
       />
-      <SectionPlaceholder
-        titleKey="initiativeAgreement:detail.agreementBrief"
-        testId="initiative-agreement-brief-section"
+
+      <DocumentUploadDialog
+        open={uploadOpen}
+        close={() => {
+          setUploadOpen(false)
+          refetchDocuments()
+        }}
+        parentType={PARENT_TYPE}
+        parentID={initiativeAgreementId}
       />
-      {/* Attachments reuse the shared document components with the
-          existing "initiativeAgreement" parent type */}
-      <SectionPlaceholder
-        titleKey="initiativeAgreement:detail.documents"
-        testId="initiative-agreement-documents-section"
-      />
-      {/* Designated actions grid (ID, name, assigned analyst, last
-          comment, compliance units to be issued) */}
-      <SectionPlaceholder
-        titleKey="initiativeAgreement:detail.designatedActions"
-        testId="initiative-agreement-actions-section"
-      />
-      {/* Internal/public comments reuse components/Comments with
-          entityType "initiativeAgreement" and commentMode "dual" */}
-      <SectionPlaceholder
-        titleKey="initiativeAgreement:detail.comments"
-        testId="initiative-agreement-comments-section"
-      />
+
+      {/* Designated actions grid arrives with #4896, comments with #4897. */}
+      <Paper
+        variant="outlined"
+        sx={{ p: 3, mt: 3 }}
+        data-test="initiative-agreement-actions-section"
+      >
+        <BCTypography variant="h6" color="primary" mb={1}>
+          {t('initiativeAgreement:detail.designatedActions')}
+        </BCTypography>
+        <BCTypography variant="body2" color="text.secondary">
+          {t('initiativeAgreement:detail.sectionPlaceholder')}
+        </BCTypography>
+      </Paper>
     </BCBox>
   )
 }

--- a/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { Divider, Paper, Stack } from '@mui/material'
@@ -20,6 +20,7 @@ import { dateFormatter } from '@/utils/formatters'
 import withRole from '@/utils/withRole'
 
 import { useGetInitiativeAgreement } from '@/hooks/useInitiativeAgreements'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 
 // The shared document machinery keys on this string for initiative agreements.
@@ -47,6 +48,19 @@ const InitiativeAgreementDetailBase = () => {
     PARENT_TYPE,
     initiativeAgreementId
   )
+
+  // Surface the agreement code in the breadcrumb while this page is open.
+  const setAgreementCrumb = useInitiativeAgreementPageStore(
+    (state) => state.setAgreementCrumb
+  )
+  useEffect(() => {
+    setAgreementCrumb(
+      agreement
+        ? agreement.iaCode || `IA${agreement.initiativeAgreementId}`
+        : null
+    )
+    return () => setAgreementCrumb(null)
+  }, [agreement, setAgreementCrumb])
 
   if (isLoading) {
     return <Loading message={t('initiativeAgreement:loadingText')} />
@@ -187,7 +201,9 @@ const InitiativeAgreementDetailBase = () => {
                 </BCTypography>
                 {/* Upload is IDIR-only for this story; the shared upload
                     endpoint's role list is broader than this module. */}
-                <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+                <Role
+                  roles={[roles.ia_analyst, roles.ia_manager, roles.director]}
+                >
                   <BCTypography
                     component="button"
                     variant="body4"
@@ -210,6 +226,7 @@ const InitiativeAgreementDetailBase = () => {
                   parentID={initiativeAgreementId}
                   parentType={PARENT_TYPE}
                   data={documents}
+                  detailed
                 />
               ) : (
                 <BCTypography variant="body4" color="text.secondary">

--- a/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 import { roles } from '@/constants/roles'
 import { wrapper } from '@/tests/utils/wrapper'
 import { InitiativeAgreementDetail } from '../InitiativeAgreementDetail'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key) => key })
@@ -19,7 +20,8 @@ let mockRoles = [{ name: roles.ia_analyst }]
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
     data: { roles: mockRoles },
-    hasRoles: (...names) => names.some((n) => mockRoles.some((r) => r.name === n)),
+    hasRoles: (...names) =>
+      names.some((n) => mockRoles.some((r) => r.name === n)),
     hasAnyRole: (...names) =>
       names.some((n) => mockRoles.some((r) => r.name === n))
   })
@@ -42,8 +44,7 @@ vi.mock('@/hooks/useDocuments', () => ({
 }))
 
 vi.mock('@/components/Documents/DocumentUploadDialog', () => ({
-  default: ({ open }) =>
-    open ? <div data-test="upload-dialog" /> : null
+  default: ({ open }) => (open ? <div data-test="upload-dialog" /> : null)
 }))
 
 const agreement = {
@@ -84,9 +85,9 @@ describe('InitiativeAgreementDetail', () => {
   it('renders the agreement card with organization, status and dates', () => {
     render(<InitiativeAgreementDetail />, { wrapper })
 
-    expect(screen.getByTestId('initiative-agreement-detail-title')).toHaveTextContent(
-      'IA-26ORG1'
-    )
+    expect(
+      screen.getByTestId('initiative-agreement-detail-title')
+    ).toHaveTextContent('IA-26ORG1')
     expect(screen.getByText('Test Organization')).toBeInTheDocument()
     expect(screen.getByTestId('agreement-status-chip')).toHaveTextContent(
       'Underway'
@@ -101,7 +102,9 @@ describe('InitiativeAgreementDetail', () => {
     expect(
       screen.getByText('Renewable Fuels Production Facility')
     ).toBeInTheDocument()
-    expect(screen.getByText('A description of the project.')).toBeInTheDocument()
+    expect(
+      screen.getByText('A description of the project.')
+    ).toBeInTheDocument()
   })
 
   it('offers document upload to an IA analyst', () => {
@@ -112,7 +115,9 @@ describe('InitiativeAgreementDetail', () => {
   it('does not offer document upload to a BCeID proponent', () => {
     mockRoles = [{ name: roles.ia_proponent }]
     render(<InitiativeAgreementDetail />, { wrapper })
-    expect(screen.queryByTestId('upload-documents-button')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('upload-documents-button')
+    ).not.toBeInTheDocument()
   })
 
   it('renders an empty state when the agreement has no documents', () => {
@@ -131,6 +136,44 @@ describe('InitiativeAgreementDetail', () => {
     })
     render(<InitiativeAgreementDetail />, { wrapper })
     expect(screen.getByTestId('alert-box')).toHaveTextContent('boom')
+  })
+
+  it('renders document rows with size and uploading organization code', () => {
+    mockDocuments.mockReturnValue({
+      data: [
+        {
+          documentId: 9,
+          fileName: 'signed-agreement.pdf',
+          fileSize: 1000000,
+          createDate: '2026-06-01T00:00:00Z',
+          createUser: 'LCFS1_bat',
+          uploadingOrganizationCode: 'BETZ'
+        },
+        {
+          documentId: 10,
+          fileName: 'award-letter.pdf',
+          fileSize: 2048,
+          createDate: '2026-06-02T00:00:00Z',
+          createUser: 'IDIRSTAFF',
+          uploadingOrganizationCode: null
+        }
+      ],
+      refetch: vi.fn()
+    })
+    render(<InitiativeAgreementDetail />, { wrapper })
+
+    expect(screen.getByText('signed-agreement.pdf')).toBeInTheDocument()
+    expect(screen.getByText(/1 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/BETZ/)).toBeInTheDocument()
+    // Government upload falls back to the government label.
+    expect(screen.getByText(/gov/)).toBeInTheDocument()
+  })
+
+  it('publishes the agreement code to the breadcrumb store', () => {
+    render(<InitiativeAgreementDetail />, { wrapper })
+    expect(useInitiativeAgreementPageStore.getState().agreementCrumb).toBe(
+      'IA-26ORG1'
+    )
   })
 
   it('tolerates an organization with no address', () => {

--- a/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
@@ -1,63 +1,149 @@
 import React from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { roles } from '@/constants/roles'
 import { wrapper } from '@/tests/utils/wrapper'
 import { InitiativeAgreementDetail } from '../InitiativeAgreementDetail'
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key) => key
-  })
+  useTranslation: () => ({ t: (key) => key })
 }))
 
 vi.mock('@react-keycloak/web', () => ({
   useKeycloak: () => ({
-    keycloak: {
-      token: 'mock-token',
-      authenticated: true,
-      initialized: true
-    }
+    keycloak: { token: 'mock-token', authenticated: true, initialized: true }
   })
 }))
 
+let mockRoles = [{ name: roles.ia_analyst }]
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
-    data: { roles: [{ name: 'IA Analyst' }] },
-    hasRoles: (...names) => names.includes(roles.ia_analyst),
-    hasAnyRole: (...names) => names.includes(roles.ia_analyst)
+    data: { roles: mockRoles },
+    hasRoles: (...names) => names.some((n) => mockRoles.some((r) => r.name === n)),
+    hasAnyRole: (...names) =>
+      names.some((n) => mockRoles.some((r) => r.name === n))
   })
 }))
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal()
-  return {
-    ...actual,
-    useParams: () => ({ initiativeAgreementId: '5' })
-  }
+  return { ...actual, useParams: () => ({ initiativeAgreementId: '5' }) }
 })
 
+const mockAgreement = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useGetInitiativeAgreement: () => mockAgreement()
+}))
+
+const mockDocuments = vi.fn()
+vi.mock('@/hooks/useDocuments', () => ({
+  useDocuments: () => mockDocuments(),
+  useDownloadDocument: () => vi.fn()
+}))
+
+vi.mock('@/components/Documents/DocumentUploadDialog', () => ({
+  default: ({ open }) =>
+    open ? <div data-test="upload-dialog" /> : null
+}))
+
+const agreement = {
+  initiativeAgreementId: 5,
+  iaCode: 'IA-26ORG1',
+  title: 'Renewable Fuels Production Facility',
+  projectDescription: 'A description of the project.',
+  agreementStartDate: '2026-06-19',
+  agreementEndDate: '2027-05-03',
+  lifecycleStatus: { status: 'Underway' },
+  organization: {
+    organizationId: 1,
+    name: 'Test Organization',
+    phone: '604-555-0100',
+    email: 'contact@example.com',
+    orgAddress: {
+      streetAddress: '697 Burrard Street',
+      city: 'Vancouver',
+      provinceState: 'BC',
+      country: 'Canada',
+      postalcodeZipcode: 'V6G 2P3'
+    }
+  }
+}
+
 describe('InitiativeAgreementDetail', () => {
-  it('renders the detail scaffold sections with the reference number', () => {
+  beforeEach(() => {
+    mockRoles = [{ name: roles.ia_analyst }]
+    mockAgreement.mockReturnValue({
+      data: agreement,
+      isLoading: false,
+      isError: false,
+      error: null
+    })
+    mockDocuments.mockReturnValue({ data: [], refetch: vi.fn() })
+  })
+
+  it('renders the agreement card with organization, status and dates', () => {
     render(<InitiativeAgreementDetail />, { wrapper })
 
+    expect(screen.getByTestId('initiative-agreement-detail-title')).toHaveTextContent(
+      'IA-26ORG1'
+    )
+    expect(screen.getByText('Test Organization')).toBeInTheDocument()
+    expect(screen.getByTestId('agreement-status-chip')).toHaveTextContent(
+      'Underway'
+    )
+    expect(screen.getByText(/697 Burrard Street/)).toBeInTheDocument()
+    expect(screen.getByText('604-555-0100')).toBeInTheDocument()
+    expect(screen.getByText('IA5')).toBeInTheDocument()
+  })
+
+  it('renders the agreement brief', () => {
+    render(<InitiativeAgreementDetail />, { wrapper })
     expect(
-      screen.getByTestId('initiative-agreement-detail-title')
-    ).toHaveTextContent('IA5')
-    expect(
-      screen.getByTestId('initiative-agreement-header-section')
+      screen.getByText('Renewable Fuels Production Facility')
     ).toBeInTheDocument()
+    expect(screen.getByText('A description of the project.')).toBeInTheDocument()
+  })
+
+  it('offers document upload to an IA analyst', () => {
+    render(<InitiativeAgreementDetail />, { wrapper })
+    expect(screen.getByTestId('upload-documents-button')).toBeInTheDocument()
+  })
+
+  it('does not offer document upload to a BCeID proponent', () => {
+    mockRoles = [{ name: roles.ia_proponent }]
+    render(<InitiativeAgreementDetail />, { wrapper })
+    expect(screen.queryByTestId('upload-documents-button')).not.toBeInTheDocument()
+  })
+
+  it('renders an empty state when the agreement has no documents', () => {
+    render(<InitiativeAgreementDetail />, { wrapper })
     expect(
-      screen.getByTestId('initiative-agreement-brief-section')
+      screen.getByText('initiativeAgreement:detail.noDocuments')
     ).toBeInTheDocument()
-    expect(
-      screen.getByTestId('initiative-agreement-documents-section')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId('initiative-agreement-actions-section')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId('initiative-agreement-comments-section')
-    ).toBeInTheDocument()
+  })
+
+  it('surfaces a load failure instead of a blank card', () => {
+    mockAgreement.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: 'boom' }
+    })
+    render(<InitiativeAgreementDetail />, { wrapper })
+    expect(screen.getByTestId('alert-box')).toHaveTextContent('boom')
+  })
+
+  it('tolerates an organization with no address', () => {
+    mockAgreement.mockReturnValue({
+      data: {
+        ...agreement,
+        organization: { organizationId: 1, name: 'Test Organization' }
+      },
+      isLoading: false,
+      isError: false,
+      error: null
+    })
+    render(<InitiativeAgreementDetail />, { wrapper })
+    expect(screen.getByText('Test Organization')).toBeInTheDocument()
   })
 })

--- a/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
+++ b/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
@@ -1,11 +1,22 @@
 import Box from '@mui/material/Box'
 import { List } from '@mui/material'
+import prettyBytes from 'pretty-bytes'
+import { useTranslation } from 'react-i18next'
 import BCTypography from '@/components/BCTypography'
 import { useDownloadDocument } from '@/hooks/useDocuments.js'
 import { timezoneFormatter } from '@/utils/formatters'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 
-export const SupportingDocumentSummary = ({ parentID, parentType, data }) => {
+// `detailed` adds the file size and the uploading organization's code to
+// each row (initiative agreement wireframes); other callers keep the
+// original compact line.
+export const SupportingDocumentSummary = ({
+  parentID,
+  parentType,
+  data,
+  detailed = false
+}) => {
+  const { t } = useTranslation(['common'])
   const downloadDocument = useDownloadDocument(parentType, parentID)
   const { hasRoles } = useCurrentUser()
   const files = Array.isArray(data) ? data : []
@@ -38,7 +49,11 @@ export const SupportingDocumentSummary = ({ parentID, parentType, data }) => {
               variant="subtitle2"
               sx={{ marginLeft: 1 }}
             >
-              - {timezoneFormatter({ value: file.createDate })}
+              {detailed
+                ? `- ${prettyBytes(file.fileSize ?? 0)} - ${
+                    file.uploadingOrganizationCode || t('gov')
+                  } - ${timezoneFormatter({ value: file.createDate })}`
+                : `- ${timezoneFormatter({ value: file.createDate })}`}
               {file.createUser && !hasRoles('Supplier')
                 ? ` - ${file.createUser}`
                 : ''}

--- a/frontend/src/views/SupportingDocuments/__tests__/SupportingDocumentSummary.test.jsx
+++ b/frontend/src/views/SupportingDocuments/__tests__/SupportingDocumentSummary.test.jsx
@@ -15,6 +15,10 @@ vi.mock('@/utils/formatters', () => ({
   timezoneFormatter: vi.fn()
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
 vi.mock('@/components/BCTypography', () => ({
   default: ({ children, onClick, ...props }) => (
     <span data-test="bc-typography" onClick={onClick} {...props}>
@@ -36,48 +40,52 @@ describe('SupportingDocumentSummary', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    
+
     // Setup default mock implementations
     const { useDownloadDocument } = await import('@/hooks/useDocuments.js')
     const { useCurrentUser } = await import('@/hooks/useCurrentUser')
     const { timezoneFormatter } = await import('@/utils/formatters')
-    
+
     vi.mocked(useDownloadDocument).mockReturnValue(mockDownloadDocument)
     vi.mocked(useCurrentUser).mockReturnValue({ hasRoles: mockHasRoles })
     vi.mocked(timezoneFormatter).mockImplementation(mockTimezoneFormatter)
-    
+
     mockTimezoneFormatter.mockReturnValue('2023-01-01 12:00')
   })
 
   it('renders main component with empty data', () => {
     render(<SupportingDocumentSummary {...defaultProps} />)
-    
+
     // Should render the empty list container but no document items
     expect(screen.queryByTestId('bc-typography')).not.toBeInTheDocument()
   })
 
   it('renders empty data array without items', () => {
     render(<SupportingDocumentSummary {...defaultProps} data={[]} />)
-    
+
     // Should render no document items
     expect(screen.queryByTestId('bc-typography')).not.toBeInTheDocument()
     expect(screen.queryByText(/test-file/)).not.toBeInTheDocument()
   })
 
   it('renders single document', () => {
-    const singleDocData = [{
-      documentId: 1,
-      fileName: 'test-document.pdf',
-      createDate: '2023-01-01T12:00:00Z',
-      createUser: 'Test User'
-    }]
-    
+    const singleDocData = [
+      {
+        documentId: 1,
+        fileName: 'test-document.pdf',
+        createDate: '2023-01-01T12:00:00Z',
+        createUser: 'Test User'
+      }
+    ]
+
     mockHasRoles.mockReturnValue(false)
 
     render(<SupportingDocumentSummary {...defaultProps} data={singleDocData} />)
-    
+
     expect(screen.getByText('test-document.pdf')).toBeInTheDocument()
-    expect(mockTimezoneFormatter).toHaveBeenCalledWith({ value: '2023-01-01T12:00:00Z' })
+    expect(mockTimezoneFormatter).toHaveBeenCalledWith({
+      value: '2023-01-01T12:00:00Z'
+    })
   })
 
   it('renders multiple documents', () => {
@@ -95,109 +103,185 @@ describe('SupportingDocumentSummary', () => {
         createUser: 'User 2'
       }
     ]
-    
+
     mockHasRoles.mockReturnValue(false)
 
-    render(<SupportingDocumentSummary {...defaultProps} data={multipleDocsData} />)
-    
+    render(
+      <SupportingDocumentSummary {...defaultProps} data={multipleDocsData} />
+    )
+
     expect(screen.getByText('document-1.pdf')).toBeInTheDocument()
     expect(screen.getByText('document-2.pdf')).toBeInTheDocument()
   })
 
   it('calls downloadDocument when file name is clicked', () => {
-    const docData = [{
-      documentId: 123,
-      fileName: 'clickable-document.pdf',
-      createDate: '2023-01-01T12:00:00Z'
-    }]
-    
+    const docData = [
+      {
+        documentId: 123,
+        fileName: 'clickable-document.pdf',
+        createDate: '2023-01-01T12:00:00Z'
+      }
+    ]
+
     render(<SupportingDocumentSummary {...defaultProps} data={docData} />)
-    
+
     const fileName = screen.getByText('clickable-document.pdf')
     fireEvent.click(fileName)
-    
+
     expect(mockDownloadDocument).toHaveBeenCalledWith(123)
   })
 
   it('formats timezone correctly', () => {
-    const docData = [{
-      documentId: 1,
-      fileName: 'test.pdf',
-      createDate: '2023-06-15T14:30:00Z'
-    }]
-    
+    const docData = [
+      {
+        documentId: 1,
+        fileName: 'test.pdf',
+        createDate: '2023-06-15T14:30:00Z'
+      }
+    ]
+
     mockTimezoneFormatter.mockReturnValue('Jun 15, 2023 2:30 PM')
 
     render(<SupportingDocumentSummary {...defaultProps} data={docData} />)
-    
-    expect(mockTimezoneFormatter).toHaveBeenCalledWith({ value: '2023-06-15T14:30:00Z' })
+
+    expect(mockTimezoneFormatter).toHaveBeenCalledWith({
+      value: '2023-06-15T14:30:00Z'
+    })
     expect(screen.getByText(/Jun 15, 2023 2:30 PM/)).toBeInTheDocument()
   })
 
   it('displays createUser when user does not have Supplier role', () => {
-    const docData = [{
-      documentId: 1,
-      fileName: 'test.pdf',
-      createDate: '2023-01-01T12:00:00Z',
-      createUser: 'John Doe'
-    }]
-    
+    const docData = [
+      {
+        documentId: 1,
+        fileName: 'test.pdf',
+        createDate: '2023-01-01T12:00:00Z',
+        createUser: 'John Doe'
+      }
+    ]
+
     mockHasRoles.mockReturnValue(false) // Not a supplier
 
     render(<SupportingDocumentSummary {...defaultProps} data={docData} />)
-    
+
     expect(screen.getByText(/- John Doe/)).toBeInTheDocument()
   })
 
   it('hides createUser when user has Supplier role', () => {
-    const docData = [{
-      documentId: 1,
-      fileName: 'test.pdf',
-      createDate: '2023-01-01T12:00:00Z',
-      createUser: 'John Doe'
-    }]
-    
+    const docData = [
+      {
+        documentId: 1,
+        fileName: 'test.pdf',
+        createDate: '2023-01-01T12:00:00Z',
+        createUser: 'John Doe'
+      }
+    ]
+
     mockHasRoles.mockReturnValue(true) // Is a supplier
 
     render(<SupportingDocumentSummary {...defaultProps} data={docData} />)
-    
+
     expect(screen.queryByText(/- John Doe/)).not.toBeInTheDocument()
   })
 
   it('handles missing createUser gracefully', () => {
-    const docData = [{
-      documentId: 1,
-      fileName: 'test.pdf',
-      createDate: '2023-01-01T12:00:00Z'
-      // No createUser property
-    }]
-    
+    const docData = [
+      {
+        documentId: 1,
+        fileName: 'test.pdf',
+        createDate: '2023-01-01T12:00:00Z'
+        // No createUser property
+      }
+    ]
+
     mockHasRoles.mockReturnValue(false)
 
     render(<SupportingDocumentSummary {...defaultProps} data={docData} />)
-    
-    // Should only display timestamp, not user info 
+
+    // Should only display timestamp, not user info
     const timestampElement = screen.getByText('- 2023-01-01 12:00')
     expect(timestampElement).toBeInTheDocument()
     expect(screen.getByText('test.pdf')).toBeInTheDocument()
-    
+
     // The text content should not include additional user info beyond the timestamp
     expect(timestampElement.textContent).toBe('- 2023-01-01 12:00')
   })
 
   it('calls useDownloadDocument hook with correct parameters', async () => {
     const { useDownloadDocument } = await import('@/hooks/useDocuments.js')
-    
-    render(<SupportingDocumentSummary parentID={456} parentType="compliance-report" data={[]} />)
-    
+
+    render(
+      <SupportingDocumentSummary
+        parentID={456}
+        parentType="compliance-report"
+        data={[]}
+      />
+    )
+
     expect(useDownloadDocument).toHaveBeenCalledWith('compliance-report', 456)
   })
 
   it('calls useCurrentUser hook', async () => {
     const { useCurrentUser } = await import('@/hooks/useCurrentUser')
-    
+
     render(<SupportingDocumentSummary {...defaultProps} />)
-    
+
     expect(useCurrentUser).toHaveBeenCalled()
+  })
+})
+describe('SupportingDocumentSummary detailed mode', () => {
+  const detailedFile = {
+    documentId: 9,
+    fileName: 'signed-agreement.pdf',
+    fileSize: 1000000,
+    createDate: '2026-06-01T00:00:00Z',
+    createUser: 'LCFS1_bat',
+    uploadingOrganizationCode: 'BETZ'
+  }
+
+  beforeEach(async () => {
+    const { useDownloadDocument } = await import('@/hooks/useDocuments.js')
+    const { useCurrentUser } = await import('@/hooks/useCurrentUser')
+    const { timezoneFormatter } = await import('@/utils/formatters')
+    vi.mocked(useDownloadDocument).mockReturnValue(vi.fn())
+    vi.mocked(useCurrentUser).mockReturnValue({ hasRoles: () => false })
+    vi.mocked(timezoneFormatter).mockReturnValue('2026-06-01 12:00')
+  })
+
+  it('shows size and uploading organization code when detailed', () => {
+    render(
+      <SupportingDocumentSummary
+        parentID={5}
+        parentType="initiativeAgreement"
+        data={[detailedFile]}
+        detailed
+      />
+    )
+    expect(screen.getByText(/1 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/BETZ/)).toBeInTheDocument()
+  })
+
+  it('labels government uploads when the uploader has no organization', () => {
+    render(
+      <SupportingDocumentSummary
+        parentID={5}
+        parentType="initiativeAgreement"
+        data={[{ ...detailedFile, uploadingOrganizationCode: null }]}
+        detailed
+      />
+    )
+    expect(screen.getByText(/gov/)).toBeInTheDocument()
+  })
+
+  it('keeps the compact line for existing callers', () => {
+    render(
+      <SupportingDocumentSummary
+        parentID={5}
+        parentType="compliance_report"
+        data={[detailedFile]}
+      />
+    )
+    expect(screen.queryByText(/1 MB/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/BETZ/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

The top section of the IDIR initiative agreement detail page (#4839). Targets the module's epic branch, not `develop`.

Replaces the placeholder with the agreement record:

- **Agreement card** — organization name with its lifecycle status, the address block, phone and email; reference number, agreement code and the agreement dates.
- **Agreement brief** — project title and description.
- **Documents** — the files attached to the agreement, with download, plus upload for IDIR users.

The designated actions grid and the comments panel stay as placeholders; they arrive with #4896 and #4897.

### Notes for a reviewer

**The profile's organization payload is a separate schema from the grid's.** The detail card needs the address block, but the list query and the legacy award flow do not eager-load it, and a lazy load in async SQLAlchemy raises `MissingGreenlet`. Widening the shared schema would have broken those paths, so the richer payload belongs only to the profile response, and the profile query eager-loads the address.

**Every address field is optional.** Organization address rows carry gaps, and an agreement whose organization has no address should render an incomplete card rather than fail the request. There is a test for each case.

**Upload is scoped to IA analysts, managers and directors.** The shared upload endpoint's role list is deliberately broader than this module, so the real control is the positive role check on the action, backed by a test that a BCeID proponent is not offered it.

**The upload dialog had no initiative agreement case**, so it silently rendered compliance report copy. Added, along with the locale keys it needs.

### Testing

52 backend tests in the module pass, including new coverage that the profile returns the organization address block and that an organization without an address returns a card rather than a 500. 18 frontend tests on the detail view cover the card contents, the brief, the document empty state, the load failure path, the analyst seeing upload and the proponent not, and an organization with no address. Type-check shows no new errors.

Refs #4839
