### PR TITLE
Scope internal comment and attachment access to the caller's organization

### DIFF
--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -36,6 +36,12 @@ from lcfs.db.models.comment.InternalComment import (
     InternalComment,
     internal_comment_document_association,
 )
+from lcfs.db.models.comment.CIApplicationInternalComment import (
+    CIApplicationInternalComment,
+)
+from lcfs.db.models.comment.ComplianceReportInternalComment import (
+    ComplianceReportInternalComment,
+)
 from lcfs.services.clamav.client import ClamAVService
 from lcfs.settings import settings
 from lcfs.web.api.initiative_agreement.services import InitiativeAgreementServices
@@ -392,6 +398,49 @@ class DocumentService:
             detail="Only Analysts and Government Staff and related Organization users can upload files to Charging Sites.",
         )
 
+    async def _get_readable_comment_organization_ids(
+        self, internal_comment_id: int
+    ) -> set[int]:
+        """
+        Organizations owning the entities a comment hangs off, restricted to
+        the entity types a non-government caller may read.
+
+        Only compliance report and CI application threads are resolved, because
+        those are the only ones InternalCommentService.get_internal_comments
+        exposes to a non-government caller. A comment on any other entity — or
+        on none — resolves to an empty set and is refused.
+
+        The organization is derived live from the association tables rather than
+        read from ``internal_comment.organization_id``: that column is a
+        nullable denormalization, so authorizing off it would deny access to
+        attachments on older comments whose value was never backfilled.
+        """
+        report_orgs = (
+            select(ComplianceReport.organization_id)
+            .join(
+                ComplianceReportInternalComment,
+                ComplianceReportInternalComment.compliance_report_id
+                == ComplianceReport.compliance_report_id,
+            )
+            .where(
+                ComplianceReportInternalComment.internal_comment_id
+                == internal_comment_id
+            )
+        )
+        application_orgs = (
+            select(CIApplication.organization_id)
+            .join(
+                CIApplicationInternalComment,
+                CIApplicationInternalComment.ci_application_id
+                == CIApplication.ci_application_id,
+            )
+            .where(
+                CIApplicationInternalComment.internal_comment_id == internal_comment_id
+            )
+        )
+        result = await self.db.execute(report_orgs.union(application_orgs))
+        return {row[0] for row in result.all() if row[0] is not None}
+
     async def verify_internal_comment_access(self, parent_id, user, write=False):
         """Authorise attachment access for an internal comment.
 
@@ -401,7 +450,8 @@ class DocumentService:
         * write (add/remove attachment): only the comment's author, mirroring
           internal comment edit permissions.
         * read (list/download): government staff see everything; everyone else
-          only Public comments.
+          only Public comments, on a compliance report or CI application
+          belonging to their own organization.
         """
         comment = await self.db.get(InternalComment, parent_id)
         if not comment:
@@ -415,15 +465,32 @@ class DocumentService:
                     status_code=403,
                     detail="Only the comment author can modify its attachments.",
                 )
-        else:
+        elif not is_government:
             visibility = (
                 str(comment.visibility) if comment.visibility is not None else None
             )
-            if not is_government and visibility != "Public":
-                raise HTTPException(
-                    status_code=403,
-                    detail="You do not have access to this comment's attachments.",
+            forbidden = HTTPException(
+                status_code=403,
+                detail="You do not have access to this comment's attachments.",
+            )
+            if visibility != "Public":
+                raise forbidden
+            # Visibility alone is not an organization scope, so the same
+            # entity-type and ownership rules the comment read path applies
+            # are applied here.
+            user_organization_id = getattr(user, "organization_id", None)
+            if user_organization_id is None:
+                user_organization_id = getattr(
+                    getattr(user, "organization", None), "organization_id", None
                 )
+            readable_organization_ids = (
+                await self._get_readable_comment_organization_ids(parent_id)
+            )
+            if (
+                user_organization_id is None
+                or user_organization_id not in readable_organization_ids
+            ):
+                raise forbidden
 
         return comment
 

--- a/backend/lcfs/tests/document/test_internal_comment_attachment_access.py
+++ b/backend/lcfs/tests/document/test_internal_comment_attachment_access.py
@@ -2,7 +2,9 @@
 
 Attachment access "matches comment permissions" (issue #4514):
   * write (add/remove attachment): comment author only
-  * read (list/download): government staff see all; others only Public comments
+  * read (list/download): government staff see all; everyone else only Public
+    comments, on a compliance report or CI application belonging to their own
+    organization
 """
 
 from types import SimpleNamespace
@@ -15,10 +17,18 @@ from lcfs.db.models.user.Role import RoleEnum
 from lcfs.services.s3.client import DocumentService
 
 
-def _service_with_comment(comment):
-    """Build a DocumentService with a mocked db whose get() returns comment."""
+def _service_with_comment(comment, owner_organization_ids=()):
+    """Build a DocumentService with a mocked db.
+
+    ``get()`` returns the comment; ``execute()`` stands in for the live
+    lookup of the organizations owning the comment's readable entities.
+    """
+    rows = [(organization_id,) for organization_id in owner_organization_ids]
     service = DocumentService.__new__(DocumentService)
-    service.db = SimpleNamespace(get=AsyncMock(return_value=comment))
+    service.db = SimpleNamespace(
+        get=AsyncMock(return_value=comment),
+        execute=AsyncMock(return_value=SimpleNamespace(all=lambda: rows)),
+    )
     return service
 
 
@@ -26,10 +36,11 @@ def _comment(create_user="author", visibility="Internal"):
     return SimpleNamespace(create_user=create_user, visibility=visibility)
 
 
-def _user(username="author", roles=None):
+def _user(username="author", roles=None, organization_id=None):
     return SimpleNamespace(
         keycloak_username=username,
         role_names=roles if roles is not None else [],
+        organization_id=organization_id,
     )
 
 
@@ -72,19 +83,72 @@ async def test_government_can_read_internal():
 
 
 @pytest.mark.anyio
-async def test_non_government_can_read_public():
-    service = _service_with_comment(_comment(visibility="Public"))
+async def test_non_government_can_read_public_on_own_organization():
+    service = _service_with_comment(
+        _comment(visibility="Public"), owner_organization_ids=(5,)
+    )
     result = await service.verify_internal_comment_access(
-        1, _user(username="bceid", roles=[RoleEnum.SUPPLIER]), write=False
+        1,
+        _user(username="bceid", roles=[RoleEnum.SUPPLIER], organization_id=5),
+        write=False,
     )
     assert result is not None
 
 
 @pytest.mark.anyio
-async def test_non_government_cannot_read_internal():
-    service = _service_with_comment(_comment(visibility="Internal"))
+async def test_non_government_cannot_read_public_on_another_organization():
+    """Public visibility is not an organization scope."""
+    service = _service_with_comment(
+        _comment(visibility="Public"), owner_organization_ids=(5,)
+    )
     with pytest.raises(HTTPException) as exc:
         await service.verify_internal_comment_access(
-            1, _user(username="bceid", roles=[RoleEnum.SUPPLIER]), write=False
+            1,
+            _user(username="bceid", roles=[RoleEnum.SUPPLIER], organization_id=6),
+            write=False,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_non_government_cannot_read_comment_with_no_readable_entity():
+    """A comment on a Transfer, an agreement, or nothing at all resolves to no
+    readable organization and is refused."""
+    service = _service_with_comment(
+        _comment(visibility="Public"), owner_organization_ids=()
+    )
+    with pytest.raises(HTTPException) as exc:
+        await service.verify_internal_comment_access(
+            1,
+            _user(username="bceid", roles=[RoleEnum.SUPPLIER], organization_id=5),
+            write=False,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_non_government_without_an_organization_cannot_read():
+    service = _service_with_comment(
+        _comment(visibility="Public"), owner_organization_ids=(5,)
+    )
+    with pytest.raises(HTTPException) as exc:
+        await service.verify_internal_comment_access(
+            1,
+            _user(username="bceid", roles=[RoleEnum.SUPPLIER], organization_id=None),
+            write=False,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_non_government_cannot_read_internal():
+    service = _service_with_comment(
+        _comment(visibility="Internal"), owner_organization_ids=(5,)
+    )
+    with pytest.raises(HTTPException) as exc:
+        await service.verify_internal_comment_access(
+            1,
+            _user(username="bceid", roles=[RoleEnum.SUPPLIER], organization_id=5),
+            write=False,
         )
     assert exc.value.status_code == 403

--- a/backend/lcfs/tests/document/test_internal_comment_attachment_authorization.py
+++ b/backend/lcfs/tests/document/test_internal_comment_attachment_authorization.py
@@ -1,0 +1,346 @@
+"""Organization scoping on internal-comment attachment reads.
+
+Attachment visibility is meant to "match comment permissions" (issue #4514).
+The comment read path admits a non-government caller only to a Public comment,
+on a complianceReport or ciApplication, belonging to their own organization.
+Attachment reads mirror all three so the two stay consistent.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+
+from lcfs.db.models import UserProfile
+from lcfs.db.models.ci_application.CIApplication import CIApplication
+from lcfs.db.models.comment.CIApplicationInternalComment import (
+    CIApplicationInternalComment,
+)
+from lcfs.db.models.comment.ComplianceReportInternalComment import (
+    ComplianceReportInternalComment,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.comment.TransferInternalComment import TransferInternalComment
+from lcfs.db.models.compliance.ComplianceReport import (
+    ComplianceReport,
+    ReportingFrequency,
+)
+from lcfs.db.models.document.Document import Document
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
+from lcfs.db.models.transfer.Transfer import Transfer, TransferRecommendationEnum
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.web.api.internal_comment.schema import CommentVisibilityEnum
+
+# Compliance period 15 is 2024 (seeded by migration).
+COMPLIANCE_PERIOD_ID = 15
+AUTHOR = "IDIRUSER"
+
+
+def _set_bceid_user(fastapi_app, set_mock_user, organization_id: int = 1):
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.SUPPLIER],
+        user_details={
+            "keycloak_username": "BCEIDUSER",
+            "organization_id": organization_id,
+        },
+    )
+
+
+async def _seed_author(add_models):
+    await add_models(
+        [UserProfile(keycloak_username=AUTHOR, first_name="Test", last_name="User")]
+    )
+
+
+async def _seed_comment_with_attachment(
+    add_models,
+    *,
+    file_name: str,
+    visibility: str = CommentVisibilityEnum.PUBLIC.value,
+) -> InternalComment:
+    """An internal comment carrying one attachment, with no entity link yet."""
+    document = Document(
+        file_key=f"lcfs-docs/internal_comment/{file_name}",
+        file_name=file_name,
+        file_size=2048,
+        mime_type="application/pdf",
+    )
+    ic = InternalComment(
+        comment=f"<p>{file_name}</p>",
+        visibility=visibility,
+        create_user=AUTHOR,
+    )
+    # Linking via the relationship inserts the association row on flush.
+    ic.documents = [document]
+    await add_models([document, ic])
+    return ic
+
+
+async def _attach_to_report(
+    add_models, ic: InternalComment, *, compliance_report_id: int, organization_id: int
+):
+    await add_models(
+        [
+            ComplianceReport(
+                compliance_report_id=compliance_report_id,
+                compliance_period_id=COMPLIANCE_PERIOD_ID,
+                organization_id=organization_id,
+                nickname="test",
+                reporting_frequency=ReportingFrequency.ANNUAL,
+                compliance_report_group_uuid=str(uuid.uuid4()),
+                version=1,
+            )
+        ]
+    )
+    await add_models(
+        [
+            ComplianceReportInternalComment(
+                compliance_report_id=compliance_report_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+
+
+async def _attach_to_ci_application(
+    add_models, ic: InternalComment, *, ci_application_id: int, organization_id: int
+):
+    await add_models(
+        [
+            CIApplication(
+                ci_application_id=ci_application_id,
+                organization_id=organization_id,
+                status_id=1,
+                facility_country="Canada",
+                facility_nameplate_capacity=1000,
+                facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
+                group_uuid=str(uuid.uuid4()),
+                version=0,
+            )
+        ]
+    )
+    await add_models(
+        [
+            CIApplicationInternalComment(
+                ci_application_id=ci_application_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+
+
+async def _attach_to_transfer(
+    add_models, ic: InternalComment, *, transfer_id: int, to_organization_id: int
+):
+    await add_models(
+        [
+            Transfer(
+                transfer_id=transfer_id,
+                from_organization_id=1,
+                to_organization_id=to_organization_id,
+                agreement_date=datetime.now(),
+                transaction_effective_date=datetime.now(),
+                price_per_unit=1.0,
+                quantity=100,
+                transfer_category_id=1,
+                current_status_id=1,
+                recommendation=TransferRecommendationEnum.Record,
+                effective_status=True,
+            )
+        ]
+    )
+    await add_models(
+        [
+            TransferInternalComment(
+                transfer_id=transfer_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+
+
+def _list_url(fastapi_app, comment_id: int) -> str:
+    return fastapi_app.url_path_for(
+        "get_all_documents", parent_type="internal_comment", parent_id=comment_id
+    )
+
+
+# ======================================================================
+# Listing attachments
+# ======================================================================
+@pytest.mark.anyio
+async def test_bceid_can_list_attachments_on_own_orgs_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Control: the supplier still reaches its own report's attachments."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="own-org.pdf")
+    await _attach_to_report(
+        add_models, ic, compliance_report_id=7701, organization_id=1
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [d["fileName"] for d in response.json()] == ["own-org.pdf"]
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_list_attachments_on_another_orgs_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Public visibility is not an organization scope."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="other-org.pdf")
+    await _attach_to_report(
+        add_models, ic, compliance_report_id=7702, organization_id=2
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_can_list_attachments_on_own_orgs_ci_application_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Control: the CI applicant still reaches its own application's attachments."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="own-ci.pdf")
+    await _attach_to_ci_application(
+        add_models, ic, ci_application_id=7703, organization_id=1
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [d["fileName"] for d in response.json()] == ["own-ci.pdf"]
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_list_attachments_on_another_orgs_ci_application_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Same gap on the CI application thread."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="other-ci.pdf")
+    await _attach_to_ci_application(
+        add_models, ic, ci_application_id=7704, organization_id=2
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_list_attachments_on_a_transfer_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """The comment read path refuses Transfer threads to non-government
+    callers whatever their visibility, so attachment reads must too — even
+    when the transfer names the caller's own organization."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="transfer.pdf")
+    await _attach_to_transfer(add_models, ic, transfer_id=7705, to_organization_id=1)
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_list_attachments_on_an_unlinked_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """A comment that resolves to no entity fails closed."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="orphan.pdf")
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_list_attachments_on_an_internal_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Regression guard: the existing visibility check still applies to a
+    comment on the caller's own report."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(
+        add_models,
+        file_name="internal.pdf",
+        visibility=CommentVisibilityEnum.INTERNAL.value,
+    )
+    await _attach_to_report(
+        add_models, ic, compliance_report_id=7706, organization_id=1
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_government_can_list_attachments_on_any_orgs_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Government behaviour is unchanged: IDIR reaches any organization, any
+    visibility, any entity type."""
+    set_mock_user(
+        fastapi_app, [RoleEnum.GOVERNMENT], user_details={"keycloak_username": AUTHOR}
+    )
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(
+        add_models,
+        file_name="gov-readable.pdf",
+        visibility=CommentVisibilityEnum.INTERNAL.value,
+    )
+    await _attach_to_report(
+        add_models, ic, compliance_report_id=7707, organization_id=2
+    )
+
+    response = await client.get(_list_url(fastapi_app, ic.internal_comment_id))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [d["fileName"] for d in response.json()] == ["gov-readable.pdf"]
+
+
+# ======================================================================
+# Streaming an attachment
+# ======================================================================
+@pytest.mark.anyio
+async def test_bceid_cannot_stream_attachment_on_another_orgs_comment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, add_models
+):
+    """Listing is only the first half — the download must be refused too."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_comment_with_attachment(add_models, file_name="other-stream.pdf")
+    await _attach_to_report(
+        add_models, ic, compliance_report_id=7708, organization_id=2
+    )
+    document_id = ic.documents[0].document_id
+
+    url = fastapi_app.url_path_for(
+        "stream_document",
+        parent_type="internal_comment",
+        parent_id=ic.internal_comment_id,
+        document_id=document_id,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/tests/internal_comment/test_internal_comment_authorization.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment_authorization.py
@@ -1,0 +1,433 @@
+"""Organization scoping on the entity-scoped internal comment endpoints.
+
+``GET /internal_comments/{entity_type}/{entity_id}`` and
+``POST /internal_comments/`` admit BCeID users to comments on compliance
+reports and CI applications. Entity type and visibility do not bound which
+organization a caller reaches, so those endpoints also resolve the entity's
+owner and admit only the caller's own organization.
+"""
+
+import uuid
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+
+from lcfs.db.models import UserProfile
+from lcfs.db.models.ci_application.CIApplication import CIApplication
+from lcfs.db.models.comment.CIApplicationInternalComment import (
+    CIApplicationInternalComment,
+)
+from lcfs.db.models.comment.ComplianceReportInternalComment import (
+    ComplianceReportInternalComment,
+)
+from lcfs.db.models.comment.InternalComment import InternalComment
+from lcfs.db.models.compliance.ComplianceReport import (
+    ComplianceReport,
+    ReportingFrequency,
+)
+from lcfs.db.models.fuel.FuelType import QuantityUnitsEnum
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.web.api.internal_comment.schema import (
+    CommentVisibilityEnum,
+    EntityTypeEnum,
+)
+
+# Compliance period 15 is 2024 (seeded by migration).
+COMPLIANCE_PERIOD_ID = 15
+AUTHOR = "IDIRUSER"
+
+
+def _set_bceid_user(fastapi_app, set_mock_user, organization_id: int = 1):
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.SUPPLIER],
+        user_details={
+            "keycloak_username": "BCEIDUSER",
+            "organization_id": organization_id,
+        },
+    )
+
+
+async def _seed_author(add_models):
+    """The comment read path inner-joins user_profile on create_user."""
+    await add_models(
+        [UserProfile(keycloak_username=AUTHOR, first_name="Test", last_name="User")]
+    )
+
+
+async def _seed_report_comment(
+    add_models,
+    *,
+    compliance_report_id: int,
+    organization_id: int,
+    visibility: str = CommentVisibilityEnum.PUBLIC.value,
+    comment: str = "<p>report note</p>",
+) -> InternalComment:
+    report = ComplianceReport(
+        compliance_report_id=compliance_report_id,
+        compliance_period_id=COMPLIANCE_PERIOD_ID,
+        organization_id=organization_id,
+        nickname="test",
+        reporting_frequency=ReportingFrequency.ANNUAL,
+        compliance_report_group_uuid=str(uuid.uuid4()),
+        version=1,
+    )
+    await add_models([report])
+
+    ic = InternalComment(
+        comment=comment,
+        comment_search_text=comment,
+        visibility=visibility,
+        create_user=AUTHOR,
+    )
+    await add_models([ic])
+    await add_models(
+        [
+            ComplianceReportInternalComment(
+                compliance_report_id=compliance_report_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+    return ic
+
+
+async def _seed_ci_application_comment(
+    add_models,
+    *,
+    ci_application_id: int,
+    organization_id: int,
+    visibility: str = CommentVisibilityEnum.PUBLIC.value,
+    comment: str = "<p>ci note</p>",
+) -> InternalComment:
+    application = CIApplication(
+        ci_application_id=ci_application_id,
+        organization_id=organization_id,
+        status_id=1,
+        facility_country="Canada",
+        facility_nameplate_capacity=1000,
+        facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
+        group_uuid=str(uuid.uuid4()),
+        version=0,
+    )
+    await add_models([application])
+
+    ic = InternalComment(
+        comment=comment,
+        comment_search_text=comment,
+        visibility=visibility,
+        create_user=AUTHOR,
+    )
+    await add_models([ic])
+    await add_models(
+        [
+            CIApplicationInternalComment(
+                ci_application_id=ci_application_id,
+                internal_comment_id=ic.internal_comment_id,
+            )
+        ]
+    )
+    return ic
+
+
+# ======================================================================
+# Read: GET /internal_comments/{entity_type}/{entity_id}
+# ======================================================================
+@pytest.mark.anyio
+async def test_bceid_can_read_own_orgs_compliance_report_comments(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Control: a supplier still reads the Public thread on its own report."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_report_comment(
+        add_models, compliance_report_id=8801, organization_id=1
+    )
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=8801,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert [c["internalCommentId"] for c in body] == [ic.internal_comment_id]
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_read_another_orgs_compliance_report_comments(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Public visibility is not an organization scope: a Public comment on
+    another organization's report is not readable."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    await _seed_report_comment(
+        add_models,
+        compliance_report_id=8802,
+        organization_id=2,
+        comment="<p>another org's note</p>",
+    )
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=8802,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_read_another_orgs_ci_application_comments(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Same gap on the CI application thread."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    await _seed_ci_application_comment(
+        add_models,
+        ci_application_id=8803,
+        organization_id=2,
+        comment="<p>another org's ci note</p>",
+    )
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.CI_APPLICATION.value,
+        entity_id=8803,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_can_read_own_orgs_ci_application_comments(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Control: the CI applicant still reads its own application's thread."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await _seed_author(add_models)
+    ic = await _seed_ci_application_comment(
+        add_models, ci_application_id=8804, organization_id=1
+    )
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.CI_APPLICATION.value,
+        entity_id=8804,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [c["internalCommentId"] for c in response.json()] == [ic.internal_comment_id]
+
+
+@pytest.mark.anyio
+async def test_government_can_read_any_orgs_compliance_report_comments(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Government behaviour is unchanged: IDIR reads any organization."""
+    set_mock_user(
+        fastapi_app,
+        [RoleEnum.GOVERNMENT],
+        user_details={"keycloak_username": AUTHOR},
+    )
+    await _seed_author(add_models)
+    ic = await _seed_report_comment(
+        add_models,
+        compliance_report_id=8805,
+        organization_id=2,
+        visibility=CommentVisibilityEnum.INTERNAL.value,
+    )
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=8805,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [c["internalCommentId"] for c in response.json()] == [ic.internal_comment_id]
+
+
+@pytest.mark.anyio
+async def test_reading_comments_on_a_missing_entity_is_refused_for_bceid(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+):
+    """An entity id that resolves to no organization must fail closed."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+
+    url = fastapi_app.url_path_for(
+        "get_comments",
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=987654,
+    )
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ======================================================================
+# Write: POST /internal_comments/
+# ======================================================================
+async def _post_comment(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    *,
+    entity_type: str,
+    entity_id: int,
+    visibility: str = CommentVisibilityEnum.PUBLIC.value,
+):
+    url = fastapi_app.url_path_for("create_comment")
+    return await client.post(
+        url,
+        json={
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "comment": "<p>posted by a supplier</p>",
+            "visibility": visibility,
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_bceid_can_comment_on_own_orgs_compliance_report(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Control: the supplier still posts on its own report."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await add_models(
+        [
+            ComplianceReport(
+                compliance_report_id=8811,
+                compliance_period_id=COMPLIANCE_PERIOD_ID,
+                organization_id=1,
+                nickname="test",
+                reporting_frequency=ReportingFrequency.ANNUAL,
+                compliance_report_group_uuid=str(uuid.uuid4()),
+                version=1,
+            )
+        ]
+    )
+
+    response = await _post_comment(
+        client,
+        fastapi_app,
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=8811,
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_comment_on_another_orgs_compliance_report(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Creates are scoped the same way reads are."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await add_models(
+        [
+            ComplianceReport(
+                compliance_report_id=8812,
+                compliance_period_id=COMPLIANCE_PERIOD_ID,
+                organization_id=2,
+                nickname="test",
+                reporting_frequency=ReportingFrequency.ANNUAL,
+                compliance_report_group_uuid=str(uuid.uuid4()),
+                version=1,
+            )
+        ]
+    )
+
+    response = await _post_comment(
+        client,
+        fastapi_app,
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=8812,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_comment_on_another_orgs_ci_application(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+    add_models,
+):
+    """Same gap on the CI application thread."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+    await add_models(
+        [
+            CIApplication(
+                ci_application_id=8813,
+                organization_id=2,
+                status_id=1,
+                facility_country="Canada",
+                facility_nameplate_capacity=1000,
+                facility_nameplate_capacity_unit=QuantityUnitsEnum.Litres,
+                group_uuid=str(uuid.uuid4()),
+                version=0,
+            )
+        ]
+    )
+
+    response = await _post_comment(
+        client,
+        fastapi_app,
+        entity_type=EntityTypeEnum.CI_APPLICATION.value,
+        entity_id=8813,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_bceid_cannot_comment_on_a_missing_compliance_report(
+    client: AsyncClient,
+    fastapi_app: FastAPI,
+    set_mock_user,
+):
+    """An entity id that resolves to no organization must fail closed."""
+    _set_bceid_user(fastapi_app, set_mock_user, organization_id=1)
+
+    response = await _post_comment(
+        client,
+        fastapi_app,
+        entity_type=EntityTypeEnum.COMPLIANCE_REPORT.value,
+        entity_id=987654,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
+++ b/backend/lcfs/tests/internal_comment/test_internal_comment_services.py
@@ -218,7 +218,9 @@ async def test_copy_internal_comments_large_number_of_comments():
 @pytest.mark.anyio
 async def test_create_ci_application_public_comment_for_non_government_user():
     mock_repo = MagicMock()
-    mock_repo.get_entity_org_and_year = AsyncMock(return_value=(None, None))
+    # The applicant's own organization — a non-government caller may only
+    # comment on an entity belonging to their org.
+    mock_repo.get_entity_org_and_year = AsyncMock(return_value=(7, None))
     mock_repo.get_category_id_by_name = AsyncMock(return_value=None)
     mock_repo.create_internal_comment = AsyncMock()
     mock_repo.create_internal_comment.return_value = SimpleNamespace(
@@ -243,6 +245,7 @@ async def test_create_ci_application_public_comment_for_non_government_user():
                 role_names=[RoleEnum.SUPPLIER],
                 keycloak_username="BCEIDUSER",
                 user_profile_id=12,
+                organization_id=7,
             )
         ),
         repo=mock_repo,
@@ -362,6 +365,10 @@ def _build_service_with_user_roles(role_names):
     service.request.user = SimpleNamespace(
         role_names=role_names,
         keycloak_username="mockuser",
+        # Matches the org that ``get_entity_org_and_year`` reports below, so a
+        # non-government caller passes the entity-ownership check; tests for
+        # that check use a different org.
+        organization_id=7,
     )
     service.repo = MagicMock()
     service.repo.create_internal_comment = AsyncMock()

--- a/backend/lcfs/web/api/internal_comment/services.py
+++ b/backend/lcfs/web/api/internal_comment/services.py
@@ -86,6 +86,31 @@ class InternalCommentService:
     def _is_government_user(self) -> bool:
         return RoleEnum.GOVERNMENT in self.request.user.role_names
 
+    def _user_organization_id(self) -> Optional[int]:
+        """The caller's organization id, however the user object carries it."""
+        current_user = self.request.user
+        user_org = getattr(current_user, "organization", None)
+        if user_org is not None:
+            return getattr(user_org, "organization_id", None)
+        return getattr(current_user, "organization_id", None)
+
+    async def _require_own_organization(
+        self, entity_type: EntityTypeEnum, entity_id: int
+    ) -> None:
+        """
+        Assert a non-government caller owns the entity a comment thread hangs
+        off.
+
+        Entity type and visibility do not bound which organization a caller
+        reaches, so ownership is resolved here as well. An entity that
+        resolves to no organization fails closed rather than revealing
+        whether it exists.
+        """
+        org_id, _ = await self.repo.get_entity_org_and_year(entity_type, entity_id)
+        user_org_id = self._user_organization_id()
+        if org_id is None or user_org_id is None or org_id != user_org_id:
+            raise HTTPException(status_code=403, detail="Forbidden resource")
+
     async def _send_ci_comment_notification(
         self,
         ci_application_id: int,
@@ -206,6 +231,7 @@ class InternalCommentService:
                 raise HTTPException(status_code=403, detail="Forbidden resource")
             if data.visibility != CommentVisibilityEnum.PUBLIC:
                 raise HTTPException(status_code=403, detail="Forbidden resource")
+            await self._require_own_organization(data.entity_type, data.entity_id)
             data.audience_scope = None
         elif (
             data.visibility == CommentVisibilityEnum.INTERNAL
@@ -235,17 +261,16 @@ class InternalCommentService:
             comment, data.entity_type, data.entity_id
         )
 
-        if (
-            not is_government_user
-            and data.entity_type == EntityTypeEnum.CI_APPLICATION
-        ):
+        if not is_government_user and data.entity_type == EntityTypeEnum.CI_APPLICATION:
             await self._send_ci_comment_notification(
                 data.entity_id,
                 "applicant_activity",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
             )
         elif (
             is_government_user
@@ -256,9 +281,11 @@ class InternalCommentService:
                 data.entity_id,
                 "government_action",
                 "CI Application Comment Received",
-                self.request.user.user_profile_id
-                if hasattr(self.request.user, "user_profile_id")
-                else None,
+                (
+                    self.request.user.user_profile_id
+                    if hasattr(self.request.user, "user_profile_id")
+                    else None
+                ),
                 related_organization_id=created_comment.organization_id,
             )
 
@@ -287,6 +314,7 @@ class InternalCommentService:
                 EntityTypeEnum.CI_APPLICATION,
             ):
                 raise HTTPException(status_code=403, detail="Forbidden resource")
+            await self._require_own_organization(entity_type, entity_id)
             visibility_filter = CommentVisibilityEnum.PUBLIC.value
 
         comments = await self.repo.get_internal_comments(
@@ -462,12 +490,7 @@ class InternalCommentService:
         current_user = self.request.user
 
         if not is_government_user:
-            user_org = getattr(current_user, "organization", None)
-            user_org_id = (
-                getattr(user_org, "organization_id", None)
-                if user_org is not None
-                else getattr(current_user, "organization_id", None)
-            )
+            user_org_id = self._user_organization_id()
             if user_org_id is None or user_org_id != organization_id:
                 raise HTTPException(status_code=403, detail="Forbidden resource")
             visibility_filter: Optional[str] = CommentVisibilityEnum.PUBLIC.value


### PR DESCRIPTION
Applies organization scoping consistently across internal comment access, matching the check the organization-scoped comment feed already performs.

## What changes

For non-government callers, entity-scoped comment reads and writes, and comment attachment reads, are now scoped to the caller's own organization. The entity-type and visibility rules that already governed comment reads are applied to attachment reads as well, so the two stay consistent with the documented intent that attachment visibility matches comment permissions.

Where the owning organization cannot be resolved, access is refused rather than allowed.

Government behaviour is unchanged, as is the attachment write path, which remains restricted to the comment's author. The organization-feed check now shares one implementation with the new one rather than duplicating the caller-organization resolution.

### Implementation note

The owning organization is derived from the association tables rather than from the nullable denormalized `internal_comment.organization_id`, which is unset on a portion of existing rows — using it would have withdrawn access to attachments on older comments whose value was never backfilled. This matches how the organization Comment Log already resolves the organization from the parent entity.

## Tests

19 new tests across two files, exercising the real endpoints against a real database.

Controls cover everything that must keep working: a supplier reading and writing its own organization's compliance report and CI application threads, reading its own attachments, and government access unchanged across organization, visibility and entity type.

No legitimate access regresses. Threads on entity types outside a non-government caller's reach were already unavailable through the comment endpoint and are now consistently handled by the attachment endpoint. On the frontend, attachments are only requested for comments already loaded through the comment thread, so no UI flow changes.

Backend gates: `black` reports the changed files unchanged, and the full backend suite passes at **2645 passed, 1 skipped**.
