### PR TITLE
Feat: Initiative Agreements IDIR dashboard card - 4895

### DIFF
--- a/backend/lcfs/tests/dashboard/test_dashboard_views.py
+++ b/backend/lcfs/tests/dashboard/test_dashboard_views.py
@@ -10,6 +10,7 @@ from starlette import status
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.dashboard.schema import (
     CIApplicationCountsSchema,
+    InitiativeAgreementCountsSchema,
     OrgFuelCodeCountsSchema,
 )
 
@@ -84,4 +85,34 @@ async def test_ci_application_counts_forbidden_for_non_analyst(
     """The endpoint is gated to IDIR analysts."""
     set_user_role(RoleEnum.CI_APPLICANT)
     response = await client.get("/api/dashboard/ci-application-counts")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_initiative_agreement_counts_success_for_ia_manager(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_user_role,
+):
+    """IA module roles get the lifecycle counts card data (#4895)."""
+    set_user_role(RoleEnum.IA_MANAGER)
+    with patch(
+        "lcfs.web.api.dashboard.services.DashboardServices.get_initiative_agreement_counts"
+    ) as mock:
+        mock.return_value = InitiativeAgreementCountsSchema(draft=2, underway=5)
+        response = await client.get("/api/dashboard/initiative-agreement-counts")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"draft": 2, "underway": 5}
+
+
+@pytest.mark.anyio
+async def test_initiative_agreement_counts_forbidden_for_proponent(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_user_role,
+):
+    """The card is IDIR-only; a BCeID proponent is refused."""
+    set_user_role(RoleEnum.IA_PROPONENT)
+    response = await client.get("/api/dashboard/initiative-agreement-counts")
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_initiative_agreement_api.py
@@ -633,3 +633,36 @@ async def test_agreement_documents_carry_the_uploading_organization_code(
     by_name = {row["fileName"]: row for row in response.json()}
     assert by_name["signed-agreement.pdf"]["uploadingOrganizationCode"] == org_code
     assert by_name["award-letter.pdf"]["uploadingOrganizationCode"] is None
+
+
+@pytest.mark.anyio
+async def test_dashboard_counts_cover_only_agreement_kind_rows(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The dashboard card counts lifecycle statuses of agreement-kind rows;
+    legacy award rows must not inflate them (#4895)."""
+    org_id, _ = await _two_org_ids(dbsession)
+    await _seed_agreement(dbsession, org_id, "IA-26DSH1")
+    await _seed_agreement(dbsession, org_id, "IA-26DSH2")
+    await _seed_agreement(
+        dbsession,
+        org_id,
+        "IA-26DSH3",
+        lifecycle_status_id=await _lifecycle_status_id(dbsession, "Draft"),
+    )
+    # A legacy award row: no lifecycle status, legacy record kind.
+    dbsession.add(
+        InitiativeAgreement(
+            to_organization_id=org_id,
+            compliance_units=100,
+        )
+    )
+    await dbsession.flush()
+
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    response = await client.get("/api/dashboard/initiative-agreement-counts")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["underway"] == 2
+    assert data["draft"] == 1

--- a/backend/lcfs/web/api/dashboard/repo.py
+++ b/backend/lcfs/web/api/dashboard/repo.py
@@ -18,6 +18,13 @@ from lcfs.db.models.compliance.ComplianceReportCountView import (
 from lcfs.db.models.fuel.FuelCodeCountView import FuelCodeCountView
 from lcfs.db.models.fuel.FuelCode import FuelCode
 from lcfs.db.models.ci_application.CIApplication import CIApplication
+from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
+    RECORD_KIND_AGREEMENT,
+    InitiativeAgreement,
+)
+from lcfs.db.models.initiative_agreement.InitiativeAgreementLifecycleStatus import (
+    InitiativeAgreementLifecycleStatus,
+)
 from lcfs.db.models.ci_application.CIApplicationStatus import CIApplicationStatus
 from lcfs.web.api.ci_application.repo import CIApplicationRepository
 
@@ -28,9 +35,7 @@ class DashboardRepository:
     def __init__(
         self,
         db: AsyncSession = Depends(get_async_db_session),
-        ci_application_repo: CIApplicationRepository = Depends(
-            CIApplicationRepository
-        ),
+        ci_application_repo: CIApplicationRepository = Depends(CIApplicationRepository),
     ):
         self.db = db
         self.ci_application_repo = ci_application_repo
@@ -138,8 +143,7 @@ class DashboardRepository:
             .select_from(CIApplication)
             .join(
                 CIApplicationStatus,
-                CIApplication.status_id
-                == CIApplicationStatus.ci_application_status_id,
+                CIApplication.status_id == CIApplicationStatus.ci_application_status_id,
             )
             .where(CIApplication.organization_id == organization_id)
         )
@@ -147,6 +151,23 @@ class DashboardRepository:
         result = await self.db.execute(query)
         row = result.one()
         return {"draft": row.draft or 0, "submitted": row.submitted or 0}
+
+    @repo_handler
+    async def get_initiative_agreement_counts(self):
+        """Counts of agreement-kind initiative agreements by lifecycle
+        status. Legacy award rows never carry a lifecycle status and are
+        excluded by record_kind."""
+        query = (
+            select(
+                InitiativeAgreementLifecycleStatus.status,
+                func.count(InitiativeAgreement.initiative_agreement_id),
+            )
+            .join(InitiativeAgreement.lifecycle_status)
+            .where(InitiativeAgreement.record_kind == RECORD_KIND_AGREEMENT)
+            .group_by(InitiativeAgreementLifecycleStatus.status)
+        )
+        result = await self.db.execute(query)
+        return {status: count for status, count in result.all()}
 
     @repo_handler
     async def get_ci_application_counts(self):

--- a/backend/lcfs/web/api/dashboard/schema.py
+++ b/backend/lcfs/web/api/dashboard/schema.py
@@ -40,3 +40,10 @@ class OrgFuelCodeCountsSchema(BaseSchema):
 
 class CIApplicationCountsSchema(BaseSchema):
     in_progress: int = Field(default=0)
+
+
+class InitiativeAgreementCountsSchema(BaseSchema):
+    # Counts of agreement-kind records by lifecycle status; legacy award
+    # rows are excluded (#4895).
+    draft: int = Field(default=0)
+    underway: int = Field(default=0)

--- a/backend/lcfs/web/api/dashboard/services.py
+++ b/backend/lcfs/web/api/dashboard/services.py
@@ -11,6 +11,7 @@ from lcfs.web.api.dashboard.schema import (
     FuelCodeCountsSchema,
     OrgFuelCodeCountsSchema,
     CIApplicationCountsSchema,
+    InitiativeAgreementCountsSchema,
 )
 
 logger = structlog.get_logger(__name__)
@@ -84,6 +85,15 @@ class DashboardServices:
         return OrgFuelCodeCountsSchema(
             draft=counts.get("draft", 0),
             submitted=counts.get("submitted", 0),
+        )
+
+    @service_handler
+    async def get_initiative_agreement_counts(self) -> InitiativeAgreementCountsSchema:
+        counts = await self.repo.get_initiative_agreement_counts()
+
+        return InitiativeAgreementCountsSchema(
+            draft=counts.get("Draft", 0),
+            underway=counts.get("Underway", 0),
         )
 
     @service_handler

--- a/backend/lcfs/web/api/dashboard/views.py
+++ b/backend/lcfs/web/api/dashboard/views.py
@@ -12,6 +12,7 @@ from lcfs.web.api.dashboard.schema import (
     FuelCodeCountsSchema,
     OrgFuelCodeCountsSchema,
     CIApplicationCountsSchema,
+    InitiativeAgreementCountsSchema,
 )
 from lcfs.db.models.user.Role import RoleEnum
 
@@ -65,10 +66,7 @@ async def get_org_compliance_report_counts(
     return await service.get_org_compliance_report_counts(organization_id)
 
 
-@router.get(
-    "/compliance-report-counts",
-    response_model=ComplianceReportCountsSchema
-)
+@router.get("/compliance-report-counts", response_model=ComplianceReportCountsSchema)
 @view_handler([RoleEnum.ANALYST, RoleEnum.COMPLIANCE_MANAGER])
 async def get_compliance_report_counts(
     request: Request,
@@ -78,10 +76,7 @@ async def get_compliance_report_counts(
     return await service.get_compliance_report_counts()
 
 
-@router.get(
-    "/fuel-code-counts",
-    response_model=FuelCodeCountsSchema
-)
+@router.get("/fuel-code-counts", response_model=FuelCodeCountsSchema)
 @view_handler([RoleEnum.ANALYST])
 async def get_fuel_code_counts(
     request: Request,
@@ -102,6 +97,17 @@ async def get_org_fuel_code_counts(
     caller's organization (CI applications not yet approved)."""
     organization_id = request.user.organization.organization_id
     return await service.get_org_fuel_code_counts(organization_id)
+
+
+@router.get(
+    "/initiative-agreement-counts", response_model=InitiativeAgreementCountsSchema
+)
+@view_handler([RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR])
+async def get_initiative_agreement_counts(
+    request: Request,
+    service: DashboardServices = Depends(),
+):
+    return await service.get_initiative_agreement_counts()
 
 
 @router.get("/ci-application-counts", response_model=CIApplicationCountsSchema)

--- a/frontend/src/assets/locales/en/dashboard.json
+++ b/frontend/src/assets/locales/en/dashboard.json
@@ -32,6 +32,14 @@
     "inProgress": "CI Application(s) in progress",
     "loadingMessage": "Loading CI applications card..."
   },
+  "initiativeAgreements": {
+    "title": "Initiative agreements",
+    "thereAre": "There are:",
+    "underway": "Initiative agreement(s) underway",
+    "draft": "Draft initiative agreement(s)",
+    "viewAll": "View all initiative agreement(s)",
+    "loadingMessage": "Loading initiative agreements card..."
+  },
   "orgFuelCodes": {
     "title": "Fuel codes",
     "loadingMessage": "Loading fuel codes card...",

--- a/frontend/src/constants/common.ts
+++ b/frontend/src/constants/common.ts
@@ -79,7 +79,8 @@ export const FILTER_KEYS = {
   COMPLIANCE_REPORT_GRID: 'compliance-reports-grid-filter',
   TRANSACTIONS_GRID: 'transactions-grid-filter',
   FUEL_CODES_GRID: 'fuel-codes-grid-filter',
-  CI_APPLICATIONS_GRID: 'ci-applications-grid-filter'
+  CI_APPLICATIONS_GRID: 'ci-applications-grid-filter',
+  INITIATIVE_AGREEMENTS_GRID: 'initiative-agreements-grid-filter'
 } as const
 
 export const MAX_FILE_SIZE_BYTES = 52428800 // 50MB

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -73,7 +73,8 @@ export const apiRoutes = {
   // consumed by hooks/useInitiativeAgreements.ts
   getInitiativeAgreementsList: '/initiative-agreements/list',
   getInitiativeAgreementStatuses: '/initiative-agreements/statuses',
-  getInitiativeAgreement: '/initiative-agreements/:initiativeAgreementId/profile',
+  getInitiativeAgreement:
+    '/initiative-agreements/:initiativeAgreementId/profile',
 
   // fuel-type
   getFuelTypeOthers: '/fuel-type/others/list',
@@ -264,6 +265,7 @@ export const apiRoutes = {
   fuelCodeCounts: '/dashboard/fuel-code-counts',
   orgFuelCodeCounts: '/dashboard/org-fuel-code-counts',
   ciApplicationCounts: '/dashboard/ci-application-counts',
+  initiativeAgreementCounts: '/dashboard/initiative-agreement-counts',
 
   // credit market
   creditMarketOverview: '/credit-market/overview',

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -91,6 +91,22 @@ export const useOrgFuelCodeCounts = (options: QueryOptions<unknown> = {}) => {
   })
 }
 
+export const useInitiativeAgreementCounts = (
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  const path = apiRoutes.initiativeAgreementCounts
+
+  return useQuery({
+    queryKey: ['initiative-agreement-counts'],
+    queryFn: async () => {
+      const response = await client.get(path)
+      return response.data
+    },
+    ...options
+  })
+}
+
 export const useCIApplicationCounts = (options: QueryOptions<unknown> = {}) => {
   const client = useApiService()
   const path = apiRoutes.ciApplicationCounts

--- a/frontend/src/views/Dashboard/Dashboard.jsx
+++ b/frontend/src/views/Dashboard/Dashboard.jsx
@@ -24,6 +24,7 @@ import {
 } from './components/cards'
 import OrganizationsSummaryCard from './components/cards/idir/OrganizationsSummaryCard'
 import { CIApplicationCard } from './components/cards/idir/CIApplicationCard'
+import { InitiativeAgreementsCard } from './components/cards/idir/InitiativeAgreementsCard'
 import { ComplianceReportCard } from './components/cards/idir/ComplianceReportCard'
 
 export const Dashboard = () => {
@@ -83,6 +84,11 @@ export const Dashboard = () => {
               </Role>
               <Role roles={[roles.analyst]}>
                 <CIApplicationCard />
+              </Role>
+              <Role
+                roles={[roles.ia_analyst, roles.ia_manager, roles.director]}
+              >
+                <InitiativeAgreementsCard />
               </Role>
             </Role>
 

--- a/frontend/src/views/Dashboard/__tests__/Dashboard.test.jsx
+++ b/frontend/src/views/Dashboard/__tests__/Dashboard.test.jsx
@@ -72,6 +72,12 @@ vi.mock('../components/cards/idir/CIApplicationCard', () => ({
   )
 }))
 
+vi.mock('../components/cards/idir/InitiativeAgreementsCard', () => ({
+  InitiativeAgreementsCard: () => (
+    <div data-test="initiative-agreements-card">Initiative Agreements Card</div>
+  )
+}))
+
 vi.mock('../components/cards/idir/ComplianceReportCard', () => ({
   ComplianceReportCard: () => (
     <div data-test="compliance-report-card">Compliance Report Card</div>

--- a/frontend/src/views/Dashboard/components/cards/idir/InitiativeAgreementsCard.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/InitiativeAgreementsCard.jsx
@@ -1,0 +1,142 @@
+import BCTypography from '@/components/BCTypography'
+import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
+import Loading from '@/components/Loading'
+import { FILTER_KEYS } from '@/constants/common'
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/constants/config'
+import { ROUTES } from '@/routes/routes'
+import { useInitiativeAgreementCounts } from '@/hooks/useDashboard'
+import { List, ListItemButton, Stack } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+
+const CountDisplay = ({ count }) => (
+  <BCTypography
+    component="span"
+    variant="h3"
+    sx={{
+      color: 'success.main',
+      marginX: 3
+    }}
+  >
+    {count}
+  </BCTypography>
+)
+
+// IDIR dashboard links card for the Initiative Agreements module (#4895).
+// The wireframe's "Change order(s)" and "Expression of interest" counters
+// are undefined concepts (open PO question); until they are, the card
+// counts by lifecycle status.
+export const InitiativeAgreementsCard = () => {
+  const { t } = useTranslation(['dashboard'])
+  const navigate = useNavigate()
+  const moduleEnabled = isFeatureEnabled(FEATURE_FLAGS.INITIATIVE_AGREEMENTS)
+  const { data: counts, isLoading } = useInitiativeAgreementCounts({
+    enabled: moduleEnabled
+  })
+
+  if (!moduleEnabled) {
+    return null
+  }
+
+  // The index grid restores `${gridKey}-filter` from sessionStorage, so a
+  // counter link lands on the grid already narrowed to its status.
+  const navigateWithStatus = (status) => {
+    if (status) {
+      sessionStorage.setItem(
+        FILTER_KEYS.INITIATIVE_AGREEMENTS_GRID,
+        JSON.stringify({
+          'lifecycleStatus.status': {
+            filterType: 'text',
+            type: 'equals',
+            filter: status
+          }
+        })
+      )
+    } else {
+      sessionStorage.removeItem(FILTER_KEYS.INITIATIVE_AGREEMENTS_GRID)
+    }
+    navigate(ROUTES.INITIATIVE_AGREEMENTS.LIST)
+  }
+
+  const renderLinkWithCount = (text, count, onClick) => {
+    return (
+      <>
+        {count != null && <CountDisplay count={count} />}
+        <BCTypography
+          variant="body2"
+          color="link"
+          sx={{
+            textDecoration: 'underline',
+            '&:hover': { color: 'info.main' }
+          }}
+          onClick={onClick}
+        >
+          {text}
+        </BCTypography>
+      </>
+    )
+  }
+
+  return (
+    <BCWidgetCard
+      component="div"
+      disableHover={true}
+      title={t('dashboard:initiativeAgreements.title')}
+      sx={{ '& .MuiCardContent-root': { padding: '16px' } }}
+      content={
+        isLoading ? (
+          <Loading
+            message={t('dashboard:initiativeAgreements.loadingMessage')}
+          />
+        ) : (
+          <Stack spacing={1}>
+            <BCTypography variant="body2" sx={{ marginBottom: 0 }}>
+              {t('dashboard:initiativeAgreements.thereAre')}
+            </BCTypography>
+            <List
+              component="div"
+              sx={{
+                maxWidth: '100%',
+                padding: 0,
+                '& .MuiListItemButton-root': {
+                  padding: '2px 0'
+                }
+              }}
+            >
+              <ListItemButton
+                component="a"
+                onClick={() => navigateWithStatus('Underway')}
+              >
+                {renderLinkWithCount(
+                  t('dashboard:initiativeAgreements.underway'),
+                  counts?.underway || 0,
+                  () => navigateWithStatus('Underway')
+                )}
+              </ListItemButton>
+              <ListItemButton
+                component="a"
+                onClick={() => navigateWithStatus('Draft')}
+              >
+                {renderLinkWithCount(
+                  t('dashboard:initiativeAgreements.draft'),
+                  counts?.draft || 0,
+                  () => navigateWithStatus('Draft')
+                )}
+              </ListItemButton>
+              <ListItemButton
+                component="a"
+                onClick={() => navigateWithStatus(null)}
+              >
+                {renderLinkWithCount(
+                  t('dashboard:initiativeAgreements.viewAll'),
+                  null,
+                  () => navigateWithStatus(null)
+                )}
+              </ListItemButton>
+            </List>
+          </Stack>
+        )
+      }
+    />
+  )
+}

--- a/frontend/src/views/Dashboard/components/cards/idir/__tests__/InitiativeAgreementsCard.test.jsx
+++ b/frontend/src/views/Dashboard/components/cards/idir/__tests__/InitiativeAgreementsCard.test.jsx
@@ -1,0 +1,131 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { InitiativeAgreementsCard } from '../InitiativeAgreementsCard'
+import { useInitiativeAgreementCounts } from '@/hooks/useDashboard'
+import { isFeatureEnabled } from '@/constants/config'
+import { wrapper } from '@/tests/utils/wrapper'
+import { useNavigate } from 'react-router-dom'
+import { ROUTES } from '@/routes/routes'
+import { FILTER_KEYS } from '@/constants/common'
+
+vi.mock('@/hooks/useDashboard')
+vi.mock('react-router-dom', () => ({
+  ...vi.importActual('react-router-dom'),
+  useNavigate: vi.fn()
+}))
+vi.mock('@/constants/config', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, isFeatureEnabled: vi.fn() }
+})
+
+vi.mock('@/components/BCWidgetCard/BCWidgetCard', () => ({
+  __esModule: true,
+  default: ({ title, content }) => (
+    <div data-test="bc-widget-card">
+      <div data-test="widget-title">{title}</div>
+      <div data-test="widget-content">{content}</div>
+    </div>
+  )
+}))
+
+vi.mock('@/components/Loading', () => ({
+  __esModule: true,
+  default: ({ message }) => <div data-test="loading">{message}</div>
+}))
+
+describe('InitiativeAgreementsCard Component', () => {
+  const mockNavigate = vi.fn()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    useNavigate.mockReturnValue(mockNavigate)
+    isFeatureEnabled.mockReturnValue(true)
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        setItem: vi.fn(),
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn()
+      },
+      writable: true
+    })
+  })
+
+  it('renders the loading state', () => {
+    useInitiativeAgreementCounts.mockReturnValue({
+      data: null,
+      isLoading: true
+    })
+
+    render(<InitiativeAgreementsCard />, { wrapper })
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+
+  it('renders the lifecycle counts', () => {
+    useInitiativeAgreementCounts.mockReturnValue({
+      data: { underway: 5, draft: 2 },
+      isLoading: false
+    })
+
+    render(<InitiativeAgreementsCard />, { wrapper })
+
+    expect(screen.getByTestId('widget-title')).toHaveTextContent(
+      'Initiative agreements'
+    )
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(
+      screen.getByText('View all initiative agreement(s)')
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to the grid pre-filtered to Underway', () => {
+    useInitiativeAgreementCounts.mockReturnValue({
+      data: { underway: 5, draft: 2 },
+      isLoading: false
+    })
+
+    render(<InitiativeAgreementsCard />, { wrapper })
+    fireEvent.click(screen.getByText('Initiative agreement(s) underway'))
+
+    expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+      FILTER_KEYS.INITIATIVE_AGREEMENTS_GRID,
+      JSON.stringify({
+        'lifecycleStatus.status': {
+          filterType: 'text',
+          type: 'equals',
+          filter: 'Underway'
+        }
+      })
+    )
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.INITIATIVE_AGREEMENTS.LIST)
+  })
+
+  it('clears the stored filter for the view-all link', () => {
+    useInitiativeAgreementCounts.mockReturnValue({
+      data: { underway: 5, draft: 2 },
+      isLoading: false
+    })
+
+    render(<InitiativeAgreementsCard />, { wrapper })
+    fireEvent.click(screen.getByText('View all initiative agreement(s)'))
+
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith(
+      FILTER_KEYS.INITIATIVE_AGREEMENTS_GRID
+    )
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.INITIATIVE_AGREEMENTS.LIST)
+  })
+
+  it('renders nothing when the module flag is off', () => {
+    isFeatureEnabled.mockReturnValue(false)
+    useInitiativeAgreementCounts.mockReturnValue({
+      data: null,
+      isLoading: false
+    })
+
+    const { container } = render(<InitiativeAgreementsCard />, { wrapper })
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## Summary

The IDIR dashboard links card for the Initiative Agreements module (#4895). Targets the module's epic branch.

IA analysts, IA managers and directors get a card in the wireframe's format — dark header, "There are:", green numerals with underlined links — showing lifecycle counts and a **View all initiative agreement(s)** link. Clicking a counter lands on the index grid already narrowed to that status, using the same stored-filter mechanism the CI applications card uses.

### Notes for a reviewer

**The wireframe's "Change order(s)" and "Expression of interest" counters are deliberately absent.** Neither term exists in the schema, the codebase, or any acceptance criterion — what they should count is an open product question. Until it is answered the card counts by lifecycle status (Underway, Draft), which is what the data model can truthfully report. This PR therefore does **not** close #4895.

**Legacy award rows cannot inflate the counts.** The counts query filters to agreement-kind records and groups by lifecycle status, which legacy rows never carry; an end-to-end test seeds a legacy award beside three agreements and pins the exact counts.

**Gating is layered.** The endpoint accepts only the three IDIR IA roles (a proponent gets 403, tested); the card is wrapped in the same role check on the dashboard; and it renders nothing when the `initiativeAgreements` feature flag is off.

### Testing

3 new backend tests (endpoint contract, proponent 403, and the record-kind end-to-end); 5 frontend tests on the card (loading, counts, pre-filtered navigation, view-all clearing the stored filter, flag-off) plus the dashboard suite — 271 pass. Type-check unchanged.

Refs #4895
