### PR TITLE
Feat: Folder tree drag and drop - 4925

### DIFF
--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -102,6 +102,13 @@
     "folderActions": "Folder actions",
     "loading": "Loading documents...",
     "empty": "No documents or folders yet.",
-    "helperText": "Double-click any name to rename. Deleting a folder moves its contents up one level."
+    "helperText": "Double-click any name to rename. Drag files into folders. Deleting a folder moves its contents up one level.",
+    "uploadHere": "Upload here",
+    "dropToRoot": "Drop here to move out of all folders",
+    "moved": "Moved {{count}} file(s)",
+    "movedFolder": "Moved folder",
+    "undo": "Undo",
+    "draggingFiles": "{{count}} file(s)",
+    "draggingFolder": "Folder"
   }
 }

--- a/frontend/src/hooks/useDocumentFolders.ts
+++ b/frontend/src/hooks/useDocumentFolders.ts
@@ -76,7 +76,8 @@ export const useUpdateFolder = (
   parentID: number | string
 ) => {
   const client = useApiService()
-  const invalidate = useInvalidateTree(parentType, parentID)
+  const queryClient = useQueryClient()
+  const key = treeKey(parentType, parentID)
   return useMutation({
     mutationFn: async ({
       folderId,
@@ -98,7 +99,35 @@ export const useUpdateFolder = (
           payload
         )
       ).data,
-    onSuccess: invalidate
+    // A drag that visibly waits on a round trip reads as broken, so
+    // folder moves apply optimistically and roll back on error.
+    onMutate: async (variables) => {
+      if (variables.parentFolderId === undefined && !variables.moveToRoot) {
+        return {}
+      }
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData(key)
+      if (previous) {
+        const { applyFolderMove } = await import(
+          '@/views/InitiativeAgreements/components/documentTreeDnd'
+        )
+        queryClient.setQueryData(
+          key,
+          applyFolderMove(
+            previous,
+            variables.folderId,
+            variables.moveToRoot ? null : variables.parentFolderId
+          )
+        )
+      }
+      return { previous }
+    },
+    onError: (_error, _variables, context: any) => {
+      if (context?.previous) {
+        queryClient.setQueryData(key, context.previous)
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: key })
   })
 }
 
@@ -132,7 +161,8 @@ export const useMoveDocuments = (
   parentID: number | string
 ) => {
   const client = useApiService()
-  const invalidate = useInvalidateTree(parentType, parentID)
+  const queryClient = useQueryClient()
+  const key = treeKey(parentType, parentID)
   return useMutation({
     mutationFn: async ({
       documentIds,
@@ -145,6 +175,71 @@ export const useMoveDocuments = (
         fillPath(apiRoutes.documentFolderItems, parentType, parentID),
         { documentIds, folderId }
       ),
-    onSuccess: invalidate
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData(key)
+      if (previous) {
+        const { applyDocumentMove } = await import(
+          '@/views/InitiativeAgreements/components/documentTreeDnd'
+        )
+        queryClient.setQueryData(
+          key,
+          applyDocumentMove(previous, variables.documentIds, variables.folderId)
+        )
+      }
+      return { previous }
+    },
+    onError: (_error, _variables, context: any) => {
+      if (context?.previous) {
+        queryClient.setQueryData(key, context.previous)
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: key })
+  })
+}
+
+/**
+ * Upload files straight into a folder: the shared upload route first, then
+ * one placement call — the design's two-call pattern, so the upload path
+ * itself stays untouched. A failure between the calls leaves the file at
+ * the root: visible and fixable by dragging.
+ */
+export const useFolderUpload = (
+  parentType: string,
+  parentID: number | string
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  const key = treeKey(parentType, parentID)
+  return useMutation({
+    mutationFn: async ({
+      files,
+      folderId
+    }: {
+      files: File[]
+      folderId: number | null
+    }) => {
+      const uploadPath = apiRoutes.getDocuments
+        .replace(':parentType', parentType)
+        .replace(':parentID', String(parentID))
+      const documentIds: number[] = []
+      for (const file of files) {
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('filename', file.name)
+        const response = await client.post(uploadPath, formData, {
+          headers: { 'Content-Type': 'multipart/form-data' }
+        })
+        documentIds.push(response.data.documentId)
+      }
+      if (folderId !== null && documentIds.length) {
+        await client.put(
+          fillPath(apiRoutes.documentFolderItems, parentType, parentID),
+          { documentIds, folderId }
+        )
+      }
+      return documentIds
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: key })
   })
 }

--- a/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
@@ -1,23 +1,35 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
+  Button,
   IconButton,
   ListItemIcon,
   ListItemText,
   Menu,
   MenuItem,
-  TextField,
-  Tooltip
+  Snackbar,
+  TextField
 } from '@mui/material'
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView'
 import { TreeItem } from '@mui/x-tree-view/TreeItem'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
 import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline'
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined'
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined'
 import prettyBytes from 'pretty-bytes'
 
 import BCBox from '@/components/BCBox'
@@ -28,13 +40,26 @@ import {
   useCreateFolder,
   useDeleteFolder,
   useDocumentTree,
+  useFolderUpload,
+  useMoveDocuments,
   useUpdateFolder
 } from '@/hooks/useDocumentFolders'
 import { timezoneFormatter } from '@/utils/formatters'
+import {
+  ROOT_DROP_ID,
+  collectDescendantFolderIds,
+  docDragId,
+  folderDragId,
+  invertDocumentMove,
+  resolveDrop
+} from './documentTreeDnd'
 
-// Folder tree for a designated action's evidence files (#4925, phase 2):
-// nested folders with inline create and rename, delete, and the parent's
-// unplaced documents at the root. Dragging arrives with phase 3.
+// Folder tree for a designated action's evidence files (#4925). Phase 3
+// adds dragging: files and folders move by pointer, multi-selections
+// travel as one unit, OS file drops upload into the target folder, and
+// every move offers an undo.
+
+const AUTO_EXPAND_MS = 700
 
 const NameEditor = ({ initialValue, onCommit, onCancel }) => (
   <TextField
@@ -56,11 +81,22 @@ const NameEditor = ({ initialValue, onCommit, onCancel }) => (
   />
 )
 
-const FileRow = ({ file, onDownload, government }) => {
-  const { t } = useTranslation(['common'])
+const FileLabel = ({ file, onDownload }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: docDragId(file.documentId)
+  })
   return (
     <Box
-      sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.25 }}
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        py: 0.25,
+        opacity: isDragging ? 0.4 : 1
+      }}
       data-test={`tree-file-${file.documentId}`}
     >
       <InsertDriveFileOutlinedIcon fontSize="small" color="action" />
@@ -89,6 +125,132 @@ const FileRow = ({ file, onDownload, government }) => {
   )
 }
 
+const FolderLabel = ({
+  folder,
+  invalid,
+  renaming,
+  onCommitRename,
+  onCancelRename,
+  onOpenMenu,
+  onStartRename,
+  onOsFileDrop,
+  externalDragSuppressed
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging
+  } = useDraggable({
+    id: folderDragId(folder.folderId),
+    disabled: folder.isSystem
+  })
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: folderDragId(folder.folderId),
+    disabled: invalid
+  })
+  const [osDragOver, setOsDragOver] = useState(false)
+
+  if (renaming) {
+    return (
+      <NameEditor
+        initialValue={folder.name}
+        onCommit={onCommitRename}
+        onCancel={onCancelRename}
+      />
+    )
+  }
+
+  const isExternalFileDrag = (event) =>
+    !externalDragSuppressed &&
+    Array.from(event.dataTransfer?.types ?? []).includes('Files')
+
+  return (
+    <Box
+      ref={(node) => {
+        setDragRef(node)
+        setDropRef(node)
+      }}
+      {...attributes}
+      {...listeners}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        borderRadius: 1,
+        px: 0.5,
+        opacity: invalid || isDragging ? 0.4 : 1,
+        bgcolor: isOver || osDragOver ? 'action.selected' : 'transparent'
+      }}
+      data-test={`tree-folder-${folder.folderId}`}
+      onDoubleClick={(event) => {
+        if (folder.isSystem) return
+        event.stopPropagation()
+        onStartRename()
+      }}
+      onDragEnter={(event) => {
+        if (isExternalFileDrag(event)) {
+          event.preventDefault()
+          setOsDragOver(true)
+        }
+      }}
+      onDragOver={(event) => {
+        if (isExternalFileDrag(event)) event.preventDefault()
+      }}
+      onDragLeave={() => setOsDragOver(false)}
+      onDrop={(event) => {
+        if (isExternalFileDrag(event)) {
+          event.preventDefault()
+          setOsDragOver(false)
+          onOsFileDrop(Array.from(event.dataTransfer.files))
+        }
+      }}
+    >
+      <FolderOutlinedIcon fontSize="small" color="action" />
+      <BCTypography component="span" variant="subtitle2">
+        {folder.name}
+      </BCTypography>
+      <BCTypography component="span" variant="subtitle2" color="text.secondary">
+        ({folder.documentCount})
+      </BCTypography>
+      {!folder.isSystem && (
+        <IconButton
+          size="small"
+          data-test={`folder-menu-${folder.folderId}`}
+          aria-label="folder actions"
+          onClick={onOpenMenu}
+        >
+          <MoreVertIcon fontSize="inherit" />
+        </IconButton>
+      )}
+    </Box>
+  )
+}
+
+const RootDropZone = ({ visible, label }) => {
+  const { setNodeRef, isOver } = useDroppable({ id: ROOT_DROP_ID })
+  if (!visible) return null
+  return (
+    <Box
+      ref={setNodeRef}
+      data-test="root-drop-zone"
+      sx={{
+        mt: 1,
+        p: 1,
+        border: '1px dashed',
+        borderColor: isOver ? 'primary.main' : 'divider',
+        borderRadius: 1,
+        bgcolor: isOver ? 'action.selected' : 'transparent',
+        textAlign: 'center'
+      }}
+    >
+      <BCTypography variant="body4" color="text.secondary">
+        {label}
+      </BCTypography>
+    </Box>
+  )
+}
+
 export const DocumentTree = ({ parentType, parentID }) => {
   const { t } = useTranslation(['common', 'initiativeAgreement'])
   const { data: tree, isLoading } = useDocumentTree(parentType, parentID)
@@ -96,11 +258,32 @@ export const DocumentTree = ({ parentType, parentID }) => {
   const { mutate: createFolder } = useCreateFolder(parentType, parentID)
   const { mutate: updateFolder } = useUpdateFolder(parentType, parentID)
   const { mutate: deleteFolder } = useDeleteFolder(parentType, parentID)
+  const { mutate: moveDocuments } = useMoveDocuments(parentType, parentID)
+  const { mutate: uploadToFolder } = useFolderUpload(parentType, parentID)
 
-  // creating: null | { parentFolderId } — an inline editing row.
   const [creating, setCreating] = useState(null)
   const [renamingId, setRenamingId] = useState(null)
-  const [menu, setMenu] = useState(null) // { anchorEl, folder }
+  const [menu, setMenu] = useState(null)
+  const [selectedItems, setSelectedItems] = useState([])
+  const [expandedItems, setExpandedItems] = useState([])
+  const seededExpansion = useRef(false)
+  const [dragState, setDragState] = useState(null) // { activeId, invalid: Set }
+  const [undo, setUndo] = useState(null) // { message, run }
+  const hoverTimer = useRef(null)
+  const uploadInputRef = useRef(null)
+  const uploadTargetRef = useRef(null)
+
+  const sensors = useSensors(
+    // A few pixels of slack so click-to-download never starts a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  )
+
+  useEffect(() => {
+    if (!seededExpansion.current && tree?.folders?.length) {
+      setExpandedItems(tree.folders.map((f) => `folder-${f.folderId}`))
+      seededExpansion.current = true
+    }
+  }, [tree])
 
   if (isLoading) {
     return <Loading message={t('initiativeAgreement:folders.loading')} />
@@ -108,6 +291,10 @@ export const DocumentTree = ({ parentType, parentID }) => {
 
   const folders = tree?.folders ?? []
   const rootDocuments = tree?.rootDocuments ?? []
+
+  const selectedDocumentIds = selectedItems
+    .filter((id) => id.startsWith('doc-'))
+    .map((id) => Number(id.slice(4)))
 
   const openMenu = (event, folder) => {
     event.stopPropagation()
@@ -134,50 +321,137 @@ export const DocumentTree = ({ parentType, parentID }) => {
     setRenamingId(null)
   }
 
+  const runDocumentMove = (documentIds, folderId) => {
+    const inverse = invertDocumentMove(tree, documentIds)
+    moveDocuments(
+      { documentIds, folderId },
+      {
+        onSuccess: () => {
+          setUndo({
+            message: t('initiativeAgreement:folders.moved', {
+              count: documentIds.length
+            }),
+            run: () =>
+              inverse.forEach((group) =>
+                moveDocuments({
+                  documentIds: group.documentIds,
+                  folderId: group.folderId
+                })
+              )
+          })
+        }
+      }
+    )
+  }
+
+  const handleDragStart = (event) => {
+    const activeId = String(event.active.id)
+    let invalid = new Set()
+    if (activeId.startsWith('folder-')) {
+      const folderId = Number(activeId.slice(7))
+      invalid = collectDescendantFolderIds(folders, folderId)
+      invalid.add(folderId)
+    }
+    setDragState({ activeId, invalid })
+  }
+
+  const handleDragOver = (event) => {
+    const overId = event.over ? String(event.over.id) : null
+    clearTimeout(hoverTimer.current)
+    if (overId?.startsWith('folder-')) {
+      // A collapsed folder should not be a two-step target.
+      hoverTimer.current = setTimeout(() => {
+        setExpandedItems((current) =>
+          current.includes(overId) ? current : [...current, overId]
+        )
+      }, AUTO_EXPAND_MS)
+    }
+  }
+
+  const handleDragEnd = (event) => {
+    clearTimeout(hoverTimer.current)
+    setDragState(null)
+    const descriptor = resolveDrop({
+      activeId: String(event.active.id),
+      overId: event.over ? String(event.over.id) : null,
+      tree,
+      selectedDocumentIds
+    })
+    if (!descriptor) return
+    if (descriptor.type === 'moveDocuments') {
+      runDocumentMove(descriptor.documentIds, descriptor.folderId)
+    } else if (descriptor.type === 'moveFolder') {
+      const previousParent =
+        folders && descriptor.folderId
+          ? (function find(list) {
+              for (const folder of list) {
+                if (folder.folderId === descriptor.folderId) {
+                  return folder.parentFolderId ?? null
+                }
+                const nested = find(folder.children ?? [])
+                if (nested !== undefined) return nested
+              }
+              return undefined
+            })(folders)
+          : null
+      updateFolder(
+        descriptor.parentFolderId === null
+          ? { folderId: descriptor.folderId, moveToRoot: true }
+          : {
+              folderId: descriptor.folderId,
+              parentFolderId: descriptor.parentFolderId
+            },
+        {
+          onSuccess: () => {
+            setUndo({
+              message: t('initiativeAgreement:folders.movedFolder'),
+              run: () =>
+                updateFolder(
+                  previousParent === null
+                    ? { folderId: descriptor.folderId, moveToRoot: true }
+                    : {
+                        folderId: descriptor.folderId,
+                        parentFolderId: previousParent
+                      }
+                )
+            })
+          }
+        }
+      )
+    }
+  }
+
+  const startUploadHere = (folderId) => {
+    uploadTargetRef.current = folderId
+    uploadInputRef.current?.click()
+  }
+
+  const handleUploadInput = (event) => {
+    const files = Array.from(event.target.files ?? [])
+    if (files.length) {
+      uploadToFolder({ files, folderId: uploadTargetRef.current ?? null })
+    }
+    event.target.value = ''
+  }
+
   const renderFolder = (folder) => (
     <TreeItem
       key={folder.folderId}
       itemId={`folder-${folder.folderId}`}
       label={
-        renamingId === folder.folderId ? (
-          <NameEditor
-            initialValue={folder.name}
-            onCommit={(value) => commitRename(folder.folderId, value)}
-            onCancel={() => setRenamingId(null)}
-          />
-        ) : (
-          <Box
-            sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-            data-test={`tree-folder-${folder.folderId}`}
-            onDoubleClick={(event) => {
-              if (folder.isSystem) return
-              event.stopPropagation()
-              setRenamingId(folder.folderId)
-            }}
-          >
-            <FolderOutlinedIcon fontSize="small" color="action" />
-            <BCTypography component="span" variant="subtitle2">
-              {folder.name}
-            </BCTypography>
-            <BCTypography
-              component="span"
-              variant="subtitle2"
-              color="text.secondary"
-            >
-              ({folder.documentCount})
-            </BCTypography>
-            {!folder.isSystem && (
-              <IconButton
-                size="small"
-                data-test={`folder-menu-${folder.folderId}`}
-                aria-label={t('initiativeAgreement:folders.folderActions')}
-                onClick={(event) => openMenu(event, folder)}
-              >
-                <MoreVertIcon fontSize="inherit" />
-              </IconButton>
-            )}
-          </Box>
-        )
+        <FolderLabel
+          folder={folder}
+          invalid={dragState?.invalid?.has(folder.folderId) ?? false}
+          renaming={renamingId === folder.folderId}
+          onCommitRename={(value) => commitRename(folder.folderId, value)}
+          onCancelRename={() => setRenamingId(null)}
+          onOpenMenu={(event) => openMenu(event, folder)}
+          onStartRename={() => setRenamingId(folder.folderId)}
+          onOsFileDrop={(files) =>
+            uploadToFolder({ files, folderId: folder.folderId })
+          }
+          externalDragSuppressed={!!dragState}
+        />
       }
     >
       {folder.children?.map(renderFolder)}
@@ -185,7 +459,7 @@ export const DocumentTree = ({ parentType, parentID }) => {
         <TreeItem
           key={`doc-${file.documentId}`}
           itemId={`doc-${file.documentId}`}
-          label={<FileRow file={file} onDownload={downloadDocument} />}
+          label={<FileLabel file={file} onDownload={downloadDocument} />}
         />
       ))}
       {creating?.parentFolderId === folder.folderId && (
@@ -202,6 +476,19 @@ export const DocumentTree = ({ parentType, parentID }) => {
       )}
     </TreeItem>
   )
+
+  const activeDragLabel = () => {
+    if (!dragState) return null
+    if (dragState.activeId.startsWith('doc-')) {
+      const count = selectedDocumentIds.includes(
+        Number(dragState.activeId.slice(4))
+      )
+        ? selectedDocumentIds.length
+        : 1
+      return t('initiativeAgreement:folders.draggingFiles', { count })
+    }
+    return t('initiativeAgreement:folders.draggingFolder')
+  }
 
   return (
     <BCBox data-test="document-tree">
@@ -227,30 +514,73 @@ export const DocumentTree = ({ parentType, parentID }) => {
         </BCTypography>
       </Box>
 
-      <SimpleTreeView
-        defaultExpandedItems={folders.map((f) => `folder-${f.folderId}`)}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => {
+          clearTimeout(hoverTimer.current)
+          setDragState(null)
+        }}
       >
-        {folders.map(renderFolder)}
-        {creating && creating.parentFolderId === null && (
-          <TreeItem
-            itemId="new-at-root"
-            label={
-              <NameEditor
-                initialValue={t('initiativeAgreement:folders.newFolderName')}
-                onCommit={commitCreate}
-                onCancel={() => setCreating(null)}
-              />
-            }
-          />
-        )}
-        {rootDocuments.map((file) => (
-          <TreeItem
-            key={`doc-${file.documentId}`}
-            itemId={`doc-${file.documentId}`}
-            label={<FileRow file={file} onDownload={downloadDocument} />}
-          />
-        ))}
-      </SimpleTreeView>
+        <SimpleTreeView
+          multiSelect
+          selectedItems={selectedItems}
+          onSelectedItemsChange={(_event, items) =>
+            setSelectedItems(Array.isArray(items) ? items : [items])
+          }
+          expandedItems={expandedItems}
+          onExpandedItemsChange={(_event, items) => setExpandedItems(items)}
+        >
+          {folders.map(renderFolder)}
+          {creating && creating.parentFolderId === null && (
+            <TreeItem
+              itemId="new-at-root"
+              label={
+                <NameEditor
+                  initialValue={t('initiativeAgreement:folders.newFolderName')}
+                  onCommit={commitCreate}
+                  onCancel={() => setCreating(null)}
+                />
+              }
+            />
+          )}
+          {rootDocuments.map((file) => (
+            <TreeItem
+              key={`doc-${file.documentId}`}
+              itemId={`doc-${file.documentId}`}
+              label={<FileLabel file={file} onDownload={downloadDocument} />}
+            />
+          ))}
+        </SimpleTreeView>
+
+        <RootDropZone
+          visible={!!dragState}
+          label={t('initiativeAgreement:folders.dropToRoot')}
+        />
+
+        <DragOverlay>
+          {dragState ? (
+            <Box
+              sx={{
+                px: 1.5,
+                py: 0.5,
+                bgcolor: 'background.paper',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                boxShadow: 2
+              }}
+            >
+              <BCTypography variant="subtitle2">
+                {activeDragLabel()}
+              </BCTypography>
+            </Box>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
 
       {!folders.length && !rootDocuments.length && !creating && (
         <BCTypography variant="body4" color="text.secondary">
@@ -266,6 +596,15 @@ export const DocumentTree = ({ parentType, parentID }) => {
       >
         {t('initiativeAgreement:folders.helperText')}
       </BCTypography>
+
+      <input
+        ref={uploadInputRef}
+        type="file"
+        multiple
+        hidden
+        data-test="folder-upload-input"
+        onChange={handleUploadInput}
+      />
 
       {/* Focus must land on the inline editor a menu action opens, so the
           menu must not yank it back to its anchor on close. */}
@@ -287,6 +626,20 @@ export const DocumentTree = ({ parentType, parentID }) => {
           </ListItemIcon>
           <ListItemText>
             {t('initiativeAgreement:folders.newSubfolder')}
+          </ListItemText>
+        </MenuItem>
+        <MenuItem
+          data-test="menu-upload-here"
+          onClick={() => {
+            startUploadHere(menu.folder.folderId)
+            closeMenu()
+          }}
+        >
+          <ListItemIcon>
+            <UploadFileOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>
+            {t('initiativeAgreement:folders.uploadHere')}
           </ListItemText>
         </MenuItem>
         <MenuItem
@@ -314,6 +667,27 @@ export const DocumentTree = ({ parentType, parentID }) => {
           <ListItemText>{t('initiativeAgreement:folders.delete')}</ListItemText>
         </MenuItem>
       </Menu>
+
+      <Snackbar
+        open={!!undo}
+        autoHideDuration={6000}
+        onClose={() => setUndo(null)}
+        message={undo?.message}
+        data-test="move-undo-toast"
+        action={
+          <Button
+            color="secondary"
+            size="small"
+            data-test="undo-move-button"
+            onClick={() => {
+              undo?.run()
+              setUndo(null)
+            }}
+          >
+            {t('initiativeAgreement:folders.undo')}
+          </Button>
+        }
+      />
     </BCBox>
   )
 }

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
@@ -12,12 +12,15 @@ const mockTree = vi.fn()
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 const mockDelete = vi.fn()
+const mockMove = vi.fn()
+const mockUpload = vi.fn()
 vi.mock('@/hooks/useDocumentFolders', () => ({
   useDocumentTree: () => mockTree(),
   useCreateFolder: () => ({ mutate: mockCreate }),
   useUpdateFolder: () => ({ mutate: mockUpdate }),
   useDeleteFolder: () => ({ mutate: mockDelete }),
-  useMoveDocuments: () => ({ mutate: vi.fn() })
+  useMoveDocuments: () => ({ mutate: mockMove }),
+  useFolderUpload: () => ({ mutate: mockUpload })
 }))
 
 const mockDownload = vi.fn()
@@ -155,6 +158,21 @@ describe('DocumentTree', () => {
       name: 'Evidence',
       parentFolderId: 12
     })
+  })
+
+  it('uploads into a folder from the menu', () => {
+    render(<DocumentTree parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    fireEvent.click(screen.getByTestId('folder-menu-12'))
+    fireEvent.click(screen.getByTestId('menu-upload-here'))
+
+    const input = screen.getByTestId('folder-upload-input')
+    const file = new File(['x'], 'evidence.pdf', { type: 'application/pdf' })
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(mockUpload).toHaveBeenCalledWith({ files: [file], folderId: 12 })
   })
 
   it('shows the empty state', () => {

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/documentTreeDnd.test.js
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/documentTreeDnd.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDocumentMove,
+  applyFolderMove,
+  collectDescendantFolderIds,
+  findFolderOfDocument,
+  invertDocumentMove,
+  resolveDrop
+} from '../documentTreeDnd'
+
+const doc = (documentId, fileName = `${documentId}.pdf`) => ({
+  documentId,
+  fileName,
+  fileSize: 1,
+  createDate: null,
+  createUser: null
+})
+
+const tree = {
+  folders: [
+    {
+      folderId: 1,
+      name: 'Top',
+      parentFolderId: null,
+      sortOrder: 0,
+      isSystem: false,
+      documentCount: 2,
+      documents: [doc(10)],
+      children: [
+        {
+          folderId: 2,
+          name: 'Middle',
+          parentFolderId: 1,
+          sortOrder: 0,
+          isSystem: false,
+          documentCount: 1,
+          documents: [doc(11)],
+          children: []
+        }
+      ]
+    },
+    {
+      folderId: 3,
+      name: 'Other',
+      parentFolderId: null,
+      sortOrder: 0,
+      isSystem: false,
+      documentCount: 0,
+      documents: [],
+      children: []
+    }
+  ],
+  rootDocuments: [doc(12)]
+}
+
+describe('documentTreeDnd', () => {
+  it('collects descendants of a folder', () => {
+    expect(collectDescendantFolderIds(tree.folders, 1)).toEqual(new Set([2]))
+    expect(collectDescendantFolderIds(tree.folders, 3)).toEqual(new Set())
+  })
+
+  it('finds the folder a document sits in', () => {
+    expect(findFolderOfDocument(tree, 11)).toBe(2)
+    expect(findFolderOfDocument(tree, 12)).toBeNull()
+  })
+
+  it('resolves a file dropped on a folder', () => {
+    expect(
+      resolveDrop({ activeId: 'doc-12', overId: 'folder-2', tree })
+    ).toEqual({ type: 'moveDocuments', documentIds: [12], folderId: 2 })
+  })
+
+  it('drags a multi-selection as one unit when the dragged file is in it', () => {
+    expect(
+      resolveDrop({
+        activeId: 'doc-10',
+        overId: 'folder-3',
+        tree,
+        selectedDocumentIds: [10, 12]
+      })
+    ).toEqual({ type: 'moveDocuments', documentIds: [10, 12], folderId: 3 })
+
+    // A drag of an unselected file ignores the selection.
+    expect(
+      resolveDrop({
+        activeId: 'doc-11',
+        overId: 'folder-3',
+        tree,
+        selectedDocumentIds: [10, 12]
+      })
+    ).toEqual({ type: 'moveDocuments', documentIds: [11], folderId: 3 })
+  })
+
+  it('resolves a file dropped on the root zone', () => {
+    expect(resolveDrop({ activeId: 'doc-11', overId: 'root', tree })).toEqual({
+      type: 'moveDocuments',
+      documentIds: [11],
+      folderId: null
+    })
+  })
+
+  it('ignores a drop that changes nothing', () => {
+    expect(resolveDrop({ activeId: 'doc-12', overId: 'root', tree })).toBeNull()
+    expect(
+      resolveDrop({ activeId: 'doc-11', overId: 'folder-2', tree })
+    ).toBeNull()
+  })
+
+  it('resolves a folder move and refuses cycles', () => {
+    expect(
+      resolveDrop({ activeId: 'folder-2', overId: 'folder-3', tree })
+    ).toEqual({ type: 'moveFolder', folderId: 2, parentFolderId: 3 })
+    expect(resolveDrop({ activeId: 'folder-2', overId: 'root', tree })).toEqual(
+      { type: 'moveFolder', folderId: 2, parentFolderId: null }
+    )
+    // Into itself or its own subtree: refused.
+    expect(
+      resolveDrop({ activeId: 'folder-1', overId: 'folder-2', tree })
+    ).toBeNull()
+    expect(
+      resolveDrop({ activeId: 'folder-1', overId: 'folder-1', tree })
+    ).toBeNull()
+    // Into its current parent: nothing changes.
+    expect(
+      resolveDrop({ activeId: 'folder-2', overId: 'folder-1', tree })
+    ).toBeNull()
+  })
+
+  it('applies a document move optimistically with recomputed counts', () => {
+    const next = applyDocumentMove(tree, [12], 2)
+    const top = next.folders.find((f) => f.folderId === 1)
+    const middle = top.children[0]
+    expect(middle.documents.map((d) => d.documentId)).toEqual([11, 12])
+    expect(middle.documentCount).toBe(2)
+    expect(top.documentCount).toBe(3)
+    expect(next.rootDocuments).toEqual([])
+  })
+
+  it('applies a move to root optimistically', () => {
+    const next = applyDocumentMove(tree, [11], null)
+    const top = next.folders.find((f) => f.folderId === 1)
+    expect(top.children[0].documents).toEqual([])
+    expect(top.documentCount).toBe(1)
+    expect(next.rootDocuments.map((d) => d.documentId)).toEqual([12, 11])
+  })
+
+  it('applies a folder move optimistically', () => {
+    const next = applyFolderMove(tree, 2, 3)
+    const top = next.folders.find((f) => f.folderId === 1)
+    const other = next.folders.find((f) => f.folderId === 3)
+    expect(top.children).toEqual([])
+    expect(other.children.map((f) => f.folderId)).toEqual([2])
+    expect(other.documentCount).toBe(1)
+    expect(top.documentCount).toBe(1)
+  })
+
+  it('inverts a move back to each previous folder', () => {
+    expect(invertDocumentMove(tree, [10, 11, 12])).toEqual([
+      { folderId: 1, documentIds: [10] },
+      { folderId: 2, documentIds: [11] },
+      { folderId: null, documentIds: [12] }
+    ])
+  })
+})

--- a/frontend/src/views/InitiativeAgreements/components/documentTreeDnd.js
+++ b/frontend/src/views/InitiativeAgreements/components/documentTreeDnd.js
@@ -1,0 +1,194 @@
+// Pure logic for the folder tree's drag and drop (#4925, phase 3).
+// Kept free of React so the interesting decisions — what a drop means,
+// which targets are legal, how the tree transforms optimistically — are
+// unit-testable without simulating pointer gestures.
+
+export const DOC_PREFIX = 'doc-'
+export const FOLDER_PREFIX = 'folder-'
+export const ROOT_DROP_ID = 'root'
+
+export const docDragId = (documentId) => `${DOC_PREFIX}${documentId}`
+export const folderDragId = (folderId) => `${FOLDER_PREFIX}${folderId}`
+
+const parseId = (id) => {
+  if (id === ROOT_DROP_ID) return { kind: 'root' }
+  if (String(id).startsWith(DOC_PREFIX)) {
+    return { kind: 'doc', id: Number(String(id).slice(DOC_PREFIX.length)) }
+  }
+  if (String(id).startsWith(FOLDER_PREFIX)) {
+    return {
+      kind: 'folder',
+      id: Number(String(id).slice(FOLDER_PREFIX.length))
+    }
+  }
+  return { kind: 'unknown' }
+}
+
+export const flattenFolders = (folders, acc = []) => {
+  for (const folder of folders ?? []) {
+    acc.push(folder)
+    flattenFolders(folder.children, acc)
+  }
+  return acc
+}
+
+export const collectDescendantFolderIds = (folders, folderId) => {
+  const byParent = new Map()
+  for (const folder of flattenFolders(folders)) {
+    const key = folder.parentFolderId ?? null
+    if (!byParent.has(key)) byParent.set(key, [])
+    byParent.get(key).push(folder.folderId)
+  }
+  const result = new Set()
+  const frontier = [folderId]
+  while (frontier.length) {
+    const current = frontier.pop()
+    for (const child of byParent.get(current) ?? []) {
+      result.add(child)
+      frontier.push(child)
+    }
+  }
+  return result
+}
+
+export const findFolderOfDocument = (tree, documentId) => {
+  for (const folder of flattenFolders(tree?.folders)) {
+    if (folder.documents?.some((d) => d.documentId === documentId)) {
+      return folder.folderId
+    }
+  }
+  return null
+}
+
+/**
+ * Translate a finished drag into a mutation descriptor, or null when the
+ * drop changes nothing or is illegal (a folder into itself or its own
+ * subtree). selectedDocumentIds lets a multi-selection travel as one unit
+ * when the dragged file is part of it.
+ */
+export const resolveDrop = ({
+  activeId,
+  overId,
+  tree,
+  selectedDocumentIds = []
+}) => {
+  if (!overId) return null
+  const active = parseId(activeId)
+  const over = parseId(overId)
+  const targetFolderId =
+    over.kind === 'root' ? null : over.kind === 'folder' ? over.id : null
+  if (over.kind === 'doc' || over.kind === 'unknown') return null
+
+  if (active.kind === 'doc') {
+    const documentIds = selectedDocumentIds.includes(active.id)
+      ? selectedDocumentIds
+      : [active.id]
+    const unmoved = documentIds.every(
+      (id) => findFolderOfDocument(tree, id) === targetFolderId
+    )
+    if (unmoved) return null
+    return { type: 'moveDocuments', documentIds, folderId: targetFolderId }
+  }
+
+  if (active.kind === 'folder') {
+    if (targetFolderId === active.id) return null
+    if (
+      targetFolderId !== null &&
+      collectDescendantFolderIds(tree?.folders, active.id).has(targetFolderId)
+    ) {
+      return null
+    }
+    const current = flattenFolders(tree?.folders).find(
+      (f) => f.folderId === active.id
+    )
+    if ((current?.parentFolderId ?? null) === targetFolderId) return null
+    return {
+      type: 'moveFolder',
+      folderId: active.id,
+      parentFolderId: targetFolderId
+    }
+  }
+
+  return null
+}
+
+const rebuild = (flat, rootDocuments) => {
+  const nodes = new Map()
+  for (const folder of flat) {
+    nodes.set(folder.folderId, { ...folder, children: [], documentCount: 0 })
+  }
+  const roots = []
+  for (const folder of flat) {
+    const node = nodes.get(folder.folderId)
+    const parent =
+      folder.parentFolderId != null ? nodes.get(folder.parentFolderId) : null
+    if (parent) {
+      parent.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+  const rollup = (node) => {
+    node.documentCount =
+      (node.documents?.length ?? 0) +
+      node.children.reduce((sum, child) => sum + rollup(child), 0)
+    return node.documentCount
+  }
+  roots.forEach(rollup)
+  return { folders: roots, rootDocuments }
+}
+
+/** Optimistic transform: move documents into a folder (or root: null). */
+export const applyDocumentMove = (tree, documentIds, folderId) => {
+  const moving = new Set(documentIds)
+  const moved = []
+  const flat = flattenFolders(tree?.folders).map((folder) => {
+    const kept = []
+    for (const doc of folder.documents ?? []) {
+      if (moving.has(doc.documentId)) {
+        moved.push(doc)
+      } else {
+        kept.push(doc)
+      }
+    }
+    return { ...folder, documents: kept }
+  })
+  const rootKept = []
+  for (const doc of tree?.rootDocuments ?? []) {
+    if (moving.has(doc.documentId)) {
+      moved.push(doc)
+    } else {
+      rootKept.push(doc)
+    }
+  }
+  if (folderId === null) {
+    return rebuild(flat, [...rootKept, ...moved])
+  }
+  const withTarget = flat.map((folder) =>
+    folder.folderId === folderId
+      ? { ...folder, documents: [...folder.documents, ...moved] }
+      : folder
+  )
+  return rebuild(withTarget, rootKept)
+}
+
+/** Optimistic transform: reparent a folder (parentFolderId null = root). */
+export const applyFolderMove = (tree, folderId, parentFolderId) => {
+  const flat = flattenFolders(tree?.folders).map((folder) =>
+    folder.folderId === folderId ? { ...folder, parentFolderId } : folder
+  )
+  return rebuild(flat, tree?.rootDocuments ?? [])
+}
+
+/** The inverse moves needed to undo a document move, grouped by the
+ * folder each document previously sat in. */
+export const invertDocumentMove = (treeBefore, documentIds) => {
+  const groups = new Map()
+  for (const documentId of documentIds) {
+    const from = findFolderOfDocument(treeBefore, documentId)
+    const key = from ?? 'root'
+    if (!groups.has(key)) groups.set(key, { folderId: from, documentIds: [] })
+    groups.get(key).documentIds.push(documentId)
+  }
+  return [...groups.values()]
+}


### PR DESCRIPTION
## Summary

Phase 3 of document folders (#4925): drag and drop. Completes the folder work — phase 1 (#4946) built the backend layer, phase 2 (#4948) the tree.

- **Files and folders move by pointer** with an activation distance of a few pixels, so click-to-download never turns into a drag.
- **Multi-selections travel as one unit** when the dragged file is part of the selection (the tree's Ctrl/Shift selection), hitting the bulk placement endpoint once.
- **A root drop zone** appears during a drag to pull items out of all folders; **collapsed folders auto-expand** after a ~700 ms hover so they're never a two-step target.
- **Every move offers Undo** — the toast returns each file to the folder it actually came from, grouped per previous folder.
- **Illegal targets are refused client-side** — a folder cannot drop into itself or its own subtree (greyed during the drag) — and the server re-validates regardless, since phase 1 made the API the authority on cycles.
- **OS file drops upload into the target folder**: external drags are discriminated by `Files` in the data transfer and suppressed while a tree drag is active; the upload uses the existing shared route then one placement call — the design's two-call pattern, so a failure leaves a visible file at the root rather than a lost upload. The folder menu gains **Upload here** on the same flow.

### Notes for a reviewer

**The decisions are a pure module.** `documentTreeDnd.js` owns what a drop means, which targets are legal, the optimistic tree transforms (counts recomputed by rebuild, not patched), and the undo inversion — all unit-tested without simulating pointer gestures. The component wires gestures thinly over it.

**Moves are optimistic with rollback.** `useMoveDocuments` and folder moves snapshot the tree cache, apply the transform, restore on error, and reconcile on settle. A drag that visibly waits on a round trip reads as broken.

**No new dependency** — dnd-kit was already in the tree, which is why phase 2 could take the community tree view over the paid Pro reordering.

Gesture-level behaviour (pointer drags, hover expansion timing) still needs a hands-on pass against the running stack before the epic leaves draft — jsdom can assert the semantics but not the gestures.

### Testing

11 unit tests on the pure module (descendants, drop resolution including cycles/no-ops/multi-select, both optimistic transforms, undo inversion) plus the component suite (upload-here flow, and all phase 2 behaviours re-passing) — 55 pass across the module's suites. Type-check unchanged.

Refs #4925

