### PR TITLE
Feat: Initiative Agreement designated actions table - 4896

### DIFF
--- a/backend/lcfs/tests/initiative_agreement/test_designated_actions_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_designated_actions_api.py
@@ -1,0 +1,395 @@
+"""Designated action grid, analyst assignment and change log (#4896)."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from datetime import datetime
+
+from sqlalchemy import select
+
+from lcfs.db.base import ActionTypeEnum
+from lcfs.db.models.comment.DesignatedActionInternalComment import (
+    DesignatedActionInternalComment,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.initiative_agreement import DesignatedAction
+from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
+    EVENT_ANALYST_ASSIGNED,
+    EVENT_ANALYST_REASSIGNED,
+    EVENT_ANALYST_UNASSIGNED,
+    DesignatedActionHistory,
+)
+from lcfs.db.models.user.Role import Role, RoleEnum
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.db.models.user.UserRole import UserRole
+from lcfs.tests.initiative_agreement.test_initiative_agreement_api import (
+    IDIR_IA_ANALYST,
+    PAGINATION_BODY,
+    _action_status_id,
+    _seed_agreement,
+    _two_org_ids,
+)
+
+IDIR_IA_MANAGER = [RoleEnum.IA_MANAGER, RoleEnum.GOVERNMENT]
+
+
+async def _seed_action(dbsession, agreement, number, name, credits=1000, **overrides):
+    action = DesignatedAction(
+        initiative_agreement_id=agreement.initiative_agreement_id,
+        action_number=number,
+        name=name,
+        credit_allocation=credits,
+        current_status_id=await _action_status_id(dbsession, "Not started"),
+        **overrides,
+    )
+    dbsession.add(action)
+    await dbsession.flush()
+    return action
+
+
+async def _seed_ia_analyst(dbsession, username, first, last):
+    """An active IDIR user holding the IA Analyst role."""
+    user = UserProfile(
+        keycloak_email=f"{username}@gov.bc.ca",
+        keycloak_username=username,
+        email=f"{username}@gov.bc.ca",
+        first_name=first,
+        last_name=last,
+        organization_id=None,
+        is_active=True,
+    )
+    dbsession.add(user)
+    await dbsession.flush()
+    role_id = (
+        await dbsession.execute(
+            select(Role.role_id).where(Role.name == RoleEnum.IA_ANALYST)
+        )
+    ).scalar_one()
+    dbsession.add(UserRole(user_profile_id=user.user_profile_id, role_id=role_id))
+    await dbsession.flush()
+    return user
+
+
+def _list_url(fastapi_app, agreement):
+    return fastapi_app.url_path_for(
+        "get_designated_actions",
+        initiative_agreement_id=agreement.initiative_agreement_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_grid_lists_current_actions_with_analyst_and_dates(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26GRID1")
+    analyst = await _seed_ia_analyst(dbsession, "kchan", "Kenneth", "Chan")
+    await _seed_action(
+        dbsession,
+        agreement,
+        1,
+        "Commission station",
+        1850,
+        assigned_analyst_id=analyst.user_profile_id,
+    )
+    await _seed_action(dbsession, agreement, 2, "Production facility", 27309)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.post(
+        _list_url(fastapi_app, agreement), json=PAGINATION_BODY
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["pagination"]["total"] == 2
+    rows = data["designatedActions"]
+    assert [r["actionNumber"] for r in rows] == [1, 2]
+    assert rows[0]["assignedAnalyst"]["firstName"] == "Kenneth"
+    assert rows[1]["assignedAnalyst"] is None
+    assert rows[0]["creditAllocation"] == 1850
+    assert rows[0]["updateDate"] is not None
+    assert rows[0]["lastComment"] is None
+
+
+@pytest.mark.anyio
+async def test_grid_shows_one_row_per_amended_action(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26GRID2")
+    original = await _seed_action(dbsession, agreement, 1, "Original scope", 1000)
+    await _seed_action(
+        dbsession,
+        agreement,
+        1,
+        "Amended scope",
+        1500,
+        group_uuid=original.group_uuid,
+        version=1,
+        action_type=ActionTypeEnum.UPDATE,
+    )
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.post(
+        _list_url(fastapi_app, agreement), json=PAGINATION_BODY
+    )
+
+    rows = response.json()["designatedActions"]
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Amended scope"
+
+
+@pytest.mark.anyio
+async def test_grid_filters_by_name_and_assigned_analyst(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26GRID3")
+    analyst = await _seed_ia_analyst(dbsession, "efong", "Erin", "Fong")
+    await _seed_action(
+        dbsession,
+        agreement,
+        1,
+        "Charging corridor",
+        500,
+        assigned_analyst_id=analyst.user_profile_id,
+    )
+    await _seed_action(dbsession, agreement, 2, "Hydrogen station", 700)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    by_name = await client.post(
+        _list_url(fastapi_app, agreement),
+        json={
+            **PAGINATION_BODY,
+            "filters": [
+                {
+                    "field": "name",
+                    "filterType": "text",
+                    "type": "contains",
+                    "filter": "hydrogen",
+                }
+            ],
+        },
+    )
+    assert [r["name"] for r in by_name.json()["designatedActions"]] == [
+        "Hydrogen station"
+    ]
+
+    by_analyst = await client.post(
+        _list_url(fastapi_app, agreement),
+        json={
+            **PAGINATION_BODY,
+            "filters": [
+                {
+                    "field": "assignedAnalyst",
+                    "filterType": "number",
+                    "type": "equals",
+                    # The floating filter sends the id as a string.
+                    "filter": str(analyst.user_profile_id),
+                }
+            ],
+        },
+    )
+    assert [r["name"] for r in by_analyst.json()["designatedActions"]] == [
+        "Charging corridor"
+    ]
+
+
+@pytest.mark.anyio
+async def test_grid_surfaces_the_latest_action_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """DA comments post with #4900; the association already feeds the grid."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26GRID4")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    author = await _seed_ia_analyst(dbsession, "kchan2", "Kenneth", "Chan")
+
+    for text_, when in (
+        ("older note", datetime(2026, 1, 1)),
+        ("<p>newest note</p>", datetime(2026, 2, 1)),
+    ):
+        comment = InternalComment(comment=text_, visibility="Internal")
+        comment.create_user = author.keycloak_username
+        comment.create_date = when
+        dbsession.add(comment)
+        await dbsession.flush()
+        dbsession.add(
+            DesignatedActionInternalComment(
+                designated_action_id=action.designated_action_id,
+                internal_comment_id=comment.internal_comment_id,
+                designated_action_group_uuid=action.group_uuid,
+            )
+        )
+        await dbsession.flush()
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.post(
+        _list_url(fastapi_app, agreement), json=PAGINATION_BODY
+    )
+
+    row = response.json()["designatedActions"][0]
+    assert row["lastComment"]["fullName"] == "Kenneth Chan"
+    assert row["lastComment"]["comment"] == "newest note"
+
+
+@pytest.mark.anyio
+async def test_grid_is_refused_for_proponents(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26GRID5")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    forbidden = await client.post(
+        _list_url(fastapi_app, agreement), json=PAGINATION_BODY
+    )
+
+    assert forbidden.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_grid_404s_on_a_missing_agreement(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    missing = await client.post(
+        fastapi_app.url_path_for(
+            "get_designated_actions", initiative_agreement_id=999999
+        ),
+        json=PAGINATION_BODY,
+    )
+
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_manager_assignment_writes_the_change_log(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26ASGN1")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    first = await _seed_ia_analyst(dbsession, "efong2", "Erin", "Fong")
+    second = await _seed_ia_analyst(dbsession, "bwill", "Blake", "Willems")
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    url = fastapi_app.url_path_for(
+        "assign_designated_action_analyst",
+        designated_action_id=action.designated_action_id,
+    )
+
+    assigned = await client.put(url, json={"assignedAnalystId": first.user_profile_id})
+    assert assigned.status_code == status.HTTP_200_OK
+    assert assigned.json()["assignedAnalyst"]["firstName"] == "Erin"
+
+    reassigned = await client.put(
+        url, json={"assignedAnalystId": second.user_profile_id}
+    )
+    assert reassigned.json()["assignedAnalyst"]["firstName"] == "Blake"
+
+    unassigned = await client.put(url, json={"assignedAnalystId": None})
+    assert unassigned.json()["assignedAnalyst"] is None
+
+    events = (
+        (
+            await dbsession.execute(
+                select(DesignatedActionHistory)
+                .where(
+                    DesignatedActionHistory.designated_action_id
+                    == action.designated_action_id
+                )
+                .order_by(DesignatedActionHistory.designated_action_history_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [event.event for event in events] == [
+        EVENT_ANALYST_ASSIGNED,
+        EVENT_ANALYST_REASSIGNED,
+        EVENT_ANALYST_UNASSIGNED,
+    ]
+    assert events[1].snapshot == {
+        "from_analyst_id": first.user_profile_id,
+        "to_analyst_id": second.user_profile_id,
+    }
+    assert events[0].designated_action_group_uuid == action.group_uuid
+
+    # The version must not move: assignment is operational state, not a
+    # change order.
+    await dbsession.refresh(action)
+    assert action.version == 0
+
+
+@pytest.mark.parametrize(
+    "role_set",
+    [[RoleEnum.IA_ANALYST, RoleEnum.GOVERNMENT], [RoleEnum.IA_PROPONENT]],
+    ids=["ia-analyst", "proponent"],
+)
+@pytest.mark.anyio
+async def test_assignment_is_refused_below_manager(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession, role_set
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26ASGN2")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    set_mock_user(fastapi_app, role_set)
+
+    url = fastapi_app.url_path_for(
+        "assign_designated_action_analyst",
+        designated_action_id=action.designated_action_id,
+    )
+    response = await client.put(url, json={"assignedAnalystId": None})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_assignment_rejects_a_non_analyst_target(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Only active IA analysts are assignable."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26ASGN3")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    url = fastapi_app.url_path_for(
+        "assign_designated_action_analyst",
+        designated_action_id=action.designated_action_id,
+    )
+    response = await client.put(url, json={"assignedAnalystId": 999999})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_analyst_options_list_only_ia_analysts(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    analyst = await _seed_ia_analyst(dbsession, "efong3", "Erin", "Fong")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    url = fastapi_app.url_path_for("get_initiative_agreement_analysts")
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    rows = response.json()
+    ids = {row["userProfileId"] for row in rows}
+    assert analyst.user_profile_id in ids
+    erin = next(r for r in rows if r["userProfileId"] == analyst.user_profile_id)
+    assert erin["initials"] == "EF"
+    assert erin["fullName"] == "Erin Fong"
+
+
+@pytest.mark.anyio
+async def test_analyst_options_are_idir_only(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user
+):
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    url = fastapi_app.url_path_for("get_initiative_agreement_analysts")
+    forbidden = await client.get(url)
+
+    assert forbidden.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/web/api/initiative_agreement/repo.py
+++ b/backend/lcfs/web/api/initiative_agreement/repo.py
@@ -1,7 +1,7 @@
 from fastapi import Depends
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Sequence, Tuple
-from sqlalchemy import and_, asc, desc, func, select
+from sqlalchemy import String, and_, asc, desc, func, select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 from lcfs.db.base import ActionTypeEnum
@@ -24,6 +24,17 @@ from lcfs.db.models.comment.InitiativeAgreementInternalComment import (
     InitiativeAgreementInternalComment,
 )
 from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.comment.DesignatedActionInternalComment import (
+    DesignatedActionInternalComment,
+)
+from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
+    DesignatedActionHistory,
+)
+from lcfs.db.models.initiative_agreement.DesignatedActionStatus import (
+    DesignatedActionStatus,
+)
+from lcfs.db.models.user.Role import Role, RoleEnum
+from lcfs.db.models.user.UserRole import UserRole
 from lcfs.db.models.organization.Organization import Organization
 from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.web.api.base import PaginationRequestSchema
@@ -62,13 +73,28 @@ _DATE_FIELDS = {
 }
 
 
-def _build_list_filter(filter_model):
+# Keys are snake_case: FilterModel converts incoming camelCase field names.
+DA_LIST_FIELD_COLUMNS = {
+    "action_number": DesignatedAction.action_number,
+    "name": DesignatedAction.name,
+    "credit_allocation": DesignatedAction.credit_allocation,
+    "update_date": DesignatedAction.update_date,
+    # The floating select filter sends the analyst's user_profile_id.
+    "assigned_analyst": DesignatedAction.assigned_analyst_id,
+}
+
+DA_DATE_FIELDS = {"update_date"}
+
+
+def _build_list_filter(filter_model, columns=None, date_fields=None):
     """Translate one AG-Grid filter model into a SQLAlchemy condition."""
-    column = LIST_FIELD_COLUMNS.get(filter_model.field)
+    columns = LIST_FIELD_COLUMNS if columns is None else columns
+    date_fields = _DATE_FIELDS if date_fields is None else date_fields
+    column = columns.get(filter_model.field)
     if column is None:
         return None
 
-    if filter_model.filter_type == "date" or filter_model.field in _DATE_FIELDS:
+    if filter_model.filter_type == "date" or filter_model.field in date_fields:
         if filter_model.type == "inRange":
             return and_(
                 column >= filter_model.date_from, column <= filter_model.date_to
@@ -448,6 +474,218 @@ class InitiativeAgreementRepository:
             full_name = " ".join(p for p in (first_name, last_name) if p).strip()
             latest[agreement_id] = (comment, full_name)
         return latest
+
+    @repo_handler
+    async def get_designated_actions_paginated(
+        self,
+        initiative_agreement_id: int,
+        pagination: PaginationRequestSchema,
+    ) -> Tuple[List[DesignatedAction], int]:
+        """
+        Paginated current-version designated actions for one agreement's
+        grid. Change orders append rows sharing group_uuid, so the base set
+        is the highest version per group.
+        """
+        latest = (
+            select(
+                DesignatedAction.group_uuid,
+                func.max(DesignatedAction.version).label("max_version"),
+            )
+            .where(DesignatedAction.initiative_agreement_id == initiative_agreement_id)
+            .group_by(DesignatedAction.group_uuid)
+            .subquery()
+        )
+        query = (
+            select(DesignatedAction)
+            .join(
+                latest,
+                and_(
+                    DesignatedAction.group_uuid == latest.c.group_uuid,
+                    DesignatedAction.version == latest.c.max_version,
+                ),
+            )
+            .where(
+                DesignatedAction.initiative_agreement_id == initiative_agreement_id,
+                DesignatedAction.action_type != ActionTypeEnum.DELETE,
+            )
+        )
+        for filter_model in pagination.filters:
+            # The analyst floating filter's value crosses the wire as a
+            # string; the column is an integer FK.
+            if (
+                filter_model.field == "assigned_analyst"
+                and isinstance(filter_model.filter, str)
+                and filter_model.filter.isdigit()
+            ):
+                filter_model.filter = int(filter_model.filter)
+            condition = _build_list_filter(
+                filter_model, columns=DA_LIST_FIELD_COLUMNS, date_fields=DA_DATE_FIELDS
+            )
+            if condition is not None:
+                query = query.where(condition)
+
+        order_by_clauses = []
+        for order in pagination.sort_orders:
+            column = DA_LIST_FIELD_COLUMNS.get(order.field)
+            if column is None:
+                continue
+            order_by_clauses.append(
+                desc(column) if order.direction == "desc" else asc(column)
+            )
+        if not order_by_clauses:
+            order_by_clauses = [asc(DesignatedAction.action_number)]
+
+        count_query = select(func.count()).select_from(
+            query.with_only_columns(DesignatedAction.designated_action_id).subquery()
+        )
+        total_count = (await self.db.execute(count_query)).scalar_one()
+
+        offset = (pagination.page - 1) * pagination.size
+        result = await self.db.execute(
+            query.options(
+                selectinload(DesignatedAction.current_status),
+                selectinload(DesignatedAction.assigned_analyst),
+            )
+            .order_by(*order_by_clauses)
+            .offset(offset)
+            .limit(pagination.size)
+        )
+        return result.scalars().all(), total_count
+
+    @repo_handler
+    async def get_designated_action_by_id(
+        self, designated_action_id: int
+    ) -> Optional[DesignatedAction]:
+        result = await self.db.execute(
+            select(DesignatedAction)
+            .options(
+                selectinload(DesignatedAction.current_status),
+                selectinload(DesignatedAction.assigned_analyst),
+                selectinload(DesignatedAction.initiative_agreement),
+            )
+            .where(DesignatedAction.designated_action_id == designated_action_id)
+            # Refresh relationships even when the row is already in the
+            # identity map — the assignment flow re-reads after mutating.
+            .execution_options(populate_existing=True)
+        )
+        return result.scalars().first()
+
+    @repo_handler
+    async def get_latest_comments_by_designated_action_ids(
+        self,
+        designated_actions: Sequence[DesignatedAction],
+        include_internal: bool,
+    ) -> Dict[int, Tuple[InternalComment, str]]:
+        """
+        The newest comment visible to the caller, per designated action.
+
+        Comments associate by concrete id and carry a denormalized
+        group_uuid so they survive change-order version rows — match either.
+        The visibility filter is applied before ranking, as with agreements.
+        """
+        if not designated_actions:
+            return {}
+        ids = [da.designated_action_id for da in designated_actions]
+        group_uuids = [da.group_uuid for da in designated_actions if da.group_uuid]
+
+        assoc_matches = DesignatedActionInternalComment.designated_action_id.in_(ids)
+        if group_uuids:
+            assoc_matches = assoc_matches | (
+                DesignatedActionInternalComment.designated_action_group_uuid.in_(
+                    group_uuids
+                )
+            )
+
+        ranked = (
+            select(
+                DesignatedActionInternalComment.designated_action_id.label(
+                    "designated_action_id"
+                ),
+                DesignatedActionInternalComment.designated_action_group_uuid.label(
+                    "designated_action_group_uuid"
+                ),
+                InternalComment.internal_comment_id.label("internal_comment_id"),
+                func.row_number()
+                .over(
+                    partition_by=func.coalesce(
+                        DesignatedActionInternalComment.designated_action_group_uuid,
+                        func.cast(
+                            DesignatedActionInternalComment.designated_action_id,
+                            String,
+                        ),
+                    ),
+                    order_by=desc(InternalComment.create_date),
+                )
+                .label("rn"),
+            )
+            .join(
+                InternalComment,
+                InternalComment.internal_comment_id
+                == DesignatedActionInternalComment.internal_comment_id,
+            )
+            .where(assoc_matches)
+        )
+        if not include_internal:
+            ranked = ranked.where(
+                InternalComment.visibility == CommentVisibilityEnum.PUBLIC.value
+            )
+        ranked_subq = ranked.subquery()
+
+        stmt = (
+            select(
+                ranked_subq.c.designated_action_id,
+                ranked_subq.c.designated_action_group_uuid,
+                InternalComment,
+                UserProfile.first_name,
+                UserProfile.last_name,
+            )
+            .join(
+                InternalComment,
+                InternalComment.internal_comment_id
+                == ranked_subq.c.internal_comment_id,
+            )
+            .join(
+                UserProfile,
+                UserProfile.keycloak_username == InternalComment.create_user,
+                isouter=True,
+            )
+            .where(ranked_subq.c.rn == 1)
+        )
+        result = await self.db.execute(stmt)
+
+        by_group = {da.group_uuid: da.designated_action_id for da in designated_actions}
+        latest: Dict[int, Tuple[InternalComment, str]] = {}
+        for da_id, group_uuid, comment, first_name, last_name in result.all():
+            full_name = " ".join(p for p in (first_name, last_name) if p).strip()
+            key = by_group.get(group_uuid, da_id)
+            latest[key] = (comment, full_name)
+        return latest
+
+    @repo_handler
+    async def get_active_ia_analysts(self) -> List[UserProfile]:
+        """Active IDIR users holding the IA Analyst role, for assignment."""
+        result = await self.db.execute(
+            select(UserProfile)
+            .join(UserRole, UserProfile.user_profile_id == UserRole.user_profile_id)
+            .join(Role, UserRole.role_id == Role.role_id)
+            .where(
+                and_(
+                    UserProfile.is_active == True,
+                    UserProfile.organization_id.is_(None),
+                    Role.name == RoleEnum.IA_ANALYST,
+                )
+            )
+            .order_by(UserProfile.first_name, UserProfile.last_name)
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
+    async def add_designated_action_history(
+        self, history: DesignatedActionHistory
+    ) -> DesignatedActionHistory:
+        self.db.add(history)
+        await self.db.flush()
+        return history
 
     @repo_handler
     async def get_lifecycle_statuses(self) -> List[InitiativeAgreementLifecycleStatus]:

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -138,33 +138,6 @@ class AssignedAnalystSchema(BaseSchema):
         from_attributes = True
 
 
-class DesignatedActionSchema(BaseSchema):
-    designated_action_id: int
-    action_number: int
-    name: str
-    description: Optional[str] = None
-    specified_date: Optional[date] = None
-    completed_date: Optional[date] = None
-    determination_date: Optional[date] = None
-    credit_allocation: int
-    determination: Optional[str] = None
-    current_status: DesignatedActionStatusSchema
-    assigned_analyst: Optional[AssignedAnalystSchema] = None
-    transaction_id: Optional[int] = None
-
-    class Config:
-        from_attributes = True
-
-
-class InitiativeAgreementLifecycleStatusSchema(BaseSchema):
-    initiative_agreement_lifecycle_status_id: int
-    status: str
-    description: Optional[str] = None
-
-    class Config:
-        from_attributes = True
-
-
 class LastCommentSchema(BaseSchema):
     """
     Newest comment visible to the caller, for the grid's avatar column.
@@ -176,6 +149,71 @@ class LastCommentSchema(BaseSchema):
     full_name: str
     comment: str
     create_date: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DesignatedActionSchema(BaseSchema):
+    designated_action_id: int
+    action_number: int
+    name: str
+    description: Optional[str] = None
+    specified_date: Optional[date] = None
+    completed_date: Optional[date] = None
+    determination_date: Optional[date] = None
+    credit_allocation: int
+    recommended_credits: Optional[int] = None
+    determination: Optional[str] = None
+    current_status: DesignatedActionStatusSchema
+    assigned_analyst: Optional[AssignedAnalystSchema] = None
+    transaction_id: Optional[int] = None
+    update_date: Optional[datetime] = None
+    # Newest comment visible to the caller; populated by the grid endpoint
+    # only. DA comments arrive with #4900 — the column exists first.
+    last_comment: Optional[LastCommentSchema] = None
+
+    class Config:
+        from_attributes = True
+
+
+class DesignatedActionsListSchema(BaseSchema):
+    pagination: PaginationResponseSchema
+    designated_actions: List[DesignatedActionSchema]
+
+
+class AnalystAssignmentSchema(BaseSchema):
+    assigned_analyst_id: Optional[int] = None
+
+
+class IAAnalystSchema(BaseSchema):
+    user_profile_id: int
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    initials: Optional[str] = None
+    full_name: Optional[str] = None
+
+    @classmethod
+    def model_validate(cls, user):
+        if user is None:
+            return None
+        first_name = getattr(user, "first_name", "") or ""
+        last_name = getattr(user, "last_name", "") or ""
+        initials = f"{first_name[:1]}{last_name[:1]}".upper() or None
+        full_name = " ".join(p for p in (first_name, last_name) if p) or None
+        return cls(
+            user_profile_id=user.user_profile_id,
+            first_name=first_name or None,
+            last_name=last_name or None,
+            initials=initials,
+            full_name=full_name,
+        )
+
+
+class InitiativeAgreementLifecycleStatusSchema(BaseSchema):
+    initiative_agreement_lifecycle_status_id: int
+    status: str
+    description: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/lcfs/web/api/initiative_agreement/services.py
+++ b/backend/lcfs/web/api/initiative_agreement/services.py
@@ -11,6 +11,12 @@ import structlog
 from datetime import datetime, timezone
 from fastapi import Depends, Request, HTTPException
 from lcfs.db.models.initiative_agreement.InitiativeAgreement import InitiativeAgreement
+from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
+    EVENT_ANALYST_ASSIGNED,
+    EVENT_ANALYST_REASSIGNED,
+    EVENT_ANALYST_UNASSIGNED,
+    DesignatedActionHistory,
+)
 from lcfs.db.models.initiative_agreement.InitiativeAgreementStatus import (
     InitiativeAgreementStatusEnum,
 )
@@ -22,6 +28,10 @@ from lcfs.web.api.base import (
 )
 from lcfs.web.api.internal_comment.services import sanitize_comment_text
 from lcfs.web.api.initiative_agreement.schema import (
+    AnalystAssignmentSchema,
+    DesignatedActionSchema,
+    DesignatedActionsListSchema,
+    IAAnalystSchema,
     CreateInitiativeAgreementHistorySchema,
     LastCommentSchema,
     InitiativeAgreementCreateSchema,
@@ -188,6 +198,124 @@ class InitiativeAgreementServices:
             create_date=agreement.create_date,
             designated_actions=designated_actions,
         )
+
+    @service_handler
+    async def get_designated_actions_paginated(
+        self, initiative_agreement_id: int, pagination: PaginationRequestSchema
+    ) -> DesignatedActionsListSchema:
+        """Paginated designated actions for one agreement's grid (#4896)."""
+        agreement = await self.repo.get_initiative_agreement_by_id(
+            initiative_agreement_id
+        )
+        if not agreement:
+            raise DataNotFoundException(
+                f"Initiative Agreement with id {initiative_agreement_id} not found"
+            )
+        pagination = validate_pagination(pagination)
+        pagination.size = min(pagination.size, MAX_PAGE_SIZE)
+        actions, total_count = await self.repo.get_designated_actions_paginated(
+            initiative_agreement_id, pagination
+        )
+        # The grid endpoint is IDIR-only, so internal comments are visible.
+        latest_comments = await self.repo.get_latest_comments_by_designated_action_ids(
+            actions, include_internal=True
+        )
+        rows = []
+        for action in actions:
+            row = DesignatedActionSchema.model_validate(action)
+            entry = latest_comments.get(action.designated_action_id)
+            if entry:
+                comment, full_name = entry
+                if full_name:
+                    text = comment.comment_search_text or sanitize_comment_text(
+                        comment.comment
+                    )
+                    row = row.model_copy(
+                        update={
+                            "last_comment": LastCommentSchema(
+                                full_name=full_name,
+                                comment=text,
+                                create_date=comment.create_date,
+                            )
+                        }
+                    )
+            rows.append(row)
+        return DesignatedActionsListSchema(
+            pagination=PaginationResponseSchema(
+                total=total_count,
+                page=pagination.page,
+                size=pagination.size,
+                total_pages=(
+                    math.ceil(total_count / pagination.size) if pagination.size else 0
+                ),
+            ),
+            designated_actions=rows,
+        )
+
+    @service_handler
+    async def get_available_analysts(self) -> list[IAAnalystSchema]:
+        analysts = await self.repo.get_active_ia_analysts()
+        return [IAAnalystSchema.model_validate(a) for a in analysts]
+
+    @service_handler
+    async def assign_designated_action_analyst(
+        self,
+        designated_action_id: int,
+        data: AnalystAssignmentSchema,
+        user,
+    ) -> DesignatedActionSchema:
+        """
+        Assign, reassign or unassign the analyst on a designated action.
+
+        Mutates the current row in place and records the change in
+        designated_action_history — assignment is operational state, not a
+        change order, so it must never append a version row (#4896).
+        """
+        action = await self.repo.get_designated_action_by_id(designated_action_id)
+        if not action:
+            raise DataNotFoundException(
+                f"Designated action with id {designated_action_id} not found"
+            )
+
+        new_analyst_id = data.assigned_analyst_id
+        if new_analyst_id is not None:
+            analysts = await self.repo.get_active_ia_analysts()
+            if new_analyst_id not in {a.user_profile_id for a in analysts}:
+                raise HTTPException(
+                    status_code=400,
+                    detail="assigned_analyst_id is not an active IA analyst.",
+                )
+
+        old_analyst_id = action.assigned_analyst_id
+        if old_analyst_id is None and new_analyst_id is not None:
+            event = EVENT_ANALYST_ASSIGNED
+        elif old_analyst_id is not None and new_analyst_id is None:
+            event = EVENT_ANALYST_UNASSIGNED
+        elif old_analyst_id != new_analyst_id:
+            event = EVENT_ANALYST_REASSIGNED
+        else:
+            # No change; do not write a history row for a no-op.
+            return DesignatedActionSchema.model_validate(action)
+
+        action.assigned_analyst_id = new_analyst_id
+        display_name = " ".join(
+            p for p in (user.first_name, user.last_name) if p
+        ).strip()
+        await self.repo.add_designated_action_history(
+            DesignatedActionHistory(
+                designated_action_id=action.designated_action_id,
+                designated_action_group_uuid=action.group_uuid,
+                event=event,
+                user_profile_id=getattr(user, "user_profile_id", None),
+                display_name=display_name or None,
+                snapshot={
+                    "from_analyst_id": old_analyst_id,
+                    "to_analyst_id": new_analyst_id,
+                },
+            )
+        )
+        refreshed = await self.repo.get_designated_action_by_id(designated_action_id)
+        return DesignatedActionSchema.model_validate(refreshed)
 
     @service_handler
     async def update_initiative_agreement(

--- a/backend/lcfs/web/api/initiative_agreement/views.py
+++ b/backend/lcfs/web/api/initiative_agreement/views.py
@@ -4,6 +4,10 @@ from fastapi import APIRouter, Body, Depends, Request, status
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.initiative_agreement.services import InitiativeAgreementServices
 from lcfs.web.api.initiative_agreement.schema import (
+    AnalystAssignmentSchema,
+    DesignatedActionSchema,
+    DesignatedActionsListSchema,
+    IAAnalystSchema,
     InitiativeAgreementCreateSchema,
     InitiativeAgreementLifecycleStatusSchema,
     InitiativeAgreementProfileSchema,
@@ -25,6 +29,10 @@ IA_MODULE_ROLES = [
     RoleEnum.IA_PROPONENT,
 ]
 
+# The designated-action grid and analyst tools are the IDIR story (#4896);
+# the proponent's view arrives with the BCeID story.
+IA_IDIR_ROLES = [RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR]
+
 router = APIRouter()
 
 
@@ -41,6 +49,56 @@ async def get_initiative_agreements(
 ):
     """Paginated list of initiative agreements for the agreement-management grid."""
     return await service.get_initiative_agreements_paginated(pagination)
+
+
+@router.get(
+    "/analysts",
+    response_model=List[IAAnalystSchema],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def get_initiative_agreement_analysts(
+    request: Request,
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Active IA analysts, for the assignment dropdown and its filter."""
+    return await service.get_available_analysts()
+
+
+@router.post(
+    "/{initiative_agreement_id}/designated-actions/list",
+    response_model=DesignatedActionsListSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def get_designated_actions(
+    request: Request,
+    initiative_agreement_id: int,
+    pagination: PaginationRequestSchema = Body(..., embed=False),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Paginated designated actions for one agreement's grid."""
+    return await service.get_designated_actions_paginated(
+        initiative_agreement_id, pagination
+    )
+
+
+@router.put(
+    "/designated-actions/{designated_action_id}/assign",
+    response_model=DesignatedActionSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler([RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR])
+async def assign_designated_action_analyst(
+    request: Request,
+    designated_action_id: int,
+    data: AnalystAssignmentSchema = Body(...),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Assign, reassign or unassign an analyst (IA managers and directors)."""
+    return await service.assign_designated_action_analyst(
+        designated_action_id, data, request.user
+    )
 
 
 @router.get(

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -1,7 +1,7 @@
 {
   "title": "Initiative agreements",
   "initiativeAgreementsPlaceholder": "This section will provide access to Initiative Agreement functionality. Content and features are currently under development.",
-  "initiativeAgreement": "Initiative agreement \u2014 ID:",
+  "initiativeAgreement": "Initiative agreement — ID:",
   "editInitiativeAgreementID": "Edit initiative agreement ID: ",
   "newInitiativeAgreement": "New initiative agreement",
   "actionMsgs": {
@@ -53,5 +53,22 @@
     "uploadTitle": "Initiative Agreement documents",
     "documentLabel": "the initiative agreement",
     "returnButton": "Return to initiative agreement"
+  },
+  "actions": {
+    "columns": {
+      "id": "ID",
+      "name": "DA name",
+      "assignedAnalyst": "Assigned analyst",
+      "lastComment": "Last comment",
+      "creditsToBeIssued": "Compliance units to be issued",
+      "lastUpdated": "Last updated"
+    },
+    "upToCredits": "up to {{count}}",
+    "noActionsFound": "No designated actions found",
+    "unassigned": "Unassigned"
+  },
+  "actionDetail": {
+    "title": "Designated action",
+    "placeholder": "Designated action details are under construction."
   }
 }

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -75,6 +75,11 @@ export const apiRoutes = {
   getInitiativeAgreementStatuses: '/initiative-agreements/statuses',
   getInitiativeAgreement:
     '/initiative-agreements/:initiativeAgreementId/profile',
+  getInitiativeAgreementAnalysts: '/initiative-agreements/analysts',
+  getDesignatedActionsList:
+    '/initiative-agreements/:initiativeAgreementId/designated-actions/list',
+  assignDesignatedActionAnalyst:
+    '/initiative-agreements/designated-actions/:designatedActionId/assign',
 
   // fuel-type
   getFuelTypeOthers: '/fuel-type/others/list',

--- a/frontend/src/hooks/useInitiativeAgreements.ts
+++ b/frontend/src/hooks/useInitiativeAgreements.ts
@@ -1,6 +1,6 @@
 import { apiRoutes } from '@/constants/routes'
 import { useApiService } from '@/services/useApiService'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { PaginationParams, QueryOptions } from './types'
 
 // Agreement-management hooks for the Initiative Agreements module.
@@ -11,7 +11,13 @@ import type { PaginationParams, QueryOptions } from './types'
 const QUERY_KEYS = {
   list: (pagination: any) => ['initiative-agreements', pagination],
   detail: (id: any) => ['initiative-agreements', 'detail', String(id)],
-  statuses: ['initiative-agreement-statuses']
+  statuses: ['initiative-agreement-statuses'],
+  designatedActions: (agreementId: any, pagination: any) => [
+    'designated-actions',
+    String(agreementId),
+    pagination
+  ],
+  analysts: ['initiative-agreement-analysts']
 }
 
 export const useGetInitiativeAgreements = (
@@ -69,5 +75,71 @@ export const useInitiativeAgreementStatuses = (
     staleTime: 60 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
     ...options
+  })
+}
+
+/** Paginated designated actions for one agreement's grid (#4896). */
+export const useDesignatedActions = (
+  initiativeAgreementId: number | string,
+  { page = 1, size = 10, sortOrders = [], filters = [] }: PaginationParams = {},
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!initiativeAgreementId,
+    queryKey: QUERY_KEYS.designatedActions(initiativeAgreementId, {
+      page,
+      size,
+      sortOrders,
+      filters
+    }),
+    queryFn: async () =>
+      (
+        await client.post(
+          apiRoutes.getDesignatedActionsList.replace(
+            ':initiativeAgreementId',
+            String(initiativeAgreementId)
+          ),
+          { page, size, sortOrders, filters }
+        )
+      ).data,
+    ...options
+  })
+}
+
+/** Active IA analysts for the assignment dropdown and its filter. */
+export const useInitiativeAgreementAnalysts = (
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    queryKey: QUERY_KEYS.analysts,
+    queryFn: async () =>
+      (await client.get(apiRoutes.getInitiativeAgreementAnalysts)).data,
+    staleTime: 5 * 60 * 1000,
+    ...options
+  })
+}
+
+/** Assign, reassign or unassign the analyst on a designated action. */
+export const useAssignDesignatedActionAnalyst = (
+  designatedActionId: number | string
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (assignedAnalystId: number | null) =>
+      (
+        await client.put(
+          apiRoutes.assignDesignatedActionAnalyst.replace(
+            ':designatedActionId',
+            String(designatedActionId)
+          ),
+          { assignedAnalystId }
+        )
+      ).data,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['designated-actions'] })
+    }
   })
 }

--- a/frontend/src/routes/routeConfig/__tests__/initiativeAgreementRoutes.test.jsx
+++ b/frontend/src/routes/routeConfig/__tests__/initiativeAgreementRoutes.test.jsx
@@ -4,7 +4,8 @@ import { initiativeAgreementRoutes } from '../initiativeAgreementRoutes'
 // Mock the view components
 vi.mock('@/views/InitiativeAgreements', () => ({
   InitiativeAgreements: () => 'InitiativeAgreements',
-  InitiativeAgreementDetail: () => 'InitiativeAgreementDetail'
+  InitiativeAgreementDetail: () => 'InitiativeAgreementDetail',
+  DesignatedActionDetail: () => 'DesignatedActionDetail'
 }))
 
 vi.mock('../routes', () => ({
@@ -12,7 +13,9 @@ vi.mock('../routes', () => ({
   default: {
     INITIATIVE_AGREEMENTS: {
       LIST: '/initiative-agreements',
-      VIEW: '/initiative-agreements/:initiativeAgreementId'
+      VIEW: '/initiative-agreements/:initiativeAgreementId',
+      ACTION_VIEW:
+        '/initiative-agreements/:initiativeAgreementId/designated-actions/:designatedActionId'
     }
   }
 }))
@@ -20,7 +23,7 @@ vi.mock('../routes', () => ({
 describe('initiativeAgreementRoutes', () => {
   it('should export the list and detail route configurations', () => {
     expect(Array.isArray(initiativeAgreementRoutes)).toBe(true)
-    expect(initiativeAgreementRoutes).toHaveLength(2)
+    expect(initiativeAgreementRoutes).toHaveLength(3)
   })
 
   it('should have correct route structure for the agreements list', () => {
@@ -39,5 +42,16 @@ describe('initiativeAgreementRoutes', () => {
     expect(detailRoute).toBeDefined()
     expect(detailRoute.handle.title).toBe('Initiative agreement')
     expect(detailRoute.handle.crumb()).toBe('Initiative agreement')
+  })
+
+  it('should have correct route structure for the designated action detail', () => {
+    const actionRoute = initiativeAgreementRoutes.find(
+      (route) =>
+        route.path ===
+        '/initiative-agreements/:initiativeAgreementId/designated-actions/:designatedActionId'
+    )
+    expect(actionRoute).toBeDefined()
+    expect(actionRoute.handle.title).toBe('Designated action')
+    expect(actionRoute.handle.crumb()).toBe('Designated action')
   })
 })

--- a/frontend/src/routes/routeConfig/initiativeAgreementRoutes.tsx
+++ b/frontend/src/routes/routeConfig/initiativeAgreementRoutes.tsx
@@ -1,4 +1,5 @@
 import {
+  DesignatedActionDetail,
   InitiativeAgreementDetail,
   InitiativeAgreements
 } from '@/views/InitiativeAgreements'
@@ -14,6 +15,11 @@ const InitiativeAgreementsGated = withFeatureFlag(
 )
 const InitiativeAgreementDetailGated = withFeatureFlag(
   InitiativeAgreementDetail,
+  FEATURE_FLAGS.INITIATIVE_AGREEMENTS,
+  ROUTES.DASHBOARD
+)
+const DesignatedActionDetailGated = withFeatureFlag(
+  DesignatedActionDetail,
   FEATURE_FLAGS.INITIATIVE_AGREEMENTS,
   ROUTES.DASHBOARD
 )
@@ -33,6 +39,14 @@ export const initiativeAgreementRoutes: AppRouteObject[] = [
     handle: {
       title: 'Initiative agreement',
       crumb: () => 'Initiative agreement'
+    }
+  },
+  {
+    path: ROUTES.INITIATIVE_AGREEMENTS.ACTION_VIEW,
+    element: <DesignatedActionDetailGated />,
+    handle: {
+      title: 'Designated action',
+      crumb: () => 'Designated action'
     }
   }
 ]

--- a/frontend/src/routes/routes.ts
+++ b/frontend/src/routes/routes.ts
@@ -154,7 +154,9 @@ export const ROUTES = {
 
   INITIATIVE_AGREEMENTS: {
     LIST: '/initiative-agreements',
-    VIEW: '/initiative-agreements/:initiativeAgreementId'
+    VIEW: '/initiative-agreements/:initiativeAgreementId',
+    ACTION_VIEW:
+      '/initiative-agreements/:initiativeAgreementId/designated-actions/:designatedActionId'
   },
 
   FORMS: {

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import { Divider } from '@mui/material'
+
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import { roles } from '@/constants/roles'
+import { ROUTES } from '@/routes/routes'
+import withRole from '@/utils/withRole'
+
+import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
+
+// Skeleton for the designated action detail page. The grid on the
+// agreement page navigates here (#4896); the page's content — evidence
+// requirements, submissions and the action workflow — arrives with #4840.
+const DesignatedActionDetailBase = () => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const { initiativeAgreementId, designatedActionId } = useParams()
+
+  return (
+    <BCBox>
+      <InitiativeAgreementTabs />
+      <BCTypography
+        variant="h5"
+        color="primary"
+        data-test="designated-action-detail-title"
+      >
+        {t('initiativeAgreement:actionDetail.title')}
+        {` - DA${designatedActionId}-IA${initiativeAgreementId}`}
+      </BCTypography>
+      <Divider sx={{ mt: 2, mb: 3 }} />
+      <BCTypography variant="body1" color="text.secondary">
+        {t('initiativeAgreement:actionDetail.placeholder')}
+      </BCTypography>
+    </BCBox>
+  )
+}
+
+export const DesignatedActionDetail = withRole(
+  DesignatedActionDetailBase,
+  [roles.ia_analyst, roles.ia_manager, roles.director],
+  ROUTES.DASHBOARD
+)
+DesignatedActionDetail.displayName = 'DesignatedActionDetail'

--- a/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
@@ -23,6 +23,7 @@ import withRole from '@/utils/withRole'
 import { useGetInitiativeAgreement } from '@/hooks/useInitiativeAgreements'
 import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
+import { DesignatedActionsGrid } from './components/DesignatedActionsGrid'
 
 // The shared document machinery keys on this string for initiative agreements.
 const PARENT_TYPE = 'initiativeAgreement'
@@ -249,19 +250,22 @@ const InitiativeAgreementDetailBase = () => {
         parentID={initiativeAgreementId}
       />
 
-      {/* Designated actions grid arrives with #4896. */}
-      <Paper
-        variant="outlined"
-        sx={{ p: 3, mt: 3 }}
-        data-test="initiative-agreement-actions-section"
-      >
-        <BCTypography variant="h6" color="primary" mb={1}>
-          {t('initiativeAgreement:detail.designatedActions')}
-        </BCTypography>
-        <BCTypography variant="body2" color="text.secondary">
-          {t('initiativeAgreement:detail.sectionPlaceholder')}
-        </BCTypography>
-      </Paper>
+      {/* The designated-action grid is the IDIR story (#4896); the
+          proponent's view arrives with the BCeID story. */}
+      <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+        <Paper
+          variant="outlined"
+          sx={{ p: 3, mt: 3 }}
+          data-test="initiative-agreement-actions-section"
+        >
+          <BCTypography variant="h6" color="primary" mb={1}>
+            {t('initiativeAgreement:detail.designatedActions')}
+          </BCTypography>
+          <DesignatedActionsGrid
+            initiativeAgreementId={initiativeAgreementId}
+          />
+        </Paper>
+      </Role>
 
       {/* The thread is IDIR-only until the BCeID story opens Public
           comments to proponents; the API 403s them today. */}

--- a/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/InitiativeAgreementDetail.test.jsx
@@ -51,6 +51,14 @@ vi.mock('@/components/Comments', () => ({
   }
 }))
 
+const daGridProps = vi.fn()
+vi.mock('../components/DesignatedActionsGrid', () => ({
+  DesignatedActionsGrid: (props) => {
+    daGridProps(props)
+    return <div data-test="designated-actions-grid" />
+  }
+}))
+
 vi.mock('@/components/Documents/DocumentUploadDialog', () => ({
   default: ({ open }) => (open ? <div data-test="upload-dialog" /> : null)
 }))
@@ -182,6 +190,24 @@ describe('InitiativeAgreementDetail', () => {
     expect(useInitiativeAgreementPageStore.getState().agreementCrumb).toBe(
       'IA-26ORG1'
     )
+  })
+
+  it('renders the designated actions grid for IDIR IA roles', () => {
+    render(<InitiativeAgreementDetail />, { wrapper })
+
+    expect(screen.getByTestId('designated-actions-grid')).toBeInTheDocument()
+    expect(daGridProps).toHaveBeenCalledWith(
+      expect.objectContaining({ initiativeAgreementId: '5' })
+    )
+  })
+
+  it('hides the designated actions grid from a BCeID proponent', () => {
+    mockRoles = [{ name: roles.ia_proponent }]
+    render(<InitiativeAgreementDetail />, { wrapper })
+
+    expect(
+      screen.queryByTestId('designated-actions-grid')
+    ).not.toBeInTheDocument()
   })
 
   it('shows the dual-mode comment thread to IDIR IA roles', () => {

--- a/frontend/src/views/InitiativeAgreements/_schema.tsx
+++ b/frontend/src/views/InitiativeAgreements/_schema.tsx
@@ -6,7 +6,11 @@ import {
   BCDateFloatingFilter,
   BCSelectFloatingFilter
 } from '@/components/BCDataGrid/components'
-import { useInitiativeAgreementStatuses } from '@/hooks/useInitiativeAgreements'
+import {
+  useInitiativeAgreementAnalysts,
+  useInitiativeAgreementStatuses
+} from '@/hooks/useInitiativeAgreements'
+import { DAAssignedAnalystCell } from './components/DAAssignedAnalystCell'
 import { dateFormatter } from '@/utils/formatters'
 import { createStatusRenderer } from '@/utils/grid/cellRenderers'
 
@@ -144,3 +148,72 @@ export const initiativeAgreementColDefs = (t): ColDef[] => [
 ]
 
 export const defaultSortModel = [{ field: 'updateDate', direction: 'desc' }]
+
+// Column definitions for the designated actions grid on the agreement
+// detail page (#4896). The ID renders as "DA{n}-IA{agreement}", matching
+// the wireframe; the analyst column assigns inline for managers and
+// directors and its floating filter sends the analyst's id.
+export const designatedActionColDefs = (t, initiativeAgreementId): ColDef[] => [
+  {
+    colId: 'actionNumber',
+    field: 'actionNumber',
+    headerName: t('initiativeAgreement:actions.columns.id'),
+    valueGetter: (params) =>
+      `DA${params.data?.actionNumber}-IA${initiativeAgreementId}`,
+    minWidth: 120,
+    filter: false
+  },
+  {
+    field: 'name',
+    headerName: t('initiativeAgreement:actions.columns.name'),
+    minWidth: 240,
+    flex: 1,
+    filter: 'agTextColumnFilter',
+    filterParams: TEXT_FILTER_PARAMS
+  },
+  {
+    colId: 'assignedAnalyst',
+    field: 'assignedAnalyst',
+    headerName: t('initiativeAgreement:actions.columns.assignedAnalyst'),
+    minWidth: 180,
+    sortable: false,
+    valueGetter: ({ data }) => data?.assignedAnalyst?.userProfileId ?? '',
+    cellRenderer: DAAssignedAnalystCell,
+    filter: 'agTextColumnFilter',
+    floatingFilterComponent: BCSelectFloatingFilter,
+    floatingFilterComponentParams: {
+      optionsQuery: useInitiativeAgreementAnalysts,
+      valueKey: 'userProfileId',
+      labelKey: 'fullName'
+    },
+    suppressFloatingFilterButton: true
+  },
+  {
+    field: 'lastComment',
+    headerName: t('initiativeAgreement:actions.columns.lastComment'),
+    minWidth: 140,
+    sortable: false,
+    filter: false,
+    valueGetter: ({ data }) => data?.lastComment?.fullName || '',
+    cellRenderer: LastCommentRenderer
+  },
+  {
+    field: 'creditAllocation',
+    headerName: t('initiativeAgreement:actions.columns.creditsToBeIssued'),
+    minWidth: 200,
+    filter: false,
+    valueFormatter: ({ value }) =>
+      value != null
+        ? t('initiativeAgreement:actions.upToCredits', {
+            count: value.toLocaleString()
+          })
+        : '',
+    valueGetter: ({ data }) => data?.creditAllocation
+  },
+  {
+    ...dateCol(
+      'updateDate',
+      t('initiativeAgreement:actions.columns.lastUpdated')
+    )
+  }
+]

--- a/frontend/src/views/InitiativeAgreements/components/DAAssignedAnalystCell.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DAAssignedAnalystCell.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  FormControl,
+  MenuItem,
+  Select,
+  Tooltip,
+  useTheme
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+import {
+  useAssignDesignatedActionAnalyst,
+  useInitiativeAgreementAnalysts
+} from '@/hooks/useInitiativeAgreements'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { roles } from '@/constants/roles'
+
+// Assignment cell for the designated actions grid (#4896). IA managers and
+// directors assign or reassign directly from the table; everyone else sees
+// the read-only initials chip. Mirrors CIAssignedAnalystCell.
+export const DAAssignedAnalystCell = ({ data }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
+  const theme = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
+  const { hasRoles } = useCurrentUser()
+  const canAssign =
+    hasRoles?.(roles.government, roles.ia_manager) ||
+    hasRoles?.(roles.government, roles.director)
+
+  const { data: analysts = [] } = useInitiativeAgreementAnalysts({
+    enabled: canAssign
+  })
+  const { mutate: assignAnalyst, isPending } = useAssignDesignatedActionAnalyst(
+    data?.designatedActionId
+  )
+
+  const currentAssignee = data?.assignedAnalyst
+  const chipStyles = {
+    backgroundColor: theme.palette.grey[600],
+    color: theme.palette.common.white,
+    fontWeight: 700,
+    height: 28,
+    width: 28,
+    borderRadius: '50%',
+    '& .MuiChip-label': { padding: 0 }
+  }
+
+  const initialsOf = (analyst) =>
+    analyst?.initials ||
+    `${analyst?.firstName?.[0] || ''}${analyst?.lastName?.[0] || ''}`.toUpperCase()
+
+  const renderChip = (analyst) => {
+    if (!analyst) return <span>-</span>
+    return (
+      <Tooltip
+        title={analyst.fullName || `${analyst.firstName} ${analyst.lastName}`}
+      >
+        <Chip label={initialsOf(analyst)} size="small" sx={chipStyles} />
+      </Tooltip>
+    )
+  }
+
+  if (!canAssign) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+        data-test="da-analyst-readonly"
+      >
+        {renderChip(currentAssignee)}
+      </Box>
+    )
+  }
+
+  if (isPending) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+      >
+        <CircularProgress size={16} />
+      </Box>
+    )
+  }
+
+  return (
+    <FormControl
+      size="small"
+      variant="standard"
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'center'
+      }}
+    >
+      <Select
+        data-test="da-analyst-select"
+        value={currentAssignee?.userProfileId ?? ''}
+        open={isOpen}
+        onOpen={() => setIsOpen(true)}
+        onClose={() => setIsOpen(false)}
+        onChange={(event) =>
+          assignAnalyst(event.target.value === '' ? null : event.target.value)
+        }
+        displayEmpty
+        disableUnderline
+        renderValue={() => renderChip(currentAssignee)}
+        sx={{ '& .MuiSelect-select': { display: 'flex', py: 0 } }}
+      >
+        <MenuItem value="">
+          <em>{t('initiativeAgreement:actions.unassigned')}</em>
+        </MenuItem>
+        {analysts.map((analyst) => (
+          <MenuItem key={analyst.userProfileId} value={analyst.userProfileId}>
+            {analyst.fullName}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}
+
+export default DAAssignedAnalystCell

--- a/frontend/src/views/InitiativeAgreements/components/DesignatedActionsGrid.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DesignatedActionsGrid.jsx
@@ -1,0 +1,72 @@
+import { useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import BCBox from '@/components/BCBox'
+import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer'
+import { LinkRenderer } from '@/utils/grid/cellRenderers.jsx'
+import { useDesignatedActions } from '@/hooks/useInitiativeAgreements'
+import { designatedActionColDefs } from '../_schema'
+
+const initialPaginationOptions = {
+  page: 1,
+  size: 10,
+  sortOrders: [],
+  filters: []
+}
+
+// AG Grid of an agreement's designated actions (#4896). Rows navigate to
+// the designated action detail route (#4840 builds the page itself).
+export const DesignatedActionsGrid = ({ initiativeAgreementId }) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const gridRef = useRef(null)
+  const [paginationOptions, setPaginationOptions] = useState(
+    initialPaginationOptions
+  )
+
+  const queryData = useDesignatedActions(
+    initiativeAgreementId,
+    paginationOptions
+  )
+
+  const columnDefs = useMemo(
+    () => designatedActionColDefs(t, initiativeAgreementId),
+    [t, initiativeAgreementId]
+  )
+
+  const getRowId = (params) => params.data.designatedActionId.toString()
+
+  const defaultColDef = useMemo(
+    () => ({
+      cellRenderer: LinkRenderer,
+      cellRendererParams: {
+        // Relative to the agreement detail route.
+        url: (data) => `designated-actions/${data.data.designatedActionId}`
+      }
+    }),
+    []
+  )
+
+  return (
+    <BCBox component="div" sx={{ height: '100%', width: '100%' }}>
+      <BCGridViewer
+        gridRef={gridRef}
+        gridKey="designated-actions-grid"
+        columnDefs={columnDefs}
+        getRowId={getRowId}
+        overlayNoRowsTemplate={t('initiativeAgreement:actions.noActionsFound')}
+        defaultColDef={defaultColDef}
+        queryData={queryData}
+        dataKey="designatedActions"
+        paginationOptions={paginationOptions}
+        onPaginationChange={(newPagination) =>
+          setPaginationOptions((prev) => ({
+            ...prev,
+            ...newPagination
+          }))
+        }
+      />
+    </BCBox>
+  )
+}
+
+export default DesignatedActionsGrid

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DAAssignedAnalystCell.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DAAssignedAnalystCell.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DAAssignedAnalystCell } from '../DAAssignedAnalystCell'
+import { roles } from '@/constants/roles'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+let mockRoleNames = [roles.government, roles.ia_manager]
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    hasRoles: (...names) => names.every((n) => mockRoleNames.includes(n))
+  })
+}))
+
+const mockMutate = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useInitiativeAgreementAnalysts: () => ({
+    data: [
+      {
+        userProfileId: 7,
+        firstName: 'Erin',
+        lastName: 'Fong',
+        initials: 'EF',
+        fullName: 'Erin Fong'
+      }
+    ]
+  }),
+  useAssignDesignatedActionAnalyst: () => ({
+    mutate: mockMutate,
+    isPending: false
+  })
+}))
+
+const row = {
+  designatedActionId: 9,
+  assignedAnalyst: null
+}
+
+describe('DAAssignedAnalystCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRoleNames = [roles.government, roles.ia_manager]
+  })
+
+  it('lets an IA manager assign an analyst from the cell', () => {
+    render(<DAAssignedAnalystCell data={row} />, { wrapper })
+
+    const select = screen.getByTestId('da-analyst-select')
+    fireEvent.mouseDown(select.querySelector('[role="combobox"]') || select)
+    fireEvent.click(screen.getByText('Erin Fong'))
+
+    expect(mockMutate).toHaveBeenCalledWith(7)
+  })
+
+  it('shows a read-only chip to an IA analyst', () => {
+    mockRoleNames = [roles.government, roles.ia_analyst]
+    render(
+      <DAAssignedAnalystCell
+        data={{
+          ...row,
+          assignedAnalyst: { firstName: 'Erin', lastName: 'Fong' }
+        }}
+      />,
+      { wrapper }
+    )
+
+    expect(screen.getByTestId('da-analyst-readonly')).toBeInTheDocument()
+    expect(screen.queryByTestId('da-analyst-select')).not.toBeInTheDocument()
+    expect(screen.getByText('EF')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionsGrid.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionsGrid.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DesignatedActionsGrid } from '../DesignatedActionsGrid'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+const mockActions = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useDesignatedActions: (...args) => mockActions(...args),
+  useInitiativeAgreementAnalysts: () => ({ data: [] }),
+  useAssignDesignatedActionAnalyst: () => ({ mutate: vi.fn() })
+}))
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ hasRoles: () => false })
+}))
+
+// The wrapped BCGridViewer needs a heavy AG Grid environment; assert on the
+// props contract instead.
+const gridProps = vi.fn()
+vi.mock('@/components/BCDataGrid/BCGridViewer', () => ({
+  BCGridViewer: (props) => {
+    gridProps(props)
+    return <div data-test="bc-grid-viewer" />
+  }
+}))
+
+describe('DesignatedActionsGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockActions.mockReturnValue({
+      data: {
+        designatedActions: [
+          {
+            designatedActionId: 9,
+            actionNumber: 1,
+            name: 'Commission station',
+            creditAllocation: 1850
+          }
+        ],
+        pagination: { total: 1, page: 1, size: 10, totalPages: 1 }
+      },
+      isLoading: false,
+      isError: false
+    })
+  })
+
+  it('feeds the grid the paginated designated actions', () => {
+    render(<DesignatedActionsGrid initiativeAgreementId="5" />, { wrapper })
+
+    expect(screen.getByTestId('bc-grid-viewer')).toBeInTheDocument()
+    expect(mockActions).toHaveBeenCalledWith(
+      '5',
+      expect.objectContaining({ page: 1, size: 10 })
+    )
+    const props = gridProps.mock.calls[0][0]
+    expect(props.dataKey).toBe('designatedActions')
+    expect(props.gridKey).toBe('designated-actions-grid')
+  })
+
+  it('builds the wireframe ID and credits formats into the column defs', () => {
+    render(<DesignatedActionsGrid initiativeAgreementId="5" />, { wrapper })
+
+    const props = gridProps.mock.calls[0][0]
+    const cols = props.columnDefs
+    const idCol = cols.find((c) => c.colId === 'actionNumber')
+    expect(idCol.valueGetter({ data: { actionNumber: 2 } })).toBe('DA2-IA5')
+
+    const creditsCol = cols.find((c) => c.field === 'creditAllocation')
+    expect(creditsCol.valueFormatter({ value: 1850 })).toBe(
+      'initiativeAgreement:actions.upToCredits'
+    )
+
+    const rowUrl = props.defaultColDef.cellRendererParams.url({
+      data: { designatedActionId: 9 }
+    })
+    expect(rowUrl).toBe('designated-actions/9')
+  })
+})

--- a/frontend/src/views/InitiativeAgreements/index.js
+++ b/frontend/src/views/InitiativeAgreements/index.js
@@ -1,2 +1,3 @@
 export { InitiativeAgreements } from './InitiativeAgreements'
 export { InitiativeAgreementDetail } from './InitiativeAgreementDetail'
+export { DesignatedActionDetail } from './DesignatedActionDetail'


### PR DESCRIPTION
## Summary

The designated actions grid for the IDIR Initiative Agreement page (#4896). Targets the module's epic branch.

The detail page's placeholder becomes a real AG Grid with the wireframe's columns — **ID** (`DA1-IA5`), **DA name**, **Assigned analyst**, **Last comment**, **Compliance units to be issued** ("up to 1,850") and **Last updated** — with server-side filtering, sorting and paging, and row navigation to a designated action detail route (the page itself is a skeleton; #4840 builds it).

### Analyst assignment and the change log

IA managers and directors assign, reassign or unassign the analyst directly from the cell, per the AC; analysts and proponents see a read-only initials chip, and the endpoint refuses them (tested for both). Assignment **mutates the current row in place** and records `ANALYST_ASSIGNED` / `REASSIGNED` / `UNASSIGNED` in `designated_action_history` with a from/to snapshot and the acting user. It deliberately never appends a version row — versions are reserved for business-area change orders, and every child of an action (evidence, comments, documents) references a concrete `designated_action_id`. A test pins that the version stays put across the full assign→reassign→unassign cycle.

### Notes for a reviewer

- **Amended actions show once.** The grid's base set is the highest version per `group_uuid`, mirroring the profile endpoint and the charging-site precedent.
- **The last-comment column is wired but empty for now.** DA comments begin posting with #4900; the ranking query matches on either the concrete action id or the denormalized group uuid, so comments survive change-order version rows. A test seeds the association directly to prove the column.
- **Field names in filter models arrive snake_cased** (`FilterModel` converts them), so the column map keys are snake_case; the analyst floating filter's id value can arrive as a string and the query coerces it.
- **Only active IA analysts are assignable** — the target is validated against the IA Analyst role, not just any user id (400 otherwise, tested).

### Testing

12 new backend tests (grid contract, version collapsing, name and analyst filters, last-comment ranking, 403/404 paths, the assignment change-log cycle, target validation, analyst options + gating); 10 new frontend tests across the grid wrapper, the assignment cell (manager select vs read-only chip) and the detail page integration — 196 pass across the touched suites. Type-check unchanged.

Refs #4896
