### PR TITLE
Feat: Designated action comments component - 4900

### DIFF
--- a/backend/lcfs/tests/initiative_agreement/test_designated_action_comments.py
+++ b/backend/lcfs/tests/initiative_agreement/test_designated_action_comments.py
@@ -1,0 +1,190 @@
+"""Comments on designated actions (#4900).
+
+The shared internal-comment machinery gains the designatedAction entity
+type; these tests pin the thread behaviour the DA detail page and the DA
+grid's last-comment column depend on.
+"""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from lcfs.db.base import ActionTypeEnum
+from lcfs.db.models.comment.DesignatedActionInternalComment import (
+    DesignatedActionInternalComment,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+    _seed_action,
+)
+from lcfs.tests.initiative_agreement.test_initiative_agreement_api import (
+    IDIR_IA_ANALYST,
+    PAGINATION_BODY,
+    _seed_agreement,
+    _two_org_ids,
+)
+from lcfs.tests.initiative_agreement.test_initiative_agreement_comments import (
+    _ensure_author_profile,
+)
+
+
+async def _post_da_comment(client, fastapi_app, designated_action_id, text, **extra):
+    url = fastapi_app.url_path_for("create_comment")
+    payload = {
+        "entityType": "designatedAction",
+        "entityId": designated_action_id,
+        "comment": text,
+        **extra,
+    }
+    return await client.post(url, json=payload)
+
+
+@pytest.mark.anyio
+async def test_action_comments_are_internal_by_default_and_stamp_the_group(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DAC1")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await _post_da_comment(
+        client, fastapi_app, action.designated_action_id, "internal action note"
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["visibility"] == "Internal"
+
+    association = (
+        await dbsession.execute(
+            select(DesignatedActionInternalComment).where(
+                DesignatedActionInternalComment.internal_comment_id
+                == data["internalCommentId"]
+            )
+        )
+    ).scalar_one()
+    assert association.designated_action_id == action.designated_action_id
+    assert association.designated_action_group_uuid == action.group_uuid
+
+    comment = (
+        await dbsession.execute(
+            select(InternalComment).where(
+                InternalComment.internal_comment_id == data["internalCommentId"]
+            )
+        )
+    ).scalar_one()
+    # Denormalized Comment Log metadata resolves through the agreement.
+    assert comment.organization_id == org_id
+
+
+@pytest.mark.anyio
+async def test_the_thread_spans_change_order_versions(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """A comment made on the original version stays on the thread after a
+    change order appends a new version row."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DAC2")
+    original = await _seed_action(dbsession, agreement, 1, "Original scope")
+    amended = await _seed_action(
+        dbsession,
+        agreement,
+        1,
+        "Amended scope",
+        group_uuid=original.group_uuid,
+        version=1,
+        action_type=ActionTypeEnum.UPDATE,
+    )
+    await _ensure_author_profile(dbsession)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    posted = await _post_da_comment(
+        client, fastapi_app, original.designated_action_id, "before the change order"
+    )
+    assert posted.status_code == status.HTTP_201_CREATED
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type="designatedAction",
+        entity_id=amended.designated_action_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    comments = [c["comment"] for c in response.json()]
+    assert comments == ["before the change order"]
+
+
+@pytest.mark.anyio
+async def test_a_new_comment_lights_up_the_grids_last_comment_column(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """End to end with #4896: posting through the API surfaces in the
+    designated actions grid."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DAC3")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    await _ensure_author_profile(dbsession)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    posted = await _post_da_comment(
+        client,
+        fastapi_app,
+        action.designated_action_id,
+        "<p>rich <em>note</em></p>",
+    )
+    assert posted.status_code == status.HTTP_201_CREATED
+
+    grid_url = fastapi_app.url_path_for(
+        "get_designated_actions",
+        initiative_agreement_id=agreement.initiative_agreement_id,
+    )
+    response = await client.post(grid_url, json=PAGINATION_BODY)
+
+    row = response.json()["designatedActions"][0]
+    assert row["lastComment"]["comment"] == "rich note"
+    assert row["lastComment"]["fullName"] == "Mock User"
+
+
+@pytest.mark.anyio
+async def test_proponents_cannot_read_action_threads(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Internal comments must never be visible to BCeID users; for now the
+    whole thread is IDIR-only."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DAC4")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type="designatedAction",
+        entity_id=action.designated_action_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_proponents_cannot_post_to_action_threads(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DAC5")
+    action = await _seed_action(dbsession, agreement, 1, "Commission station")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    response = await _post_da_comment(
+        client,
+        fastapi_app,
+        action.designated_action_id,
+        "should not land",
+        visibility="Public",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/web/api/internal_comment/repo.py
+++ b/backend/lcfs/web/api/internal_comment/repo.py
@@ -36,6 +36,10 @@ from lcfs.db.models.comment.TransferInternalComment import TransferInternalComme
 from lcfs.db.models.comment.InitiativeAgreementInternalComment import (
     InitiativeAgreementInternalComment,
 )
+from lcfs.db.models.comment.DesignatedActionInternalComment import (
+    DesignatedActionInternalComment,
+)
+from lcfs.db.models.initiative_agreement.DesignatedAction import DesignatedAction
 from lcfs.db.models.comment.AdminAdjustmentInternalComment import (
     AdminAdjustmentInternalComment,
 )
@@ -118,6 +122,21 @@ class InternalCommentRepository:
                 compliance_report_id=entity_id,
                 internal_comment_id=internal_comment.internal_comment_id,
             )
+        elif entity_type == EntityTypeEnum.DESIGNATED_ACTION:
+            # Stamp the action's group uuid so the comment stays with the
+            # action across change-order version rows.
+            group_uuid = (
+                await self.db.execute(
+                    select(DesignatedAction.group_uuid).where(
+                        DesignatedAction.designated_action_id == entity_id
+                    )
+                )
+            ).scalar_one_or_none()
+            association = DesignatedActionInternalComment(
+                designated_action_id=entity_id,
+                internal_comment_id=internal_comment.internal_comment_id,
+                designated_action_group_uuid=group_uuid,
+            )
         elif entity_type == EntityTypeEnum.CI_APPLICATION:
             association = CIApplicationInternalComment(
                 ci_application_id=entity_id,
@@ -191,6 +210,10 @@ class InternalCommentRepository:
                 CIApplicationInternalComment,
                 CIApplicationInternalComment.ci_application_id,
             ),
+            EntityTypeEnum.DESIGNATED_ACTION: (
+                DesignatedActionInternalComment,
+                DesignatedActionInternalComment.designated_action_id,
+            ),
             EntityTypeEnum.ORGANIZATION: (
                 OrganizationInternalComment,
                 OrganizationInternalComment.organization_id,
@@ -200,6 +223,25 @@ class InternalCommentRepository:
         # Get the specific model and where condition for the given entity_type
         entity_model, where_condition = entity_mapping[entity_type]
         entity_ids = [entity_id]
+        if entity_type == EntityTypeEnum.DESIGNATED_ACTION:
+            # A change order appends a version row; the thread spans every
+            # version of the action, so expand to the whole group.
+            group_ids = (
+                (
+                    await self.db.execute(
+                        select(DesignatedAction.designated_action_id).where(
+                            DesignatedAction.group_uuid
+                            == select(DesignatedAction.group_uuid)
+                            .where(DesignatedAction.designated_action_id == entity_id)
+                            .scalar_subquery()
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if group_ids:
+                entity_ids = list(group_ids)
         if entity_type == EntityTypeEnum.COMPLIANCE_REPORT:
             # Get all related compliance report IDs in the same chain
             entity_ids = await self.report_repo.get_related_compliance_report_ids(
@@ -541,6 +583,16 @@ class InternalCommentRepository:
             stmt = select(InitiativeAgreement.to_organization_id).where(
                 InitiativeAgreement.initiative_agreement_id == entity_id
             )
+        elif entity_type == EntityTypeEnum.DESIGNATED_ACTION:
+            stmt = (
+                select(InitiativeAgreement.to_organization_id)
+                .join(
+                    DesignatedAction,
+                    DesignatedAction.initiative_agreement_id
+                    == InitiativeAgreement.initiative_agreement_id,
+                )
+                .where(DesignatedAction.designated_action_id == entity_id)
+            )
         elif entity_type == EntityTypeEnum.ADMIN_ADJUSTMENT:
             stmt = select(AdminAdjustment.to_organization_id).where(
                 AdminAdjustment.admin_adjustment_id == entity_id
@@ -793,7 +845,7 @@ class InternalCommentRepository:
 
             ilike_term = f"%{search_term}%"
             normalized_search = _SEARCH_NORMALIZE_RE.sub("", search_term).lower()
-            
+
             stripped_comment = func.regexp_replace(
                 func.coalesce(InternalComment.comment, ""),
                 r"<[^>]*>",

--- a/backend/lcfs/web/api/internal_comment/schema.py
+++ b/backend/lcfs/web/api/internal_comment/schema.py
@@ -18,6 +18,7 @@ class BaseConfig:
 class EntityTypeEnum(str, Enum):
     TRANSFER = "Transfer"
     INITIATIVE_AGREEMENT = "initiativeAgreement"
+    DESIGNATED_ACTION = "designatedAction"
     ADMIN_ADJUSTMENT = "administrativeAdjustment"
     ASSESSMENT = "Assessment"
     COMPLIANCE_REPORT = "complianceReport"

--- a/backend/lcfs/web/api/internal_comment/services.py
+++ b/backend/lcfs/web/api/internal_comment/services.py
@@ -40,6 +40,7 @@ DEFAULT_CATEGORY_BY_ENTITY: dict[EntityTypeEnum, str] = {
     EntityTypeEnum.COMPLIANCE_REPORT: "Compliance notes",
     EntityTypeEnum.TRANSFER: "Transfer notes",
     EntityTypeEnum.INITIATIVE_AGREEMENT: "IA notes",
+    EntityTypeEnum.DESIGNATED_ACTION: "IA notes",
     EntityTypeEnum.ADMIN_ADJUSTMENT: "Penalty notes",
     EntityTypeEnum.CI_APPLICATION: "CI application notes",
     EntityTypeEnum.ORGANIZATION: "Company Overview",
@@ -235,17 +236,16 @@ class InternalCommentService:
             comment, data.entity_type, data.entity_id
         )
 
-        if (
-            not is_government_user
-            and data.entity_type == EntityTypeEnum.CI_APPLICATION
-        ):
+        if not is_government_user and data.entity_type == EntityTypeEnum.CI_APPLICATION:
             await self._send_ci_comment_notification(
                 data.entity_id,
                 "applicant_activity",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
             )
         elif (
             is_government_user
@@ -256,9 +256,11 @@ class InternalCommentService:
                 data.entity_id,
                 "government_action",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
                 related_organization_id=created_comment.organization_id,
             )
 

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -4,6 +4,7 @@ import { Divider } from '@mui/material'
 
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
+import Comments from '@/components/Comments'
 import { roles } from '@/constants/roles'
 import { ROUTES } from '@/routes/routes'
 import withRole from '@/utils/withRole'
@@ -32,6 +33,16 @@ const DesignatedActionDetailBase = () => {
       <BCTypography variant="body1" color="text.secondary">
         {t('initiativeAgreement:actionDetail.placeholder')}
       </BCTypography>
+
+      {/* Standard dual-mode thread (#4900); the page is IDIR-only until
+          the BCeID story, matching the API. */}
+      <BCBox mt={3} data-test="designated-action-comments-section">
+        <Comments
+          entityType="designatedAction"
+          entityId={Number(designatedActionId)}
+          commentMode="dual"
+        />
+      </BCBox>
     </BCBox>
   )
 }

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { roles } from '@/constants/roles'
+import { wrapper } from '@/tests/utils/wrapper'
+import { DesignatedActionDetail } from '../DesignatedActionDetail'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+vi.mock('@react-keycloak/web', () => ({
+  useKeycloak: () => ({
+    keycloak: { token: 'mock-token', authenticated: true, initialized: true }
+  })
+}))
+
+let mockRoles = [{ name: roles.ia_analyst }]
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    data: { roles: mockRoles },
+    hasRoles: (...names) =>
+      names.some((n) => mockRoles.some((r) => r.name === n)),
+    hasAnyRole: (...names) =>
+      names.some((n) => mockRoles.some((r) => r.name === n))
+  })
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useParams: () => ({ initiativeAgreementId: '5', designatedActionId: '9' })
+  }
+})
+
+const commentsProps = vi.fn()
+vi.mock('@/components/Comments', () => ({
+  default: (props) => {
+    commentsProps(props)
+    return <div data-test="comments-component" />
+  }
+}))
+
+describe('DesignatedActionDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRoles = [{ name: roles.ia_analyst }]
+  })
+
+  it('renders the wireframe identifier in the title', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(
+      screen.getByTestId('designated-action-detail-title')
+    ).toHaveTextContent('DA9-IA5')
+  })
+
+  it('wires the dual-mode comment thread to the designated action', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+
+    expect(screen.getByTestId('comments-component')).toBeInTheDocument()
+    expect(commentsProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'designatedAction',
+        entityId: 9,
+        commentMode: 'dual'
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Comment threads for designated actions (#4900). Targets the module's epic branch.

The designated action page (skeleton from #4896; #4840 builds the rest) carries the standard dual-mode commenting thread: **Internal by default**, the existing warning modal before a Public comment, and the Internal / Public / All history tabs.

### What the backend gains

The shared internal-comment machinery learns the `designatedAction` entity type:

- **Creation stamps the action's `group_uuid`** on the association row — the schema put that column there so comments survive change orders, and this is the first writer to honour it.
- **Reads span the whole version group.** Fetching the thread for the current version returns comments made on any earlier version of the same action, mirroring how compliance-report chains expand.
- **Comment Log metadata resolves through the agreement** — the comment lands under the organization and the existing "IA notes" category, so the org-level Comment Log picks these up with no further work.

### Visibility

Internal comments must never reach BCeID users, and the strongest form of that holds for now: proponents are refused the thread entirely, read and write (both tested). Their view of Public comments arrives with the BCeID story, same stance as the agreement-level thread in #4941.

### Testing

5 new backend tests: default-Internal creation with group stamping and metadata denormalization, the version-spanning thread, an end-to-end proving a posted comment lights up the #4896 grid's last-comment column, and both proponent refusals. The 80 existing internal-comment tests and the 78 in the IA module all pass. 2 new frontend tests on the page wiring; dual-mode behaviours are covered by the existing `CommentList` suite. Type-check unchanged.

Refs #4900
