### PR TITLE
Feat: Designated action information display - 4840

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-08-24-12-00_b8c3d5e7f9a1.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-24-12-00_b8c3d5e7f9a1.py
@@ -1,0 +1,56 @@
+"""Add designated action document association.
+
+Documents attach to designated actions (#4840): the wireframe's evidence
+files and per-action award letters live on the action, not the agreement.
+The table mirrors initiative_agreement_document_association; the document
+folder work (#4925) builds on it.
+
+Revision ID: b8c3d5e7f9a1
+Revises: d7e2f4a9b1c6
+Create Date: 2026-08-24 12:00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b8c3d5e7f9a1"
+down_revision = "d7e2f4a9b1c6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "designated_action_document_association",
+        sa.Column("designated_action_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["designated_action_id"],
+            ["designated_action.designated_action_id"],
+            name=op.f(
+                "fk_designated_action_document_association_designated_action_id_designated_action"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["document.document_id"],
+            name=op.f("fk_designated_action_document_association_document_id_document"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "designated_action_id",
+            "document_id",
+            name=op.f("pk_designated_action_document_association"),
+        ),
+        comment=(
+            "Associates documents with designated actions; documents attach "
+            "to a concrete action row and follow the group across change "
+            "orders in queries."
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("designated_action_document_association")

--- a/backend/lcfs/db/models/document/Document.py
+++ b/backend/lcfs/db/models/document/Document.py
@@ -11,6 +11,9 @@ from lcfs.db.models.compliance.ComplianceReport import (
 from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
     initiative_agreement_document_association,
 )
+from lcfs.db.models.initiative_agreement.DesignatedAction import (
+    designated_action_document_association,
+)
 from lcfs.db.models.compliance.ChargingSite import (
     charging_site_document_association,
 )
@@ -53,6 +56,11 @@ class Document(BaseModel, Auditable):
         back_populates="documents",
     )
 
+    designated_actions = relationship(
+        "DesignatedAction",
+        secondary=designated_action_document_association,
+        back_populates="documents",
+    )
     admin_adjustments = relationship(
         "AdminAdjustment",
         secondary=admin_adjustment_document_association,

--- a/backend/lcfs/db/models/initiative_agreement/DesignatedAction.py
+++ b/backend/lcfs/db/models/initiative_agreement/DesignatedAction.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Table,
     Text,
     UniqueConstraint,
     text,
@@ -13,6 +14,25 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from lcfs.db.base import Auditable, BaseModel, Versioning
+
+# Documents attach to a concrete action row; change-order-aware reads
+# resolve across the group_uuid group like every other child (#4840).
+designated_action_document_association = Table(
+    "designated_action_document_association",
+    BaseModel.metadata,
+    Column(
+        "designated_action_id",
+        Integer,
+        ForeignKey("designated_action.designated_action_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "document_id",
+        Integer,
+        ForeignKey("document.document_id"),
+        primary_key=True,
+    ),
+)
 
 
 class DesignatedAction(BaseModel, Auditable, Versioning):
@@ -154,6 +174,11 @@ class DesignatedAction(BaseModel, Auditable, Versioning):
     )
     evidence_submissions = relationship(
         "EvidenceSubmission", back_populates="designated_action"
+    )
+    documents = relationship(
+        "Document",
+        secondary=designated_action_document_association,
+        back_populates="designated_actions",
     )
     designated_action_internal_comments = relationship(
         "DesignatedActionInternalComment", back_populates="designated_action"

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -12,6 +12,10 @@ from lcfs.db.models.compliance.ComplianceReportStatus import ComplianceReportSta
 from lcfs.db.models.initiative_agreement.InitiativeAgreement import (
     initiative_agreement_document_association,
 )
+from lcfs.db.models.initiative_agreement.DesignatedAction import (
+    DesignatedAction,
+    designated_action_document_association,
+)
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.admin_adjustment.services import AdminAdjustmentServices
 from lcfs.web.api.compliance_report.repo import ComplianceReportRepository
@@ -65,6 +69,10 @@ DOCUMENT_PARENT_ASSOCIATIONS = {
     "initiativeAgreement": (
         initiative_agreement_document_association,
         "initiative_agreement_id",
+    ),
+    "designatedAction": (
+        designated_action_document_association,
+        "designated_action_id",
     ),
     "charging_site": (
         charging_site_document_association,
@@ -147,6 +155,8 @@ class DocumentService:
             await self._verify_administrative_adjustment_access(parent_id, user)
         elif parent_type == "initiativeAgreement":
             await self._verify_initiative_agreement_access(parent_id, user)
+        elif parent_type == "designatedAction":
+            await self._verify_designated_action_access(parent_id, user)
         elif parent_type == "charging_site":
             await self._verify_charging_site_access(parent_id, user)
         elif parent_type == "internal_comment":
@@ -271,6 +281,19 @@ class DocumentService:
                 document_id=document.document_id,
             )
             await self.db.execute(stmt)
+        elif parent_type == "designatedAction":
+            action = await self.db.get(DesignatedAction, parent_id)
+            if not action:
+                raise Exception("Designated action not found")
+
+            self.db.add(document)
+            await self.db.flush()
+
+            stmt = designated_action_document_association.insert().values(
+                designated_action_id=action.designated_action_id,
+                document_id=document.document_id,
+            )
+            await self.db.execute(stmt)
         elif parent_type == "charging_site":
             charging_site = await self.charging_site_repo.get_charging_site_by_id(
                 parent_id
@@ -375,6 +398,31 @@ class DocumentService:
             status_code=400,
             detail="Only Government Staff can upload files to Initiative Agreements.",
         )
+
+    async def _verify_designated_action_access(self, parent_id, user):
+        action = await self.db.get(DesignatedAction, parent_id)
+        if not action:
+            raise HTTPException(status_code=404, detail="Designated action not found")
+
+        if RoleEnum.GOVERNMENT in user.role_names:
+            return
+        raise HTTPException(
+            status_code=400,
+            detail="Only Government Staff can upload files to designated actions.",
+        )
+
+    async def get_designated_action_agreement_id(self, designated_action_id: int):
+        """Resolve an action's agreement for parent-access checks."""
+        agreement_id = (
+            await self.db.execute(
+                select(DesignatedAction.initiative_agreement_id).where(
+                    DesignatedAction.designated_action_id == designated_action_id
+                )
+            )
+        ).scalar_one_or_none()
+        if agreement_id is None:
+            raise HTTPException(status_code=404, detail="Designated action not found")
+        return agreement_id
 
     async def _verify_charging_site_access(self, parent_id, user):
         charging_site = await self.charging_site_repo.get_charging_site_by_id(parent_id)

--- a/backend/lcfs/tests/initiative_agreement/test_designated_actions_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_designated_actions_api.py
@@ -393,3 +393,107 @@ async def test_analyst_options_are_idir_only(
     forbidden = await client.get(url)
 
     assert forbidden.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_action_profile_carries_the_agreement_and_siblings(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The detail page needs the agreement code for its title, the status
+    display order for the stepper, and sibling ids for prev/next."""
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26PROF1")
+    first = await _seed_action(dbsession, agreement, 1, "Permitting", 1850)
+    second = await _seed_action(dbsession, agreement, 2, "Construction", 27309)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    url = fastapi_app.url_path_for(
+        "get_designated_action_profile",
+        designated_action_id=second.designated_action_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["iaCode"] == "IA-26PROF1"
+    assert data["initiativeAgreementId"] == agreement.initiative_agreement_id
+    assert data["actionNumber"] == 2
+    assert data["creditAllocation"] == 27309
+    assert data["currentStatus"]["status"] == "Not started"
+    assert data["currentStatus"]["displayOrder"] == 10
+    assert data["siblingActionIds"] == [
+        first.designated_action_id,
+        second.designated_action_id,
+    ]
+
+
+@pytest.mark.anyio
+async def test_action_profile_404s_and_refuses_proponents(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    url = fastapi_app.url_path_for(
+        "get_designated_action_profile", designated_action_id=999999
+    )
+    response = await client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_action_profile_is_idir_only(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26PROF2")
+    action = await _seed_action(dbsession, agreement, 1, "Permitting")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    url = fastapi_app.url_path_for(
+        "get_designated_action_profile",
+        designated_action_id=action.designated_action_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_action_documents_list_and_are_org_gated(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Per-action documents flow through the shared machinery; access
+    resolves through the action's agreement (#4840)."""
+    from lcfs.db.models.document import Document
+    from lcfs.db.models.initiative_agreement.DesignatedAction import (
+        designated_action_document_association,
+    )
+
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, "IA-26DOC1")
+    action = await _seed_action(dbsession, agreement, 1, "Permitting")
+    document = Document(
+        file_key="da/award-letter.pdf",
+        file_name="award-letter.pdf",
+        file_size=4096,
+        mime_type="application/pdf",
+    )
+    dbsession.add(document)
+    await dbsession.flush()
+    await dbsession.execute(
+        designated_action_document_association.insert().values(
+            designated_action_id=action.designated_action_id,
+            document_id=document.document_id,
+        )
+    )
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    url = fastapi_app.url_path_for(
+        "get_all_documents",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    files = response.json()
+    assert [f["fileName"] for f in files] == ["award-letter.pdf"]

--- a/backend/lcfs/web/api/document/views.py
+++ b/backend/lcfs/web/api/document/views.py
@@ -75,6 +75,12 @@ async def validate_parent_access(
         # "administrativeAdjustment"; the frontend sends the same. Accept both
         # so the guard cannot be bypassed by choosing the other spelling.
         await aa_validate.validate_organization_access(parent_id)
+    elif parent_type == "designatedAction":
+        # An action's audience is its agreement's audience.
+        agreement_id = await document_service.get_designated_action_agreement_id(
+            parent_id
+        )
+        await ia_validate.validate_organization_access(agreement_id)
     elif parent_type == "charging_site":
         await cs_validate.validate_organization_access(parent_id)
     elif parent_type == "ci_application":

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -124,6 +124,8 @@ class CreateInitiativeAgreementHistorySchema(BaseSchema):
 class DesignatedActionStatusSchema(BaseSchema):
     designated_action_status_id: int
     status: str
+    # Drives the workflow progress stepper on the action detail page.
+    display_order: Optional[int] = None
 
     class Config:
         from_attributes = True
@@ -175,6 +177,14 @@ class DesignatedActionSchema(BaseSchema):
 
     class Config:
         from_attributes = True
+
+
+class DesignatedActionProfileSchema(DesignatedActionSchema):
+    initiative_agreement_id: int
+    ia_code: Optional[str] = None
+    # Current-version sibling ids in action_number order, for the detail
+    # page's previous/next navigation.
+    sibling_action_ids: List[int] = []
 
 
 class DesignatedActionsListSchema(BaseSchema):

--- a/backend/lcfs/web/api/initiative_agreement/services.py
+++ b/backend/lcfs/web/api/initiative_agreement/services.py
@@ -28,6 +28,7 @@ from lcfs.web.api.base import (
 )
 from lcfs.web.api.internal_comment.services import sanitize_comment_text
 from lcfs.web.api.initiative_agreement.schema import (
+    DesignatedActionProfileSchema,
     AnalystAssignmentSchema,
     DesignatedActionSchema,
     DesignatedActionsListSchema,
@@ -250,6 +251,27 @@ class InitiativeAgreementServices:
                 ),
             ),
             designated_actions=rows,
+        )
+
+    @service_handler
+    async def get_designated_action_profile(
+        self, designated_action_id: int
+    ) -> DesignatedActionProfileSchema:
+        """The action detail page's record (#4840)."""
+        action = await self.repo.get_designated_action_by_id(designated_action_id)
+        if not action:
+            raise DataNotFoundException(
+                f"Designated action with id {designated_action_id} not found"
+            )
+        siblings = await self.repo.get_current_designated_actions(
+            action.initiative_agreement_id
+        )
+        base = DesignatedActionSchema.model_validate(action)
+        return DesignatedActionProfileSchema(
+            **base.model_dump(),
+            initiative_agreement_id=action.initiative_agreement_id,
+            ia_code=action.initiative_agreement.ia_code,
+            sibling_action_ids=[s.designated_action_id for s in siblings],
         )
 
     @service_handler

--- a/backend/lcfs/web/api/initiative_agreement/views.py
+++ b/backend/lcfs/web/api/initiative_agreement/views.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Body, Depends, Request, status
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.initiative_agreement.services import InitiativeAgreementServices
 from lcfs.web.api.initiative_agreement.schema import (
+    DesignatedActionProfileSchema,
     AnalystAssignmentSchema,
     DesignatedActionSchema,
     DesignatedActionsListSchema,
@@ -81,6 +82,21 @@ async def get_designated_actions(
     return await service.get_designated_actions_paginated(
         initiative_agreement_id, pagination
     )
+
+
+@router.get(
+    "/designated-actions/{designated_action_id}/profile",
+    response_model=DesignatedActionProfileSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def get_designated_action_profile(
+    request: Request,
+    designated_action_id: int,
+    service: InitiativeAgreementServices = Depends(),
+):
+    """The designated action detail page's record."""
+    return await service.get_designated_action_profile(designated_action_id)
 
 
 @router.put(

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -68,7 +68,29 @@
     "unassigned": "Unassigned"
   },
   "actionDetail": {
-    "title": "Designated action",
-    "placeholder": "Designated action details are under construction."
+    "title": "Designated actions",
+    "cardHeader": "Designated actions",
+    "creditsToBeIssued": "Number of credits to be issued under this designated action:",
+    "upTo": "Up to {{count}}",
+    "recommendedCredits": "Recommended credits to be issued:",
+    "completionDate": "Dates for completion of designated action:",
+    "completedDate": "Completed:",
+    "determination": "Determination:",
+    "documents": "Evidence submissions",
+    "manageDocuments": "Manage documents",
+    "noDocuments": "No documents have been uploaded for this designated action.",
+    "loadFailMsg": "The designated action could not be loaded.",
+    "previousAction": "Previous designated action",
+    "nextAction": "Next designated action",
+    "steps": {
+      "submissionReceived": "Submission received",
+      "underway": "Underway",
+      "approved": "Approved"
+    }
+  },
+  "actionDocuments": {
+    "uploadTitle": "Designated action documents",
+    "documentLabel": "the designated action",
+    "returnButton": "Return to designated action"
   }
 }

--- a/frontend/src/components/Documents/DocumentUploadDialog.jsx
+++ b/frontend/src/components/Documents/DocumentUploadDialog.jsx
@@ -35,6 +35,12 @@ function DocumentUploadDialog({ open, close, parentType, parentID }) {
           documentLabel: t('initiativeAgreement:documents.documentLabel'),
           returnButton: t('initiativeAgreement:documents.returnButton')
         }
+      case 'designatedAction':
+        return {
+          title: t('initiativeAgreement:actionDocuments.uploadTitle'),
+          documentLabel: t('initiativeAgreement:actionDocuments.documentLabel'),
+          returnButton: t('initiativeAgreement:actionDocuments.returnButton')
+        }
       case 'compliance_report':
       default:
         return {

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -80,6 +80,8 @@ export const apiRoutes = {
     '/initiative-agreements/:initiativeAgreementId/designated-actions/list',
   assignDesignatedActionAnalyst:
     '/initiative-agreements/designated-actions/:designatedActionId/assign',
+  getDesignatedActionProfile:
+    '/initiative-agreements/designated-actions/:designatedActionId/profile',
 
   // fuel-type
   getFuelTypeOthers: '/fuel-type/others/list',

--- a/frontend/src/hooks/useInitiativeAgreements.ts
+++ b/frontend/src/hooks/useInitiativeAgreements.ts
@@ -107,6 +107,28 @@ export const useDesignatedActions = (
   })
 }
 
+/** The designated action detail page's record (#4840). */
+export const useDesignatedActionProfile = (
+  designatedActionId: number | string,
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!designatedActionId,
+    queryKey: ['designated-actions', 'detail', String(designatedActionId)],
+    queryFn: async () =>
+      (
+        await client.get(
+          apiRoutes.getDesignatedActionProfile.replace(
+            ':designatedActionId',
+            String(designatedActionId)
+          )
+        )
+      ).data,
+    ...options
+  })
+}
+
 /** Active IA analysts for the assignment dropdown and its filter. */
 export const useInitiativeAgreementAnalysts = (
   options: QueryOptions<unknown> = {}

--- a/frontend/src/layouts/MainLayout/components/Crumb.tsx
+++ b/frontend/src/layouts/MainLayout/components/Crumb.tsx
@@ -187,6 +187,14 @@ const Crumb = () => {
           if (reportPathRegex.test(name)) {
             routeTo = `compliance-reporting/${reportCompliancePeriod}/${complianceReportId}`
           }
+          // "Designated actions" leads back to the agreement page, where
+          // the grid lives — the bare segment path is not a route.
+          if (
+            name === 'designated-actions' &&
+            pathnames[0] === 'initiative-agreements'
+          ) {
+            routeTo = `/${pathnames.slice(0, index).join('/')}`
+          }
           const displayName =
             customCrumb.label ||
             name.charAt(0).toUpperCase() + name.slice(1).replaceAll('-', ' ')
@@ -198,6 +206,16 @@ const Crumb = () => {
 
           // Skip numeric ID crumb for fuel-code detail routes (e.g., /fuel-codes/:id/view)
           if (isNumeric(name) && pathnames[index - 1] === 'fuel-codes') {
+            return null
+          }
+
+          // Skip the numeric agreement ID between the module and the
+          // designated action child route
+          if (
+            isNumeric(name) &&
+            pathnames[index - 1] === 'initiative-agreements' &&
+            pathnames[index + 1] === 'designated-actions'
+          ) {
             return null
           }
 

--- a/frontend/src/layouts/MainLayout/components/__tests__/Crumb.test.tsx
+++ b/frontend/src/layouts/MainLayout/components/__tests__/Crumb.test.tsx
@@ -112,6 +112,27 @@ describe('Crumb', () => {
     useInitiativeAgreementPageStore.getState().setAgreementCrumb(null)
   })
 
+  it('renders the designated action trail without the numeric agreement id', () => {
+    setupRouterMocks({
+      pathname: '/initiative-agreements/5/designated-actions/9',
+      matches: [{ handle: { title: 'Designated action' } }]
+    })
+    useInitiativeAgreementPageStore.getState().setAgreementCrumb('DA1-IA5')
+
+    render(<Crumb />, { wrapper })
+
+    expect(screen.getByText('Initiative agreements')).toBeInTheDocument()
+    const designatedActions = screen.getByText('Designated actions')
+    expect(designatedActions.closest('a')).toHaveAttribute(
+      'href',
+      '/initiative-agreements/5'
+    )
+    expect(screen.queryByText('ID: 5')).not.toBeInTheDocument()
+    expect(screen.getByText('DA1-IA5')).toBeInTheDocument()
+
+    useInitiativeAgreementPageStore.getState().setAgreementCrumb(null)
+  })
+
   it('falls back to the route title when no agreement code is set', () => {
     setupRouterMocks({
       pathname: '/initiative-agreements/5',

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -1,38 +1,307 @@
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
-import { Divider } from '@mui/material'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper
+} from '@mui/material'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 
+import BCAlert from '@/components/BCAlert'
 import BCBox from '@/components/BCBox'
 import BCTypography from '@/components/BCTypography'
+import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
 import Comments from '@/components/Comments'
+import DocumentUploadDialog from '@/components/Documents/DocumentUploadDialog'
+import Loading from '@/components/Loading'
+import { Role } from '@/components/Role'
+import { SupportingDocumentSummary } from '@/views/SupportingDocuments/SupportingDocumentSummary'
 import { roles } from '@/constants/roles'
-import { ROUTES } from '@/routes/routes'
+import { useDocuments } from '@/hooks/useDocuments'
+import { ROUTES, buildPath } from '@/routes/routes'
+import { dateFormatter } from '@/utils/formatters'
 import withRole from '@/utils/withRole'
 
+import { useDesignatedActionProfile } from '@/hooks/useInitiativeAgreements'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 
-// Skeleton for the designated action detail page. The grid on the
-// agreement page navigates here (#4896); the page's content — evidence
-// requirements, submissions and the action workflow — arrives with #4840.
+// The shared document machinery keys on this string for designated actions.
+const PARENT_TYPE = 'designatedAction'
+
+// The wireframe's workflow milestones, keyed by the status lookup's
+// display_order: a status at or past the threshold completes the step.
+const WORKFLOW_STEPS = [
+  {
+    labelKey: 'initiativeAgreement:actionDetail.steps.submissionReceived',
+    threshold: 20
+  },
+  {
+    labelKey: 'initiativeAgreement:actionDetail.steps.underway',
+    threshold: 30
+  },
+  { labelKey: 'initiativeAgreement:actionDetail.steps.approved', threshold: 70 }
+]
+
+const LabelValue = ({ label, value }) => (
+  <BCTypography variant="body4" component="p">
+    <strong>{label}</strong> {value ?? '—'}
+  </BCTypography>
+)
+
 const DesignatedActionDetailBase = () => {
   const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const navigate = useNavigate()
   const { initiativeAgreementId, designatedActionId } = useParams()
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const {
+    data: action,
+    isLoading,
+    isError,
+    error
+  } = useDesignatedActionProfile(designatedActionId)
+
+  const { data: documents, refetch: refetchDocuments } = useDocuments(
+    PARENT_TYPE,
+    designatedActionId
+  )
+
+  // Surface the wireframe's action identifier in the breadcrumb.
+  const setAgreementCrumb = useInitiativeAgreementPageStore(
+    (state) => state.setAgreementCrumb
+  )
+  useEffect(() => {
+    setAgreementCrumb(
+      action
+        ? `DA${action.actionNumber}-IA${action.initiativeAgreementId}`
+        : null
+    )
+    return () => setAgreementCrumb(null)
+  }, [action, setAgreementCrumb])
+
+  if (isLoading) {
+    return <Loading message={t('initiativeAgreement:loadingText')} />
+  }
+
+  if (isError || !action) {
+    return (
+      <BCBox>
+        <InitiativeAgreementTabs />
+        <BCAlert data-test="alert-box" severity="error">
+          {error?.message || t('initiativeAgreement:actionDetail.loadFailMsg')}
+        </BCAlert>
+      </BCBox>
+    )
+  }
+
+  const displayOrder = action.currentStatus?.displayOrder ?? 0
+  const actionLabel = `DA${action.actionNumber}-IA${action.initiativeAgreementId}`
+  const siblings = action.siblingActionIds || []
+  const currentIndex = siblings.indexOf(Number(designatedActionId))
+  const previousId = currentIndex > 0 ? siblings[currentIndex - 1] : null
+  const nextId =
+    currentIndex >= 0 && currentIndex < siblings.length - 1
+      ? siblings[currentIndex + 1]
+      : null
+
+  const goToSibling = (siblingId) =>
+    navigate(
+      buildPath(ROUTES.INITIATIVE_AGREEMENTS.ACTION_VIEW, {
+        initiativeAgreementId,
+        designatedActionId: siblingId
+      })
+    )
 
   return (
     <BCBox>
       <InitiativeAgreementTabs />
+
       <BCTypography
         variant="h5"
         color="primary"
         data-test="designated-action-detail-title"
       >
         {t('initiativeAgreement:actionDetail.title')}
-        {` - DA${designatedActionId}-IA${initiativeAgreementId}`}
+        {action.iaCode ? ` - ${action.iaCode}` : ''}
       </BCTypography>
       <Divider sx={{ mt: 2, mb: 3 }} />
-      <BCTypography variant="body1" color="text.secondary">
-        {t('initiativeAgreement:actionDetail.placeholder')}
-      </BCTypography>
+
+      <Stepper
+        alternativeLabel
+        sx={{ mb: 3, maxWidth: 640 }}
+        data-test="designated-action-stepper"
+      >
+        {WORKFLOW_STEPS.map((step) => (
+          <Step key={step.labelKey} completed={displayOrder >= step.threshold}>
+            <StepLabel>{t(step.labelKey)}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      <BCWidgetCard
+        title={t('initiativeAgreement:actionDetail.cardHeader')}
+        color="nav"
+        data-test="designated-action-card"
+        content={
+          <BCBox p={1}>
+            <BCBox
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+                mb: 2
+              }}
+            >
+              <BCBox sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <BCTypography variant="h6" color="primary">
+                  {action.actionNumber}. {action.name}
+                </BCTypography>
+                {action.currentStatus?.status && (
+                  <BCBox
+                    component="span"
+                    data-test="action-status-chip"
+                    sx={{
+                      px: 1.5,
+                      py: 0.25,
+                      borderRadius: 4,
+                      bgcolor: 'success.light',
+                      color: 'success.contrastText',
+                      fontSize: '0.8rem'
+                    }}
+                  >
+                    {action.currentStatus.status}
+                  </BCBox>
+                )}
+              </BCBox>
+              <BCBox sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <IconButton
+                  size="small"
+                  data-test="previous-action-button"
+                  aria-label={t(
+                    'initiativeAgreement:actionDetail.previousAction'
+                  )}
+                  disabled={!previousId}
+                  onClick={() => goToSibling(previousId)}
+                >
+                  <ChevronLeftIcon />
+                </IconButton>
+                <BCTypography variant="body4">{actionLabel}</BCTypography>
+                <IconButton
+                  size="small"
+                  data-test="next-action-button"
+                  aria-label={t('initiativeAgreement:actionDetail.nextAction')}
+                  disabled={!nextId}
+                  onClick={() => goToSibling(nextId)}
+                >
+                  <ChevronRightIcon />
+                </IconButton>
+              </BCBox>
+            </BCBox>
+
+            <Stack spacing={0.5}>
+              <LabelValue
+                label={t('initiativeAgreement:actionDetail.creditsToBeIssued')}
+                value={t('initiativeAgreement:actionDetail.upTo', {
+                  count: (action.creditAllocation ?? 0).toLocaleString()
+                })}
+              />
+              <LabelValue
+                label={t('initiativeAgreement:actionDetail.recommendedCredits')}
+                value={
+                  action.recommendedCredits != null
+                    ? action.recommendedCredits.toLocaleString()
+                    : null
+                }
+              />
+              <LabelValue
+                label={t('initiativeAgreement:actionDetail.completionDate')}
+                value={
+                  action.specifiedDate
+                    ? dateFormatter({ value: action.specifiedDate })
+                    : null
+                }
+              />
+              {action.completedDate && (
+                <LabelValue
+                  label={t('initiativeAgreement:actionDetail.completedDate')}
+                  value={dateFormatter({ value: action.completedDate })}
+                />
+              )}
+              {action.determination && (
+                <LabelValue
+                  label={t('initiativeAgreement:actionDetail.determination')}
+                  value={action.determination}
+                />
+              )}
+            </Stack>
+
+            <Paper
+              variant="outlined"
+              sx={{ p: 2, mt: 3 }}
+              data-test="designated-action-documents-section"
+            >
+              <BCBox
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}
+              >
+                <BCTypography variant="h6" color="primary">
+                  {t('initiativeAgreement:actionDetail.documents')}
+                </BCTypography>
+                {/* The folder tree arrives with #4925; evidence review
+                    with #4899. Upload stays IDIR-side, like the API. */}
+                <Role
+                  roles={[roles.ia_analyst, roles.ia_manager, roles.director]}
+                >
+                  <BCTypography
+                    component="button"
+                    variant="body4"
+                    color="link"
+                    data-test="upload-documents-button"
+                    onClick={() => setUploadOpen(true)}
+                    sx={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    {t('initiativeAgreement:actionDetail.manageDocuments')}
+                  </BCTypography>
+                </Role>
+              </BCBox>
+              {documents?.length ? (
+                <SupportingDocumentSummary
+                  parentID={designatedActionId}
+                  parentType={PARENT_TYPE}
+                  data={documents}
+                  detailed
+                />
+              ) : (
+                <BCTypography variant="body4" color="text.secondary">
+                  {t('initiativeAgreement:actionDetail.noDocuments')}
+                </BCTypography>
+              )}
+            </Paper>
+          </BCBox>
+        }
+      />
+
+      <DocumentUploadDialog
+        open={uploadOpen}
+        close={() => {
+          setUploadOpen(false)
+          refetchDocuments()
+        }}
+        parentType={PARENT_TYPE}
+        parentID={designatedActionId}
+      />
 
       {/* Standard dual-mode thread (#4900); the page is IDIR-only until
           the BCeID story, matching the API. */}

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { roles } from '@/constants/roles'
 import { wrapper } from '@/tests/utils/wrapper'
 import { DesignatedActionDetail } from '../DesignatedActionDetail'
+import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key) => key })
@@ -26,45 +27,130 @@ vi.mock('@/hooks/useCurrentUser', () => ({
   })
 }))
 
+const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,
+    useNavigate: () => mockNavigate,
     useParams: () => ({ initiativeAgreementId: '5', designatedActionId: '9' })
   }
 })
 
-const commentsProps = vi.fn()
-vi.mock('@/components/Comments', () => ({
-  default: (props) => {
-    commentsProps(props)
-    return <div data-test="comments-component" />
-  }
+const mockProfile = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useDesignatedActionProfile: () => mockProfile()
 }))
+
+const mockDocuments = vi.fn()
+vi.mock('@/hooks/useDocuments', () => ({
+  useDocuments: () => mockDocuments(),
+  useDownloadDocument: () => vi.fn()
+}))
+
+vi.mock('@/components/Documents/DocumentUploadDialog', () => ({
+  default: ({ open }) => (open ? <div data-test="upload-dialog" /> : null)
+}))
+
+vi.mock('@/components/Comments', () => ({
+  default: () => <div data-test="comments-component" />
+}))
+
+const action = {
+  designatedActionId: 9,
+  actionNumber: 1,
+  name: 'Environmental, Regulatory & Permitting',
+  creditAllocation: 1850,
+  recommendedCredits: null,
+  specifiedDate: '2026-07-06',
+  currentStatus: { status: 'Underway', displayOrder: 30 },
+  initiativeAgreementId: 5,
+  iaCode: 'IA-26ORG1',
+  siblingActionIds: [9, 12, 15]
+}
 
 describe('DesignatedActionDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRoles = [{ name: roles.ia_analyst }]
+    mockProfile.mockReturnValue({
+      data: action,
+      isLoading: false,
+      isError: false,
+      error: null
+    })
+    mockDocuments.mockReturnValue({ data: [], refetch: vi.fn() })
   })
 
-  it('renders the wireframe identifier in the title', () => {
+  it('renders the card with name, status, credits and dates', () => {
     render(<DesignatedActionDetail />, { wrapper })
+
     expect(
       screen.getByTestId('designated-action-detail-title')
-    ).toHaveTextContent('DA9-IA5')
+    ).toHaveTextContent('IA-26ORG1')
+    expect(
+      screen.getByText('1. Environmental, Regulatory & Permitting')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('action-status-chip')).toHaveTextContent(
+      'Underway'
+    )
+    expect(
+      screen.getByText('initiativeAgreement:actionDetail.upTo')
+    ).toBeInTheDocument()
+    expect(screen.getByText('DA1-IA5')).toBeInTheDocument()
   })
 
-  it('wires the dual-mode comment thread to the designated action', () => {
+  it('completes stepper milestones up to the current status', () => {
     render(<DesignatedActionDetail />, { wrapper })
 
-    expect(screen.getByTestId('comments-component')).toBeInTheDocument()
-    expect(commentsProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entityType: 'designatedAction',
-        entityId: 9,
-        commentMode: 'dual'
-      })
+    const stepper = screen.getByTestId('designated-action-stepper')
+    const completed = stepper.querySelectorAll('.Mui-completed')
+    // Underway (display order 30) completes the first two milestones.
+    expect(completed.length).toBeGreaterThanOrEqual(2)
+    expect(
+      screen.getByText('initiativeAgreement:actionDetail.steps.approved')
+    ).toBeInTheDocument()
+  })
+
+  it('navigates between sibling actions and disables the edges', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+
+    const previous = screen.getByTestId('previous-action-button')
+    const next = screen.getByTestId('next-action-button')
+    expect(previous).toBeDisabled()
+    expect(next).not.toBeDisabled()
+
+    fireEvent.click(next)
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/initiative-agreements/5/designated-actions/12'
     )
+  })
+
+  it('publishes the action identifier to the breadcrumb store', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(useInitiativeAgreementPageStore.getState().agreementCrumb).toBe(
+      'DA1-IA5'
+    )
+  })
+
+  it('offers document upload to IDIR IA roles only', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('upload-documents-button')).toBeInTheDocument()
+  })
+
+  it('renders the comments thread', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('comments-component')).toBeInTheDocument()
+  })
+
+  it('surfaces a load failure', () => {
+    mockProfile.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: 'boom' }
+    })
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('alert-box')).toHaveTextContent('boom')
   })
 })


### PR DESCRIPTION
## Summary

The designated action detail page (#4840). Targets the module's epic branch.

The skeleton from #4896 becomes the primary record for an action:

- **Workflow progress stepper** — Submission received / Underway / Approved, driven by the status lookup's display order.
- **Action card** — `{n}. {name}` with the status chip, credit allocation as "up to N", recommended credits (display only — editing it is workflow, #4898), completion dates and determination, and **previous/next arrows** navigating the agreement's actions in order.
- **Per-action documents** — the wireframe's evidence files and award letters are per action, not per agreement, so this PR carries the `designated_action_document_association` migration and wires `designatedAction` through the shared document machinery (list, upload, stream, delete). The #4925 folder tree builds on this table.
- **Comments** — the thread from #4944 stays in place.
- **Breadcrumb** — Home › Initiative agreements › Designated actions › DA1-IA5, with the numeric agreement segment dropped and "Designated actions" linking back to the agreement page.

### Notes for a reviewer

**Document access resolves through the action's agreement.** `validate_parent_access` maps a designated action to its agreement and applies the same organization scoping as agreement documents; uploads are government-only, matching the agreement rule. The association migration is a single reversible `create_table` on top of the module's migration; Alembic remains single-head.

**Deliberately absent:** the evidence-of-completion review cards (#4899), the folder tree with rename/drag (#4925), and the Accept / Request information / Recommend workflow actions (#4898, gated on open product decisions). The stepper is display-only until the workflow story gives statuses transitions.

### Testing

4 new backend tests (profile contract including status display order and sibling ordering, 404, proponent 403, and the per-action document list flowing through the shared endpoint with agreement-scoped access) — 83 pass in the module plus the 26 document tests. 8 frontend tests on the page (stepper milestones, sibling navigation with edge disabling, breadcrumb store, upload gating, comments, failure path) plus a breadcrumb trail test — 35 pass in the module's suites. Type-check unchanged.

Refs #4840
