### PR TITLE
Feat: Designated action document folder tree UI - 4925

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@mui/icons-material": "^6.4.9",
         "@mui/material": "^6.4.9",
         "@mui/x-date-pickers": "^7.28.0",
+        "@mui/x-tree-view": "^7.29.10",
         "@react-keycloak/web": "^3.4.0",
         "@tanstack/react-query": "^5.69.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -2894,6 +2895,44 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-tree-view": {
+      "version": "7.29.10",
+      "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-7.29.10.tgz",
+      "integrity": "sha512-/ZcM582yIaQN2PmadIlQYRJzc3yXV7bh463J4GHtTmFw+PEjzUfzETBWe3VxmU3EPgIFzVQPjqAAJwylmQSJOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-internals": "7.29.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "@mui/icons-material": "^6.4.9",
     "@mui/material": "^6.4.9",
     "@mui/x-date-pickers": "^7.28.0",
+    "@mui/x-tree-view": "^7.29.10",
     "@react-keycloak/web": "^3.4.0",
     "@tanstack/react-query": "^5.69.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -92,5 +92,16 @@
     "uploadTitle": "Designated action documents",
     "documentLabel": "the designated action",
     "returnButton": "Return to designated action"
+  },
+  "folders": {
+    "newFolder": "New folder",
+    "newSubfolder": "New subfolder",
+    "newFolderName": "New folder",
+    "rename": "Rename",
+    "delete": "Delete folder",
+    "folderActions": "Folder actions",
+    "loading": "Loading documents...",
+    "empty": "No documents or folders yet.",
+    "helperText": "Double-click any name to rename. Deleting a folder moves its contents up one level."
   }
 }

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -82,6 +82,9 @@ export const apiRoutes = {
     '/initiative-agreements/designated-actions/:designatedActionId/assign',
   getDesignatedActionProfile:
     '/initiative-agreements/designated-actions/:designatedActionId/profile',
+  documentFolderTree: '/document-folders/:parentType/:parentID',
+  documentFolderUpdate: '/document-folders/:parentType/:parentID/:folderId',
+  documentFolderItems: '/document-folders/:parentType/:parentID/items',
 
   // fuel-type
   getFuelTypeOthers: '/fuel-type/others/list',

--- a/frontend/src/hooks/useDocumentFolders.ts
+++ b/frontend/src/hooks/useDocumentFolders.ts
@@ -1,0 +1,150 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { apiRoutes } from '@/constants/routes'
+import { useApiService } from '@/services/useApiService'
+
+// Folder layer for the Initiative Agreements module (#4925). The tree,
+// its mutations and placements are keyed together so any change refreshes
+// the whole view in one round trip.
+
+const treeKey = (parentType: string, parentID: number | string) => [
+  'document-tree',
+  parentType,
+  String(parentID)
+]
+
+const fillPath = (
+  template: string,
+  parentType: string,
+  parentID: number | string
+) =>
+  template
+    .replace(':parentType', parentType)
+    .replace(':parentID', String(parentID))
+
+export const useDocumentTree = (
+  parentType: string,
+  parentID: number | string,
+  options: Record<string, unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!parentID,
+    queryKey: treeKey(parentType, parentID),
+    queryFn: async () =>
+      (
+        await client.get(
+          fillPath(apiRoutes.documentFolderTree, parentType, parentID)
+        )
+      ).data,
+    ...options
+  })
+}
+
+const useInvalidateTree = (parentType: string, parentID: number | string) => {
+  const queryClient = useQueryClient()
+  return () =>
+    queryClient.invalidateQueries({ queryKey: treeKey(parentType, parentID) })
+}
+
+export const useCreateFolder = (
+  parentType: string,
+  parentID: number | string
+) => {
+  const client = useApiService()
+  const invalidate = useInvalidateTree(parentType, parentID)
+  return useMutation({
+    mutationFn: async ({
+      name,
+      parentFolderId
+    }: {
+      name: string
+      parentFolderId?: number | null
+    }) =>
+      (
+        await client.post(
+          fillPath(apiRoutes.documentFolderTree, parentType, parentID),
+          { name, parentFolderId: parentFolderId ?? null }
+        )
+      ).data,
+    onSuccess: invalidate
+  })
+}
+
+export const useUpdateFolder = (
+  parentType: string,
+  parentID: number | string
+) => {
+  const client = useApiService()
+  const invalidate = useInvalidateTree(parentType, parentID)
+  return useMutation({
+    mutationFn: async ({
+      folderId,
+      ...payload
+    }: {
+      folderId: number
+      name?: string
+      parentFolderId?: number
+      moveToRoot?: boolean
+      sortOrder?: number
+    }) =>
+      (
+        await client.put(
+          fillPath(
+            apiRoutes.documentFolderUpdate,
+            parentType,
+            parentID
+          ).replace(':folderId', String(folderId)),
+          payload
+        )
+      ).data,
+    onSuccess: invalidate
+  })
+}
+
+export const useDeleteFolder = (
+  parentType: string,
+  parentID: number | string
+) => {
+  const client = useApiService()
+  const invalidate = useInvalidateTree(parentType, parentID)
+  return useMutation({
+    mutationFn: async ({
+      folderId,
+      strategy = 'reparent'
+    }: {
+      folderId: number
+      strategy?: 'reparent' | 'cascade'
+    }) =>
+      client.delete(
+        `${fillPath(
+          apiRoutes.documentFolderUpdate,
+          parentType,
+          parentID
+        ).replace(':folderId', String(folderId))}?strategy=${strategy}`
+      ),
+    onSuccess: invalidate
+  })
+}
+
+export const useMoveDocuments = (
+  parentType: string,
+  parentID: number | string
+) => {
+  const client = useApiService()
+  const invalidate = useInvalidateTree(parentType, parentID)
+  return useMutation({
+    mutationFn: async ({
+      documentIds,
+      folderId
+    }: {
+      documentIds: number[]
+      folderId: number | null
+    }) =>
+      client.put(
+        fillPath(apiRoutes.documentFolderItems, parentType, parentID),
+        { documentIds, folderId }
+      ),
+    onSuccess: invalidate
+  })
+}

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -21,9 +22,7 @@ import Comments from '@/components/Comments'
 import DocumentUploadDialog from '@/components/Documents/DocumentUploadDialog'
 import Loading from '@/components/Loading'
 import { Role } from '@/components/Role'
-import { SupportingDocumentSummary } from '@/views/SupportingDocuments/SupportingDocumentSummary'
 import { roles } from '@/constants/roles'
-import { useDocuments } from '@/hooks/useDocuments'
 import { ROUTES, buildPath } from '@/routes/routes'
 import { dateFormatter } from '@/utils/formatters'
 import withRole from '@/utils/withRole'
@@ -31,6 +30,7 @@ import withRole from '@/utils/withRole'
 import { useDesignatedActionProfile } from '@/hooks/useInitiativeAgreements'
 import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
+import { DocumentTree } from './components/DocumentTree'
 
 // The shared document machinery keys on this string for designated actions.
 const PARENT_TYPE = 'designatedAction'
@@ -68,10 +68,11 @@ const DesignatedActionDetailBase = () => {
     error
   } = useDesignatedActionProfile(designatedActionId)
 
-  const { data: documents, refetch: refetchDocuments } = useDocuments(
-    PARENT_TYPE,
-    designatedActionId
-  )
+  const queryClient = useQueryClient()
+  const refreshTree = () =>
+    queryClient.invalidateQueries({
+      queryKey: ['document-tree', PARENT_TYPE, String(designatedActionId)]
+    })
 
   // Surface the wireframe's action identifier in the breadcrumb.
   const setAgreementCrumb = useInitiativeAgreementPageStore(
@@ -276,18 +277,10 @@ const DesignatedActionDetailBase = () => {
                   </BCTypography>
                 </Role>
               </BCBox>
-              {documents?.length ? (
-                <SupportingDocumentSummary
-                  parentID={designatedActionId}
-                  parentType={PARENT_TYPE}
-                  data={documents}
-                  detailed
-                />
-              ) : (
-                <BCTypography variant="body4" color="text.secondary">
-                  {t('initiativeAgreement:actionDetail.noDocuments')}
-                </BCTypography>
-              )}
+              <DocumentTree
+                parentType={PARENT_TYPE}
+                parentID={designatedActionId}
+              />
             </Paper>
           </BCBox>
         }
@@ -297,7 +290,7 @@ const DesignatedActionDetailBase = () => {
         open={uploadOpen}
         close={() => {
           setUploadOpen(false)
-          refetchDocuments()
+          refreshTree()
         }}
         parentType={PARENT_TYPE}
         parentID={designatedActionId}

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -52,6 +52,10 @@ vi.mock('@/components/Documents/DocumentUploadDialog', () => ({
   default: ({ open }) => (open ? <div data-test="upload-dialog" /> : null)
 }))
 
+vi.mock('../components/DocumentTree', () => ({
+  DocumentTree: () => <div data-test="document-tree" />
+}))
+
 vi.mock('@/components/Comments', () => ({
   default: () => <div data-test="comments-component" />
 }))
@@ -136,6 +140,11 @@ describe('DesignatedActionDetail', () => {
   it('offers document upload to IDIR IA roles only', () => {
     render(<DesignatedActionDetail />, { wrapper })
     expect(screen.getByTestId('upload-documents-button')).toBeInTheDocument()
+  })
+
+  it('renders the folder tree in the documents section', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('document-tree')).toBeInTheDocument()
   })
 
   it('renders the comments thread', () => {

--- a/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
@@ -1,0 +1,321 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip
+} from '@mui/material'
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView'
+import { TreeItem } from '@mui/x-tree-view/TreeItem'
+import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline'
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined'
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import prettyBytes from 'pretty-bytes'
+
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import Loading from '@/components/Loading'
+import { useDownloadDocument } from '@/hooks/useDocuments'
+import {
+  useCreateFolder,
+  useDeleteFolder,
+  useDocumentTree,
+  useUpdateFolder
+} from '@/hooks/useDocumentFolders'
+import { timezoneFormatter } from '@/utils/formatters'
+
+// Folder tree for a designated action's evidence files (#4925, phase 2):
+// nested folders with inline create and rename, delete, and the parent's
+// unplaced documents at the root. Dragging arrives with phase 3.
+
+const NameEditor = ({ initialValue, onCommit, onCancel }) => (
+  <TextField
+    size="small"
+    variant="standard"
+    autoFocus
+    defaultValue={initialValue}
+    inputProps={{ 'data-test': 'folder-name-input' }}
+    onFocus={(event) => event.target.select()}
+    onClick={(event) => event.stopPropagation()}
+    onKeyDown={(event) => {
+      event.stopPropagation()
+      if (event.key === 'Enter') {
+        onCommit(event.target.value)
+      } else if (event.key === 'Escape') {
+        onCancel()
+      }
+    }}
+  />
+)
+
+const FileRow = ({ file, onDownload, government }) => {
+  const { t } = useTranslation(['common'])
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.25 }}
+      data-test={`tree-file-${file.documentId}`}
+    >
+      <InsertDriveFileOutlinedIcon fontSize="small" color="action" />
+      <BCTypography
+        component="span"
+        variant="subtitle2"
+        color="link"
+        onClick={(event) => {
+          event.stopPropagation()
+          onDownload(file.documentId)
+        }}
+        sx={{
+          textDecoration: 'underline',
+          cursor: 'pointer',
+          '&:hover': { color: 'info.main' }
+        }}
+      >
+        {file.fileName}
+      </BCTypography>
+      <BCTypography component="span" variant="subtitle2" color="text.secondary">
+        {prettyBytes(file.fileSize ?? 0)}
+        {' · '}
+        {timezoneFormatter({ value: file.createDate })}
+      </BCTypography>
+    </Box>
+  )
+}
+
+export const DocumentTree = ({ parentType, parentID }) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const { data: tree, isLoading } = useDocumentTree(parentType, parentID)
+  const downloadDocument = useDownloadDocument(parentType, parentID)
+  const { mutate: createFolder } = useCreateFolder(parentType, parentID)
+  const { mutate: updateFolder } = useUpdateFolder(parentType, parentID)
+  const { mutate: deleteFolder } = useDeleteFolder(parentType, parentID)
+
+  // creating: null | { parentFolderId } — an inline editing row.
+  const [creating, setCreating] = useState(null)
+  const [renamingId, setRenamingId] = useState(null)
+  const [menu, setMenu] = useState(null) // { anchorEl, folder }
+
+  if (isLoading) {
+    return <Loading message={t('initiativeAgreement:folders.loading')} />
+  }
+
+  const folders = tree?.folders ?? []
+  const rootDocuments = tree?.rootDocuments ?? []
+
+  const openMenu = (event, folder) => {
+    event.stopPropagation()
+    setMenu({ anchorEl: event.currentTarget, folder })
+  }
+  const closeMenu = () => setMenu(null)
+
+  const commitCreate = (name) => {
+    const trimmed = name.trim()
+    if (trimmed) {
+      createFolder({
+        name: trimmed,
+        parentFolderId: creating?.parentFolderId ?? null
+      })
+    }
+    setCreating(null)
+  }
+
+  const commitRename = (folderId, name) => {
+    const trimmed = name.trim()
+    if (trimmed) {
+      updateFolder({ folderId, name: trimmed })
+    }
+    setRenamingId(null)
+  }
+
+  const renderFolder = (folder) => (
+    <TreeItem
+      key={folder.folderId}
+      itemId={`folder-${folder.folderId}`}
+      label={
+        renamingId === folder.folderId ? (
+          <NameEditor
+            initialValue={folder.name}
+            onCommit={(value) => commitRename(folder.folderId, value)}
+            onCancel={() => setRenamingId(null)}
+          />
+        ) : (
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+            data-test={`tree-folder-${folder.folderId}`}
+            onDoubleClick={(event) => {
+              if (folder.isSystem) return
+              event.stopPropagation()
+              setRenamingId(folder.folderId)
+            }}
+          >
+            <FolderOutlinedIcon fontSize="small" color="action" />
+            <BCTypography component="span" variant="subtitle2">
+              {folder.name}
+            </BCTypography>
+            <BCTypography
+              component="span"
+              variant="subtitle2"
+              color="text.secondary"
+            >
+              ({folder.documentCount})
+            </BCTypography>
+            {!folder.isSystem && (
+              <IconButton
+                size="small"
+                data-test={`folder-menu-${folder.folderId}`}
+                aria-label={t('initiativeAgreement:folders.folderActions')}
+                onClick={(event) => openMenu(event, folder)}
+              >
+                <MoreVertIcon fontSize="inherit" />
+              </IconButton>
+            )}
+          </Box>
+        )
+      }
+    >
+      {folder.children?.map(renderFolder)}
+      {folder.documents?.map((file) => (
+        <TreeItem
+          key={`doc-${file.documentId}`}
+          itemId={`doc-${file.documentId}`}
+          label={<FileRow file={file} onDownload={downloadDocument} />}
+        />
+      ))}
+      {creating?.parentFolderId === folder.folderId && (
+        <TreeItem
+          itemId={`new-under-${folder.folderId}`}
+          label={
+            <NameEditor
+              initialValue={t('initiativeAgreement:folders.newFolderName')}
+              onCommit={commitCreate}
+              onCancel={() => setCreating(null)}
+            />
+          }
+        />
+      )}
+    </TreeItem>
+  )
+
+  return (
+    <BCBox data-test="document-tree">
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <BCTypography
+          component="button"
+          variant="body4"
+          color="link"
+          data-test="new-folder-button"
+          onClick={() => setCreating({ parentFolderId: null })}
+          sx={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            textDecoration: 'underline',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5
+          }}
+        >
+          <CreateNewFolderOutlinedIcon fontSize="small" />
+          {t('initiativeAgreement:folders.newFolder')}
+        </BCTypography>
+      </Box>
+
+      <SimpleTreeView
+        defaultExpandedItems={folders.map((f) => `folder-${f.folderId}`)}
+      >
+        {folders.map(renderFolder)}
+        {creating && creating.parentFolderId === null && (
+          <TreeItem
+            itemId="new-at-root"
+            label={
+              <NameEditor
+                initialValue={t('initiativeAgreement:folders.newFolderName')}
+                onCommit={commitCreate}
+                onCancel={() => setCreating(null)}
+              />
+            }
+          />
+        )}
+        {rootDocuments.map((file) => (
+          <TreeItem
+            key={`doc-${file.documentId}`}
+            itemId={`doc-${file.documentId}`}
+            label={<FileRow file={file} onDownload={downloadDocument} />}
+          />
+        ))}
+      </SimpleTreeView>
+
+      {!folders.length && !rootDocuments.length && !creating && (
+        <BCTypography variant="body4" color="text.secondary">
+          {t('initiativeAgreement:folders.empty')}
+        </BCTypography>
+      )}
+
+      <BCTypography
+        variant="body4"
+        color="text.secondary"
+        component="p"
+        sx={{ mt: 1 }}
+      >
+        {t('initiativeAgreement:folders.helperText')}
+      </BCTypography>
+
+      {/* Focus must land on the inline editor a menu action opens, so the
+          menu must not yank it back to its anchor on close. */}
+      <Menu
+        anchorEl={menu?.anchorEl}
+        open={!!menu}
+        onClose={closeMenu}
+        disableRestoreFocus
+      >
+        <MenuItem
+          data-test="menu-new-subfolder"
+          onClick={() => {
+            setCreating({ parentFolderId: menu.folder.folderId })
+            closeMenu()
+          }}
+        >
+          <ListItemIcon>
+            <CreateNewFolderOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>
+            {t('initiativeAgreement:folders.newSubfolder')}
+          </ListItemText>
+        </MenuItem>
+        <MenuItem
+          data-test="menu-rename"
+          onClick={() => {
+            setRenamingId(menu.folder.folderId)
+            closeMenu()
+          }}
+        >
+          <ListItemIcon>
+            <DriveFileRenameOutlineIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('initiativeAgreement:folders.rename')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          data-test="menu-delete"
+          onClick={() => {
+            deleteFolder({ folderId: menu.folder.folderId })
+            closeMenu()
+          }}
+        >
+          <ListItemIcon>
+            <DeleteOutlineIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('initiativeAgreement:folders.delete')}</ListItemText>
+        </MenuItem>
+      </Menu>
+    </BCBox>
+  )
+}
+
+export default DocumentTree

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DocumentTree } from '../DocumentTree'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+const mockTree = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+vi.mock('@/hooks/useDocumentFolders', () => ({
+  useDocumentTree: () => mockTree(),
+  useCreateFolder: () => ({ mutate: mockCreate }),
+  useUpdateFolder: () => ({ mutate: mockUpdate }),
+  useDeleteFolder: () => ({ mutate: mockDelete }),
+  useMoveDocuments: () => ({ mutate: vi.fn() })
+}))
+
+const mockDownload = vi.fn()
+vi.mock('@/hooks/useDocuments', () => ({
+  useDownloadDocument: () => mockDownload
+}))
+
+const tree = {
+  folders: [
+    {
+      folderId: 12,
+      name: 'Permits & Approvals',
+      parentFolderId: null,
+      sortOrder: 0,
+      isSystem: false,
+      documentCount: 1,
+      documents: [
+        {
+          documentId: 88,
+          fileName: 'permit.pdf',
+          fileSize: 46080,
+          createDate: '2026-05-12T00:00:00Z',
+          createUser: 'LCFS1_bat'
+        }
+      ],
+      children: [
+        {
+          folderId: 13,
+          name: '2026',
+          parentFolderId: 12,
+          sortOrder: 0,
+          isSystem: false,
+          documentCount: 0,
+          documents: [],
+          children: []
+        }
+      ]
+    }
+  ],
+  rootDocuments: [
+    {
+      documentId: 90,
+      fileName: 'root-letter.pdf',
+      fileSize: 2048,
+      createDate: '2026-05-13T00:00:00Z',
+      createUser: 'IDIRSTAFF'
+    }
+  ]
+}
+
+describe('DocumentTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTree.mockReturnValue({ data: tree, isLoading: false })
+  })
+
+  it('renders nested folders with counts and files', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    expect(screen.getByText('Permits & Approvals')).toBeInTheDocument()
+    expect(screen.getByText('(1)')).toBeInTheDocument()
+    expect(screen.getByText('2026')).toBeInTheDocument()
+    expect(screen.getByText('permit.pdf')).toBeInTheDocument()
+    expect(screen.getByText('root-letter.pdf')).toBeInTheDocument()
+  })
+
+  it('downloads a file from its name', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByText('permit.pdf'))
+    expect(mockDownload).toHaveBeenCalledWith(88)
+  })
+
+  it('creates a folder inline with Enter and cancels with Escape', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    fireEvent.click(screen.getByTestId('new-folder-button'))
+    const input = screen.getByTestId('folder-name-input')
+    fireEvent.change(input, { target: { value: 'Signed agreements' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'Signed agreements',
+      parentFolderId: null
+    })
+
+    fireEvent.click(screen.getByTestId('new-folder-button'))
+    const second = screen.getByTestId('folder-name-input')
+    fireEvent.keyDown(second, { key: 'Escape' })
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('renames a folder from its menu', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    fireEvent.click(screen.getByTestId('folder-menu-12'))
+    fireEvent.click(screen.getByTestId('menu-rename'))
+    const input = screen.getByTestId('folder-name-input')
+    fireEvent.change(input, { target: { value: 'Approvals' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockUpdate).toHaveBeenCalledWith({ folderId: 12, name: 'Approvals' })
+  })
+
+  it('deletes a folder with the default reparent strategy', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    fireEvent.click(screen.getByTestId('folder-menu-12'))
+    fireEvent.click(screen.getByTestId('menu-delete'))
+
+    expect(mockDelete).toHaveBeenCalledWith({ folderId: 12 })
+  })
+
+  it('creates a subfolder under the menu folder', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    fireEvent.click(screen.getByTestId('folder-menu-12'))
+    fireEvent.click(screen.getByTestId('menu-new-subfolder'))
+    const input = screen.getByTestId('folder-name-input')
+    fireEvent.change(input, { target: { value: 'Evidence' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'Evidence',
+      parentFolderId: 12
+    })
+  })
+
+  it('shows the empty state', () => {
+    mockTree.mockReturnValue({
+      data: { folders: [], rootDocuments: [] },
+      isLoading: false
+    })
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    expect(
+      screen.getByText('initiativeAgreement:folders.empty')
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of document folders (#4925): the tree UI on the designated action page. Phase 1 (the backend layer, #4946) shipped dark; this makes it visible. Dragging is phase 3.

The action's documents card now renders as a tree:

- **Nested folders** with rolled-up document counts; files show size and upload date, and download from their name.
- **Inline create and rename** — "New folder" and the kebab's "New subfolder" insert an editing row in place, text pre-selected; Enter commits, Escape cancels; double-click any folder name to rename. No dialogs.
- **Delete** uses the backend's reparent strategy — contents move up one level, nothing is ever lost.
- Unplaced files sit at the root, so everything uploaded before folders existed is already where you'd expect.

Upload stays with the existing dialog (the design's two-call option A); closing it refreshes the tree.

### Notes for a reviewer

**The one new dependency is `@mui/x-tree-view` pinned to `^7`.** v8 declares a peer of `@mui/material` v7+ and will not install against this repo's v6. The community tree view is enough because phase 3's dragging uses dnd-kit — already a dependency — rather than the tree view's paid Pro reordering, per the design's licensing finding.

**Focus handling has two deliberate choices.** The kebab menu sets `disableRestoreFocus` so an inline editor it opens keeps focus rather than having it yanked back to the anchor; and blur does not cancel an edit — the tree's focus management races the editor mount, and the design specifies Enter/Escape as the contract.

**No shared component changed.** `DocumentTable`, `SupportingDocumentSummary`, `useDocuments` and the upload dialog are untouched; the tree has its own hooks file keyed `['document-tree', parentType, parentID]`.

### Testing

7 tests on the tree (nesting and counts, download, inline create via keyboard with cancel, rename and subfolder from the menu, reparent delete, empty state) plus the page integration — 43 pass across the module's suites. Type-check unchanged.

Refs #4925
