### PR TITLE
Feat: Document folder layer for designated actions - 4925

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-08-24-15-00_c9d4e6f8a0b2.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-24-15-00_c9d4e6f8a0b2.py
@@ -1,0 +1,110 @@
+"""Add document folder tables for the Initiative Agreements module.
+
+Folders are a layer beside the document system (#4925): the document table
+and every *_document_association table are untouched, placement lives in a
+side table, and a document with no placement row sits at the root. Dropping
+these two tables removes the feature completely.
+
+Revision ID: c9d4e6f8a0b2
+Revises: b8c3d5e7f9a1
+Create Date: 2026-08-24 15:00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9d4e6f8a0b2"
+down_revision = "b8c3d5e7f9a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_folder",
+        sa.Column("folder_id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("parent_type", sa.String(length=50), nullable=False),
+        sa.Column("parent_id", sa.Integer(), nullable=False),
+        sa.Column("parent_folder_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "sort_order", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column(
+            "is_system",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("create_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("update_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("create_user", sa.String(), nullable=True),
+        sa.Column("update_user", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["parent_folder_id"],
+            ["document_folder.folder_id"],
+            name=op.f("fk_document_folder_parent_folder_id_document_folder"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("folder_id", name=op.f("pk_document_folder")),
+        comment=(
+            "Folder tree for parent-scoped document organisation; documents "
+            "place into folders via document_folder_item."
+        ),
+    )
+    op.create_index(
+        "ix_document_folder_parent",
+        "document_folder",
+        ["parent_type", "parent_id"],
+    )
+    # Case-insensitive sibling uniqueness. NULL parent_folder_id (the root)
+    # coalesces to 0 because NULLs never collide in a unique index.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_document_folder_sibling_name
+        ON document_folder (
+            parent_type, parent_id, coalesce(parent_folder_id, 0), lower(name)
+        )
+        """
+    )
+
+    op.create_table(
+        "document_folder_item",
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.Column("folder_id", sa.Integer(), nullable=False),
+        sa.Column("create_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("update_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("create_user", sa.String(), nullable=True),
+        sa.Column("update_user", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["document.document_id"],
+            name=op.f("fk_document_folder_item_document_id_document"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["folder_id"],
+            ["document_folder.folder_id"],
+            name=op.f("fk_document_folder_item_folder_id_document_folder"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("document_id", name=op.f("pk_document_folder_item")),
+        comment="Places a document in a document_folder; absence means root.",
+    )
+    op.create_index(
+        "ix_document_folder_item_folder_id",
+        "document_folder_item",
+        ["folder_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_document_folder_item_folder_id", table_name="document_folder_item"
+    )
+    op.drop_table("document_folder_item")
+    op.execute("DROP INDEX uq_document_folder_sibling_name")
+    op.drop_index("ix_document_folder_parent", table_name="document_folder")
+    op.drop_table("document_folder")

--- a/backend/lcfs/db/models/document/DocumentFolder.py
+++ b/backend/lcfs/db/models/document/DocumentFolder.py
@@ -1,0 +1,101 @@
+from sqlalchemy import (
+    Boolean,
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+    text,
+)
+from sqlalchemy.orm import relationship
+
+from lcfs.db.base import Auditable, BaseModel
+
+
+class DocumentFolder(BaseModel, Auditable):
+    """
+    A folder in a per-parent document tree (#4925).
+
+    Folders are a layer beside the document system, not a change to it: the
+    document table and the six association tables carry no folder state, and
+    dropping this table (with document_folder_item) removes the feature
+    completely. parent_type/parent_id are polymorphic on purpose — extending
+    folders to another surface is one string in FOLDER_ENABLED_PARENT_TYPES,
+    not a migration.
+    """
+
+    __tablename__ = "document_folder"
+    __table_args__ = (
+        Index("ix_document_folder_parent", "parent_type", "parent_id"),
+        # Case-insensitive sibling uniqueness. parent_folder_id is NULL at
+        # the root, and NULLs never collide in a plain unique index, so the
+        # root level coalesces to 0 to get the same guarantee.
+        Index(
+            "uq_document_folder_sibling_name",
+            "parent_type",
+            "parent_id",
+            text("coalesce(parent_folder_id, 0)"),
+            func.lower(text("name")),
+            unique=True,
+        ),
+        {
+            "comment": (
+                "Folder tree for parent-scoped document organisation; "
+                "documents place into folders via document_folder_item."
+            )
+        },
+    )
+
+    folder_id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment="Unique identifier for the folder",
+    )
+    parent_type = Column(
+        String(50),
+        nullable=False,
+        comment="Owning surface, e.g. designatedAction; see FOLDER_ENABLED_PARENT_TYPES",
+    )
+    parent_id = Column(
+        Integer,
+        nullable=False,
+        comment="Id of the owning record within parent_type",
+    )
+    parent_folder_id = Column(
+        Integer,
+        ForeignKey("document_folder.folder_id", ondelete="CASCADE"),
+        nullable=True,
+        comment="Containing folder; NULL at the root of the tree",
+    )
+    name = Column(String(255), nullable=False, comment="Folder display name")
+    sort_order = Column(
+        Integer,
+        nullable=False,
+        server_default=text("0"),
+        comment="Manual ordering among siblings",
+    )
+    is_system = Column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        comment="Seeded structure; system folders reject rename, move and delete",
+    )
+
+    parent_folder = relationship(
+        "DocumentFolder", remote_side=[folder_id], back_populates="child_folders"
+    )
+    child_folders = relationship(
+        "DocumentFolder",
+        back_populates="parent_folder",
+        cascade="all, delete-orphan",
+    )
+    items = relationship(
+        "DocumentFolderItem",
+        back_populates="folder",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self):
+        return f"<DocumentFolder id={self.folder_id} name={self.name!r}>"

--- a/backend/lcfs/db/models/document/DocumentFolderItem.py
+++ b/backend/lcfs/db/models/document/DocumentFolderItem.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, ForeignKey, Index, Integer
+from sqlalchemy.orm import relationship
+
+from lcfs.db.base import Auditable, BaseModel
+
+
+class DocumentFolderItem(BaseModel, Auditable):
+    """
+    Placement of a document inside a folder (#4925).
+
+    A document with no row here sits at the root of its parent's tree, so
+    pre-existing documents need no backfill. The document FK cascades so
+    the existing delete path — which knows nothing about folders — can
+    never leave a placement row behind.
+    """
+
+    __tablename__ = "document_folder_item"
+    __table_args__ = (
+        Index("ix_document_folder_item_folder_id", "folder_id"),
+        {"comment": "Places a document in a document_folder; absence means root."},
+    )
+
+    document_id = Column(
+        Integer,
+        ForeignKey("document.document_id", ondelete="CASCADE"),
+        primary_key=True,
+        comment="The placed document; one folder per document",
+    )
+    folder_id = Column(
+        Integer,
+        ForeignKey("document_folder.folder_id", ondelete="CASCADE"),
+        nullable=False,
+        comment="The containing folder",
+    )
+
+    folder = relationship("DocumentFolder", back_populates="items")

--- a/backend/lcfs/db/models/document/__init__.py
+++ b/backend/lcfs/db/models/document/__init__.py
@@ -1,3 +1,5 @@
 from .Document import Document
+from .DocumentFolder import DocumentFolder
+from .DocumentFolderItem import DocumentFolderItem
 
-__all__ = ["Document"]
+__all__ = ["Document", "DocumentFolder", "DocumentFolderItem"]

--- a/backend/lcfs/tests/document_folder/test_document_folder_view.py
+++ b/backend/lcfs/tests/document_folder/test_document_folder_view.py
@@ -1,0 +1,374 @@
+"""Folder layer for designated action documents (#4925, phase 1).
+
+The isolation guarantee comes first: folders exist only for the surfaces
+in FOLDER_ENABLED_PARENT_TYPES, and every other parent type is refused
+before any work happens. The rest covers CRUD, the tree shape, and the
+six server-side invariants.
+"""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from lcfs.db.models.document import Document, DocumentFolder, DocumentFolderItem
+from lcfs.db.models.initiative_agreement.DesignatedAction import (
+    designated_action_document_association,
+)
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+    _seed_action,
+)
+from lcfs.tests.initiative_agreement.test_initiative_agreement_api import (
+    IDIR_IA_ANALYST,
+    _seed_agreement,
+    _two_org_ids,
+)
+
+
+async def _seed_da(dbsession, code="IA-26FLD1"):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, code)
+    return await _seed_action(dbsession, agreement, 1, "Commission station")
+
+
+async def _seed_document(dbsession, action, name="evidence.pdf"):
+    document = Document(
+        file_key=f"da/{name}",
+        file_name=name,
+        file_size=2048,
+        mime_type="application/pdf",
+    )
+    dbsession.add(document)
+    await dbsession.flush()
+    await dbsession.execute(
+        designated_action_document_association.insert().values(
+            designated_action_id=action.designated_action_id,
+            document_id=document.document_id,
+        )
+    )
+    return document
+
+
+def _tree_url(fastapi_app, action):
+    return fastapi_app.url_path_for(
+        "get_document_folder_tree",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+
+
+async def _create_folder(client, fastapi_app, action, name, parent_folder_id=None):
+    url = fastapi_app.url_path_for(
+        "create_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    payload = {"name": name}
+    if parent_folder_id is not None:
+        payload["parentFolderId"] = parent_folder_id
+    return await client.post(url, json=payload)
+
+
+@pytest.mark.parametrize(
+    "parent_type",
+    [
+        "compliance_report",
+        "ci_application",
+        "charging_site",
+        "administrativeAdjustment",
+        "internal_comment",
+        "initiativeAgreement",
+    ],
+)
+@pytest.mark.anyio
+async def test_folders_are_refused_for_every_other_parent_type(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession, parent_type
+):
+    """The isolation guarantee, as one parametrised assertion."""
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    url = fastapi_app.url_path_for(
+        "get_document_folder_tree", parent_type=parent_type, parent_id=1
+    )
+    response = await client.get(url)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_folder_crud_and_tree_shape(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession)
+    placed = await _seed_document(dbsession, action, "permit.pdf")
+    await _seed_document(dbsession, action, "root-letter.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    created = await _create_folder(client, fastapi_app, action, "Permits & Approvals")
+    assert created.status_code == status.HTTP_201_CREATED
+    folder_id = created.json()["folderId"]
+
+    child = await _create_folder(
+        client, fastapi_app, action, "2026", parent_folder_id=folder_id
+    )
+    assert child.status_code == status.HTTP_201_CREATED
+
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    moved = await client.put(
+        move_url,
+        json={"documentIds": [placed.document_id], "folderId": folder_id},
+    )
+    assert moved.status_code == status.HTTP_204_NO_CONTENT
+
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert [f["name"] for f in tree["folders"]] == ["Permits & Approvals"]
+    root_folder = tree["folders"][0]
+    assert [c["name"] for c in root_folder["children"]] == ["2026"]
+    assert [d["fileName"] for d in root_folder["documents"]] == ["permit.pdf"]
+    assert root_folder["documentCount"] == 1
+    assert [d["fileName"] for d in tree["rootDocuments"]] == ["root-letter.pdf"]
+
+    # Rename via the single update route.
+    update_url = fastapi_app.url_path_for(
+        "update_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=folder_id,
+    )
+    renamed = await client.put(update_url, json={"name": "Signed agreements"})
+    assert renamed.status_code == status.HTTP_200_OK
+    assert renamed.json()["name"] == "Signed agreements"
+
+
+@pytest.mark.anyio
+async def test_sibling_names_are_case_insensitively_unique(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD2")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    first = await _create_folder(client, fastapi_app, action, "Invoices")
+    assert first.status_code == status.HTTP_201_CREATED
+    duplicate = await _create_folder(client, fastapi_app, action, "invoices")
+    assert duplicate.status_code >= 400
+
+
+@pytest.mark.anyio
+async def test_cycles_and_depth_are_rejected(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD3")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    # Five levels are allowed; the sixth is past the cap.
+    parent_id = None
+    folder_ids = []
+    for depth in range(5):
+        created = await _create_folder(
+            client, fastapi_app, action, f"Level {depth}", parent_folder_id=parent_id
+        )
+        assert created.status_code == status.HTTP_201_CREATED
+        parent_id = created.json()["folderId"]
+        folder_ids.append(parent_id)
+
+    too_deep = await _create_folder(
+        client, fastapi_app, action, "Level 5", parent_folder_id=parent_id
+    )
+    assert too_deep.status_code == status.HTTP_400_BAD_REQUEST
+
+    # Moving the top folder under its own descendant is a cycle.
+    update_url = fastapi_app.url_path_for(
+        "update_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=folder_ids[0],
+    )
+    cycle = await client.put(update_url, json={"parentFolderId": folder_ids[-1]})
+    assert cycle.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_system_folders_reject_mutation(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD4")
+    folder = DocumentFolder(
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        name="Evidence",
+        is_system=True,
+    )
+    dbsession.add(folder)
+    await dbsession.flush()
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    update_url = fastapi_app.url_path_for(
+        "update_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=folder.folder_id,
+    )
+    renamed = await client.put(update_url, json={"name": "Renamed"})
+    assert renamed.status_code == status.HTTP_400_BAD_REQUEST
+
+    delete_url = fastapi_app.url_path_for(
+        "delete_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=folder.folder_id,
+    )
+    deleted = await client.delete(delete_url)
+    assert deleted.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_delete_reparents_by_default_and_cascades_on_request(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD5")
+    document = await _seed_document(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    top = (await _create_folder(client, fastapi_app, action, "Top")).json()
+    middle = (
+        await _create_folder(
+            client, fastapi_app, action, "Middle", parent_folder_id=top["folderId"]
+        )
+    ).json()
+    await _create_folder(
+        client, fastapi_app, action, "Leaf", parent_folder_id=middle["folderId"]
+    )
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    await client.put(
+        move_url,
+        json={"documentIds": [document.document_id], "folderId": middle["folderId"]},
+    )
+
+    # Reparent: Middle's contents move up under Top.
+    delete_url = fastapi_app.url_path_for(
+        "delete_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=middle["folderId"],
+    )
+    response = await client.delete(delete_url)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    top_node = tree["folders"][0]
+    assert [c["name"] for c in top_node["children"]] == ["Leaf"]
+    assert [d["fileName"] for d in top_node["documents"]] == ["evidence.pdf"]
+
+    # Cascade: the whole subtree goes; the file falls to the root.
+    delete_top = fastapi_app.url_path_for(
+        "delete_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=top["folderId"],
+    )
+    response = await client.delete(f"{delete_top}?strategy=cascade")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert tree["folders"] == []
+    assert [d["fileName"] for d in tree["rootDocuments"]] == ["evidence.pdf"]
+
+
+@pytest.mark.anyio
+async def test_unassociated_documents_cannot_be_placed(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD6")
+    other_action = await _seed_da(dbsession, "IA-26FLD7")
+    foreign_document = await _seed_document(dbsession, other_action, "foreign.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    folder = (await _create_folder(client, fastapi_app, action, "Mine")).json()
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    response = await client.put(
+        move_url,
+        json={
+            "documentIds": [foreign_document.document_id],
+            "folderId": folder["folderId"],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_foreign_folders_read_as_missing(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLD8")
+    other_action = await _seed_da(dbsession, "IA-26FLD9")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    foreign = (await _create_folder(client, fastapi_app, other_action, "Theirs")).json()
+    update_url = fastapi_app.url_path_for(
+        "update_document_folder",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        folder_id=foreign["folderId"],
+    )
+    response = await client.put(update_url, json={"name": "Hijack"})
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_placement_rows_die_with_their_document(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The existing delete path knows nothing about folders; the FK cascade
+    is what keeps placements from outliving documents."""
+    action = await _seed_da(dbsession, "IA-26FLDA")
+    document = await _seed_document(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    folder = (await _create_folder(client, fastapi_app, action, "Docs")).json()
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    await client.put(
+        move_url,
+        json={"documentIds": [document.document_id], "folderId": folder["folderId"]},
+    )
+
+    await dbsession.delete(document)
+    await dbsession.flush()
+
+    remaining = (
+        (
+            await dbsession.execute(
+                select(DocumentFolderItem).where(
+                    DocumentFolderItem.document_id == document.document_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+@pytest.mark.anyio
+async def test_folder_routes_are_idir_only(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26FLDB")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    response = await client.get(_tree_url(fastapi_app, action))
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/web/api/document_folder/__init__.py
+++ b/backend/lcfs/web/api/document_folder/__init__.py
@@ -1,0 +1,5 @@
+"""Document folder API package."""
+
+from lcfs.web.api.document_folder.views import router
+
+__all__ = ["router"]

--- a/backend/lcfs/web/api/document_folder/constants.py
+++ b/backend/lcfs/web/api/document_folder/constants.py
@@ -1,0 +1,13 @@
+"""The folder feature's hard scope boundary (#4925).
+
+Folders exist only for the surfaces named here. Every folder route
+validates parent_type against this set before doing anything else, so the
+feature cannot leak into an existing document surface through a bug or a
+mistyped constant. Extending folders to another surface is one string
+here plus frontend wiring — no schema change.
+"""
+
+FOLDER_ENABLED_PARENT_TYPES = frozenset({"designatedAction"})
+
+# One level below the cap is still creatable; easier to relax than impose.
+MAX_FOLDER_DEPTH = 5

--- a/backend/lcfs/web/api/document_folder/repo.py
+++ b/backend/lcfs/web/api/document_folder/repo.py
@@ -1,0 +1,139 @@
+from typing import Dict, List, Optional, Sequence, Set
+
+from fastapi import Depends
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.dependencies import get_async_db_session
+from lcfs.db.models.document import Document, DocumentFolder, DocumentFolderItem
+from lcfs.db.models.initiative_agreement.DesignatedAction import (
+    designated_action_document_association,
+)
+from lcfs.web.core.decorators import repo_handler
+
+
+class DocumentFolderRepository:
+    def __init__(self, db: AsyncSession = Depends(get_async_db_session)):
+        self.db = db
+
+    @repo_handler
+    async def get_folders(
+        self, parent_type: str, parent_id: int
+    ) -> List[DocumentFolder]:
+        result = await self.db.execute(
+            select(DocumentFolder)
+            .where(
+                DocumentFolder.parent_type == parent_type,
+                DocumentFolder.parent_id == parent_id,
+            )
+            .order_by(DocumentFolder.sort_order, DocumentFolder.name)
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
+    async def get_folder(self, folder_id: int) -> Optional[DocumentFolder]:
+        return await self.db.get(DocumentFolder, folder_id)
+
+    @repo_handler
+    async def add_folder(self, folder: DocumentFolder) -> DocumentFolder:
+        self.db.add(folder)
+        await self.db.flush()
+        await self.db.refresh(folder)
+        return folder
+
+    @repo_handler
+    async def delete_folders(self, folder_ids: Sequence[int]) -> None:
+        if not folder_ids:
+            return
+        await self.db.execute(
+            delete(DocumentFolder).where(DocumentFolder.folder_id.in_(folder_ids))
+        )
+        await self.db.flush()
+
+    @repo_handler
+    async def get_parent_documents(self, parent_id: int) -> List[Document]:
+        """Documents associated with the designated action."""
+        result = await self.db.execute(
+            select(Document)
+            .join(
+                designated_action_document_association,
+                designated_action_document_association.c.document_id
+                == Document.document_id,
+            )
+            .where(
+                designated_action_document_association.c.designated_action_id
+                == parent_id
+            )
+            .order_by(Document.file_name)
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
+    async def get_associated_document_ids(self, parent_id: int) -> Set[int]:
+        result = await self.db.execute(
+            select(designated_action_document_association.c.document_id).where(
+                designated_action_document_association.c.designated_action_id
+                == parent_id
+            )
+        )
+        return set(result.scalars().all())
+
+    @repo_handler
+    async def get_placements(self, folder_ids: Sequence[int]) -> Dict[int, int]:
+        """document_id -> folder_id for the given folders."""
+        if not folder_ids:
+            return {}
+        result = await self.db.execute(
+            select(DocumentFolderItem.document_id, DocumentFolderItem.folder_id).where(
+                DocumentFolderItem.folder_id.in_(folder_ids)
+            )
+        )
+        return {document_id: folder_id for document_id, folder_id in result.all()}
+
+    @repo_handler
+    async def set_placements(
+        self, document_ids: Sequence[int], folder_id: Optional[int]
+    ) -> None:
+        """Place documents in a folder, or at the root when folder_id is None."""
+        if not document_ids:
+            return
+        await self.db.execute(
+            delete(DocumentFolderItem).where(
+                DocumentFolderItem.document_id.in_(document_ids)
+            )
+        )
+        if folder_id is not None:
+            for document_id in document_ids:
+                self.db.add(
+                    DocumentFolderItem(document_id=document_id, folder_id=folder_id)
+                )
+        await self.db.flush()
+
+    @repo_handler
+    async def reparent_contents(
+        self, folder_id: int, new_parent_folder_id: Optional[int]
+    ) -> None:
+        """Move a folder's direct children and items up to its parent."""
+        result = await self.db.execute(
+            select(DocumentFolder).where(DocumentFolder.parent_folder_id == folder_id)
+        )
+        for child in result.scalars().all():
+            child.parent_folder_id = new_parent_folder_id
+
+        items = (
+            (
+                await self.db.execute(
+                    select(DocumentFolderItem).where(
+                        DocumentFolderItem.folder_id == folder_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for item in items:
+            if new_parent_folder_id is None:
+                await self.db.delete(item)
+            else:
+                item.folder_id = new_parent_folder_id
+        await self.db.flush()

--- a/backend/lcfs/web/api/document_folder/schema.py
+++ b/backend/lcfs/web/api/document_folder/schema.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from typing import List, Optional
+
+from lcfs.web.api.base import BaseSchema
+
+
+class FolderDocumentSchema(BaseSchema):
+    """A document row inside the tree.
+
+    Deliberately its own schema rather than FileResponseSchema: the shared
+    contract stays untouched by the folder layer.
+    """
+
+    document_id: int
+    file_name: str
+    file_size: int
+    create_date: Optional[datetime] = None
+    create_user: Optional[str] = None
+
+
+class FolderNodeSchema(BaseSchema):
+    folder_id: int
+    name: str
+    parent_folder_id: Optional[int] = None
+    sort_order: int = 0
+    is_system: bool = False
+    document_count: int = 0
+    documents: List[FolderDocumentSchema] = []
+    children: List["FolderNodeSchema"] = []
+
+
+class DocumentFolderTreeSchema(BaseSchema):
+    folders: List[FolderNodeSchema] = []
+    # Documents of the parent with no placement row.
+    root_documents: List[FolderDocumentSchema] = []
+
+
+class FolderCreateSchema(BaseSchema):
+    name: str
+    parent_folder_id: Optional[int] = None
+
+
+class FolderUpdateSchema(BaseSchema):
+    name: Optional[str] = None
+    parent_folder_id: Optional[int] = None
+    sort_order: Optional[int] = None
+    # Distinguishes "move to root" (explicit null) from "leave in place"
+    # (field absent); pydantic drops that difference otherwise.
+    move_to_root: bool = False
+
+
+class FolderItemsMoveSchema(BaseSchema):
+    document_ids: List[int]
+    # None places the documents at the root (removes their placement rows).
+    folder_id: Optional[int] = None
+
+
+class FolderSchema(BaseSchema):
+    folder_id: int
+    parent_type: str
+    parent_id: int
+    parent_folder_id: Optional[int] = None
+    name: str
+    sort_order: int = 0
+    is_system: bool = False
+
+    class Config:
+        from_attributes = True

--- a/backend/lcfs/web/api/document_folder/services.py
+++ b/backend/lcfs/web/api/document_folder/services.py
@@ -1,0 +1,261 @@
+import structlog
+from typing import Dict, List, Optional
+
+from fastapi import Depends, HTTPException, Request
+
+from lcfs.db.models.document import DocumentFolder
+from lcfs.web.api.document_folder.constants import (
+    FOLDER_ENABLED_PARENT_TYPES,
+    MAX_FOLDER_DEPTH,
+)
+from lcfs.web.api.document_folder.repo import DocumentFolderRepository
+from lcfs.web.api.document_folder.schema import (
+    DocumentFolderTreeSchema,
+    FolderCreateSchema,
+    FolderDocumentSchema,
+    FolderItemsMoveSchema,
+    FolderNodeSchema,
+    FolderSchema,
+    FolderUpdateSchema,
+)
+from lcfs.web.core.decorators import service_handler
+from lcfs.web.exception.exceptions import DataNotFoundException
+
+logger = structlog.get_logger(__name__)
+
+
+class DocumentFolderServices:
+    def __init__(
+        self,
+        repo: DocumentFolderRepository = Depends(DocumentFolderRepository),
+        request: Request = None,
+    ) -> None:
+        self.repo = repo
+        self.request = request
+
+    # ------------------------------------------------------------------
+    # Invariants. Every mutation funnels through these; the allow-list is
+    # the isolation guarantee and is checked at the view layer as well.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def ensure_parent_type_enabled(parent_type: str) -> None:
+        if parent_type not in FOLDER_ENABLED_PARENT_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Folders are not enabled for parent type '{parent_type}'.",
+            )
+
+    async def _get_scoped_folder(
+        self, folder_id: int, parent_type: str, parent_id: int
+    ) -> DocumentFolder:
+        folder = await self.repo.get_folder(folder_id)
+        if (
+            folder is None
+            or folder.parent_type != parent_type
+            or folder.parent_id != parent_id
+        ):
+            # A folder belonging to another parent is indistinguishable
+            # from a missing one on purpose.
+            raise DataNotFoundException(f"Folder {folder_id} not found")
+        return folder
+
+    async def _walk_depth_and_cycles(
+        self,
+        new_parent_id: Optional[int],
+        parent_type: str,
+        parent_id: int,
+        moving_folder_id: Optional[int] = None,
+    ) -> int:
+        """Return the depth of the new parent chain; reject cycles.
+
+        Depth 0 means the root; a folder placed there sits at depth 1.
+        """
+        depth = 0
+        current = new_parent_id
+        while current is not None:
+            if moving_folder_id is not None and current == moving_folder_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="A folder cannot be moved into itself or a descendant.",
+                )
+            folder = await self._get_scoped_folder(current, parent_type, parent_id)
+            depth += 1
+            if depth > MAX_FOLDER_DEPTH:
+                break
+            current = folder.parent_folder_id
+        if depth >= MAX_FOLDER_DEPTH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Folders may nest at most {MAX_FOLDER_DEPTH} levels deep.",
+            )
+        return depth
+
+    # ------------------------------------------------------------------
+    # Tree
+    # ------------------------------------------------------------------
+    @service_handler
+    async def get_tree(
+        self, parent_type: str, parent_id: int
+    ) -> DocumentFolderTreeSchema:
+        folders = await self.repo.get_folders(parent_type, parent_id)
+        documents = await self.repo.get_parent_documents(parent_id)
+        placements = await self.repo.get_placements([f.folder_id for f in folders])
+
+        docs_by_folder: Dict[int, List[FolderDocumentSchema]] = {}
+        root_documents: List[FolderDocumentSchema] = []
+        for document in documents:
+            payload = FolderDocumentSchema(
+                document_id=document.document_id,
+                file_name=document.file_name,
+                file_size=document.file_size,
+                create_date=document.create_date,
+                create_user=document.create_user,
+            )
+            folder_id = placements.get(document.document_id)
+            if folder_id is None:
+                root_documents.append(payload)
+            else:
+                docs_by_folder.setdefault(folder_id, []).append(payload)
+
+        nodes: Dict[int, FolderNodeSchema] = {}
+        for folder in folders:
+            documents_in_folder = docs_by_folder.get(folder.folder_id, [])
+            nodes[folder.folder_id] = FolderNodeSchema(
+                folder_id=folder.folder_id,
+                name=folder.name,
+                parent_folder_id=folder.parent_folder_id,
+                sort_order=folder.sort_order,
+                is_system=folder.is_system,
+                document_count=len(documents_in_folder),
+                documents=documents_in_folder,
+            )
+        roots: List[FolderNodeSchema] = []
+        for folder in folders:
+            node = nodes[folder.folder_id]
+            if folder.parent_folder_id and folder.parent_folder_id in nodes:
+                nodes[folder.parent_folder_id].children.append(node)
+            else:
+                roots.append(node)
+
+        # Counts roll up so a collapsed branch still shows its size.
+        def rollup(node: FolderNodeSchema) -> int:
+            node.document_count += sum(rollup(child) for child in node.children)
+            return node.document_count
+
+        for root in roots:
+            rollup(root)
+        return DocumentFolderTreeSchema(folders=roots, root_documents=root_documents)
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+    @service_handler
+    async def create_folder(
+        self, parent_type: str, parent_id: int, data: FolderCreateSchema
+    ) -> FolderSchema:
+        name = data.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Folder name is required.")
+        await self._walk_depth_and_cycles(data.parent_folder_id, parent_type, parent_id)
+        username = getattr(
+            getattr(self.request, "user", None), "keycloak_username", None
+        )
+        folder = await self.repo.add_folder(
+            DocumentFolder(
+                parent_type=parent_type,
+                parent_id=parent_id,
+                parent_folder_id=data.parent_folder_id,
+                name=name,
+                create_user=username,
+                update_user=username,
+            )
+        )
+        return FolderSchema.model_validate(folder)
+
+    @service_handler
+    async def update_folder(
+        self,
+        parent_type: str,
+        parent_id: int,
+        folder_id: int,
+        data: FolderUpdateSchema,
+    ) -> FolderSchema:
+        folder = await self._get_scoped_folder(folder_id, parent_type, parent_id)
+        if folder.is_system:
+            raise HTTPException(
+                status_code=400, detail="System folders cannot be modified."
+            )
+        if data.name is not None:
+            name = data.name.strip()
+            if not name:
+                raise HTTPException(status_code=400, detail="Folder name is required.")
+            folder.name = name
+        if data.move_to_root:
+            folder.parent_folder_id = None
+        elif data.parent_folder_id is not None:
+            await self._walk_depth_and_cycles(
+                data.parent_folder_id,
+                parent_type,
+                parent_id,
+                moving_folder_id=folder_id,
+            )
+            folder.parent_folder_id = data.parent_folder_id
+        if data.sort_order is not None:
+            folder.sort_order = data.sort_order
+        await self.repo.db.flush()
+        return FolderSchema.model_validate(folder)
+
+    @service_handler
+    async def delete_folder(
+        self, parent_type: str, parent_id: int, folder_id: int, strategy: str
+    ) -> None:
+        folder = await self._get_scoped_folder(folder_id, parent_type, parent_id)
+        if folder.is_system:
+            raise HTTPException(
+                status_code=400, detail="System folders cannot be deleted."
+            )
+        if strategy == "reparent":
+            # Contents move up one level; only the folder disappears.
+            await self.repo.reparent_contents(folder_id, folder.parent_folder_id)
+            await self.repo.delete_folders([folder_id])
+        elif strategy == "cascade":
+            # Removes the subtree's structure. Placement rows cascade away,
+            # so the files fall to the root — file deletion itself stays
+            # with the existing per-file delete flow and its ownership rule.
+            subtree = [folder_id]
+            frontier = [folder_id]
+            all_folders = await self.repo.get_folders(parent_type, parent_id)
+            children_of: Dict[Optional[int], List[int]] = {}
+            for f in all_folders:
+                children_of.setdefault(f.parent_folder_id, []).append(f.folder_id)
+            while frontier:
+                current = frontier.pop()
+                for child_id in children_of.get(current, []):
+                    subtree.append(child_id)
+                    frontier.append(child_id)
+            await self.repo.delete_folders(subtree)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="strategy must be 'reparent' or 'cascade'.",
+            )
+
+    @service_handler
+    async def move_items(
+        self, parent_type: str, parent_id: int, data: FolderItemsMoveSchema
+    ) -> None:
+        if not data.document_ids:
+            return
+        if data.folder_id is not None:
+            await self._get_scoped_folder(data.folder_id, parent_type, parent_id)
+        associated = await self.repo.get_associated_document_ids(parent_id)
+        strays = [d for d in data.document_ids if d not in associated]
+        if strays:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Documents must belong to this record before they can "
+                    f"be placed in its folders: {strays}"
+                ),
+            )
+        await self.repo.set_placements(data.document_ids, data.folder_id)

--- a/backend/lcfs/web/api/document_folder/views.py
+++ b/backend/lcfs/web/api/document_folder/views.py
@@ -1,0 +1,148 @@
+import structlog
+from fastapi import APIRouter, Body, Depends, Query, Request, status
+
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.services.s3.client import DocumentService
+from lcfs.web.api.document_folder.schema import (
+    DocumentFolderTreeSchema,
+    FolderCreateSchema,
+    FolderItemsMoveSchema,
+    FolderSchema,
+    FolderUpdateSchema,
+)
+from lcfs.web.api.document_folder.services import DocumentFolderServices
+from lcfs.web.api.initiative_agreement.validation import InitiativeAgreementValidation
+from lcfs.web.core.decorators import view_handler
+
+logger = structlog.get_logger(__name__)
+router = APIRouter()
+
+# The tree renders on the IDIR designated action page; the proponent view
+# arrives with the BCeID story, like the rest of the module.
+FOLDER_ROLES = [RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR]
+
+
+async def _validate_parent_access(
+    parent_type: str,
+    parent_id: int,
+    service: DocumentFolderServices,
+    document_service: DocumentService,
+    ia_validate: InitiativeAgreementValidation,
+) -> None:
+    """Allow-list first, then the same access resolution the shared
+    document routes use: a designated action's audience is its agreement's."""
+    service.ensure_parent_type_enabled(parent_type)
+    agreement_id = await document_service.get_designated_action_agreement_id(parent_id)
+    await ia_validate.validate_organization_access(agreement_id)
+
+
+@router.get(
+    "/{parent_type}/{parent_id}",
+    response_model=DocumentFolderTreeSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(FOLDER_ROLES)
+async def get_document_folder_tree(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> DocumentFolderTreeSchema:
+    """The whole tree in one call: nested folders with documents inlined,
+    plus the parent's unplaced documents at the root."""
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    return await service.get_tree(parent_type, parent_id)
+
+
+@router.post(
+    "/{parent_type}/{parent_id}",
+    response_model=FolderSchema,
+    status_code=status.HTTP_201_CREATED,
+)
+@view_handler(FOLDER_ROLES)
+async def create_document_folder(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    data: FolderCreateSchema = Body(...),
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> FolderSchema:
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    return await service.create_folder(parent_type, parent_id, data)
+
+
+@router.put(
+    "/{parent_type}/{parent_id}/items",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@view_handler(FOLDER_ROLES)
+async def move_document_folder_items(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    data: FolderItemsMoveSchema = Body(...),
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> None:
+    """Bulk placement — one call per drag; a null folder moves to root."""
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    await service.move_items(parent_type, parent_id, data)
+
+
+@router.put(
+    "/{parent_type}/{parent_id}/{folder_id}",
+    response_model=FolderSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(FOLDER_ROLES)
+async def update_document_folder(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    folder_id: int,
+    data: FolderUpdateSchema = Body(...),
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> FolderSchema:
+    """Rename and move, one route."""
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    return await service.update_folder(parent_type, parent_id, folder_id, data)
+
+
+@router.delete(
+    "/{parent_type}/{parent_id}/{folder_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@view_handler(FOLDER_ROLES)
+async def delete_document_folder(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    folder_id: int,
+    strategy: str = Query(
+        "reparent",
+        description="reparent moves contents up one level; cascade removes "
+        "the subtree's structure and its files fall to the root.",
+    ),
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> None:
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    await service.delete_folder(parent_type, parent_id, folder_id, strategy)

--- a/backend/lcfs/web/api/router.py
+++ b/backend/lcfs/web/api/router.py
@@ -29,6 +29,7 @@ from lcfs.web.api import (
     dashboard,
     allocation_agreement,
     document,
+    document_folder,
     fuel_type,
     audit_log,
     email,
@@ -122,6 +123,9 @@ api_router.include_router(
     fuel_supply.router, prefix="/fuel-supply", tags=["fuel_supplies"]
 )
 api_router.include_router(document.router, prefix="/documents", tags=["documents"])
+api_router.include_router(
+    document_folder.router, prefix="/document-folders", tags=["document-folders"]
+)
 api_router.include_router(fuel_type.router, prefix="/fuel-type", tags=["fuel_type"])
 api_router.include_router(audit_log.router, prefix="/audit-log", tags=["audit_log"])
 api_router.include_router(email.router, prefix="/email", tags=["emails"])


### PR DESCRIPTION
## Summary

Phase 1 of document folders for designated actions (#4925): the backend layer, shipping dark. The tree UI (phase 2) and drag-and-drop (phase 3) follow in their own PRs.

Built to the adopted design's isolation guarantee — **a layer beside the document system, not a change to it**:

- Two new tables: `document_folder` (the tree, polymorphic `parent_type`/`parent_id`) and `document_folder_item` (placement; no row means root, so pre-existing files need no backfill).
- One new router at `/document-folders/…`: tree-in-one-call, create, rename-and-move, delete with `?strategy=reparent|cascade`, and bulk placement for drags.
- One registration line in `api/router.py`.

**Not modified — not one line:** the `document` table, the six association tables, `Document.py`, `services/s3/client.py`, `FileResponseSchema`, `api/document/views.py`, or any shared frontend component. The existing document suite passing unchanged is the proof by construction.

### The hard stop

`FOLDER_ENABLED_PARENT_TYPES = frozenset({"designatedAction"})` — every folder route rejects any other parent type with 400 before doing anything else, covered by one parametrised test across all six other parent types (including `initiativeAgreement`: the wireframe's evidence tree lives on the action page, and agreement-level folders can be one added string later if wanted).

### Server-side invariants (all tested)

Folders must belong to the addressed parent — a folder from another action reads as missing, not forbidden. Placed documents must be associated with the action (join through `designated_action_document_association`). Cycles are rejected by walking the parent chain. Nesting caps at five levels. System folders (`is_system`, reserved for a future seeded structure) refuse rename, move and delete. Sibling names are case-insensitively unique, with NULL parents coalesced in the functional index so the root level gets the same guarantee.

### Two deliberate calls

**`cascade` deletes structure, not files.** The subtree's folders go and their files fall to the root; file deletion stays with the existing per-file flow and its ownership rule. This sidesteps the design's "must be able to delete every file inside" escalation entirely — nothing is ever lost by deleting a folder.

**Placement dies with its document by FK cascade**, because the existing delete path knows nothing about folders and is not being taught. Tested by deleting a placed document and asserting the placement row is gone.

### Testing

15 new tests in `tests/document_folder/`: the isolation sweep, CRUD and tree shape (nesting, inlined documents, rolled-up counts, root documents), case-insensitive sibling uniqueness, cycle and depth rejection, system-folder immutability, reparent vs cascade behaviour, unassociated-document rejection, foreign-folder 404, the FK cascade, and IDIR-only gating. 124 pass across the folder, document and IA suites; Alembic remains single-head.

Refs #4925
