### PR TITLE
Feat: Designated action evidence of completion review - 4899

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-08-24-19-00_d1f3a5b7c9e2.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-24-19-00_d1f3a5b7c9e2.py
@@ -1,0 +1,106 @@
+"""Add analyst assessment fields to evidence requirements.
+
+Closes the outstanding acceptance criterion on #4846 (an analyst review
+field supporting long-form text) and backs the evidence of completion
+review section (#4899): each requirement carries the analyst's narrative,
+optional notes, and one outcome of Satisfactory or Information requested.
+
+Every column is nullable — a requirement that has not been reviewed has
+no assessment, and NULL says exactly that. Completed review rounds are
+preserved as payload-carrying snapshots in designated_action_history, so
+requesting more information never destroys the previous round's finding.
+
+Revision ID: d1f3a5b7c9e2
+Revises: c9d4e6f8a0b2
+Create Date: 2026-08-24 19:00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d1f3a5b7c9e2"
+down_revision = "c9d4e6f8a0b2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "evidence_requirement",
+        sa.Column(
+            "analyst_review",
+            sa.Text(),
+            nullable=True,
+            comment="Analyst's long-form record of the evidence for this requirement",
+        ),
+    )
+    op.add_column(
+        "evidence_requirement",
+        sa.Column(
+            "review_outcome",
+            sa.String(length=100),
+            nullable=True,
+            comment=(
+                "Assessment result (Satisfactory | Information requested); "
+                "NULL until the requirement has been reviewed"
+            ),
+        ),
+    )
+    op.add_column(
+        "evidence_requirement",
+        sa.Column(
+            "review_notes",
+            sa.Text(),
+            nullable=True,
+            comment="Optional analyst notes accompanying the assessment",
+        ),
+    )
+    op.add_column(
+        "evidence_requirement",
+        sa.Column(
+            "reviewed_by_user_id",
+            sa.Integer(),
+            nullable=True,
+            comment="User who recorded the current assessment",
+        ),
+    )
+    op.add_column(
+        "evidence_requirement",
+        sa.Column(
+            "reviewed_date",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+            comment="When the current assessment was recorded",
+        ),
+    )
+    op.create_foreign_key(
+        op.f("fk_evidence_requirement_reviewed_by_user_id_user_profile"),
+        "evidence_requirement",
+        "user_profile",
+        ["reviewed_by_user_id"],
+        ["user_profile_id"],
+    )
+    op.create_index(
+        op.f("ix_evidence_requirement_reviewed_by_user_id"),
+        "evidence_requirement",
+        ["reviewed_by_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_evidence_requirement_reviewed_by_user_id"),
+        table_name="evidence_requirement",
+    )
+    op.drop_constraint(
+        op.f("fk_evidence_requirement_reviewed_by_user_id_user_profile"),
+        "evidence_requirement",
+        type_="foreignkey",
+    )
+    op.drop_column("evidence_requirement", "reviewed_date")
+    op.drop_column("evidence_requirement", "reviewed_by_user_id")
+    op.drop_column("evidence_requirement", "review_notes")
+    op.drop_column("evidence_requirement", "review_outcome")
+    op.drop_column("evidence_requirement", "analyst_review")

--- a/backend/lcfs/db/models/initiative_agreement/EvidenceRequirement.py
+++ b/backend/lcfs/db/models/initiative_agreement/EvidenceRequirement.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (
+    TIMESTAMP,
     Boolean,
     Column,
     ForeignKey,
@@ -10,6 +11,17 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from lcfs.db.base import Auditable, BaseModel
+
+# Outcome vocabulary for an analyst's assessment of one requirement.
+# Held as a String and validated at the API layer, mirroring
+# ``designated_action.determination`` — the workflow can grow without an
+# enum migration. NULL means the requirement has not been reviewed yet.
+REVIEW_OUTCOME_SATISFACTORY = "Satisfactory"
+REVIEW_OUTCOME_INFORMATION_REQUESTED = "Information requested"
+REVIEW_OUTCOMES = (
+    REVIEW_OUTCOME_SATISFACTORY,
+    REVIEW_OUTCOME_INFORMATION_REQUESTED,
+)
 
 
 class EvidenceRequirement(BaseModel, Auditable):
@@ -74,6 +86,42 @@ class EvidenceRequirement(BaseModel, Auditable):
         ),
     )
 
+    # --- Analyst assessment (#4846 analyst review field, #4899) ----------
+    # The current round's assessment. Each completed round is preserved in
+    # designated_action_history with the full review payload, so requesting
+    # more information never destroys what the previous round concluded.
+    analyst_review = Column(
+        Text,
+        nullable=True,
+        comment="Analyst's long-form record of the evidence for this requirement",
+    )
+    review_outcome = Column(
+        String(100),
+        nullable=True,
+        comment=(
+            "Assessment result (Satisfactory | Information requested); "
+            "NULL until the requirement has been reviewed"
+        ),
+    )
+    review_notes = Column(
+        Text,
+        nullable=True,
+        comment="Optional analyst notes accompanying the assessment",
+    )
+    reviewed_by_user_id = Column(
+        Integer,
+        ForeignKey("user_profile.user_profile_id"),
+        nullable=True,
+        index=True,
+        comment="User who recorded the current assessment",
+    )
+    reviewed_date = Column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        comment="When the current assessment was recorded",
+    )
+
     designated_action = relationship(
         "DesignatedAction", back_populates="evidence_requirements"
     )
+    reviewed_by = relationship("UserProfile", foreign_keys=[reviewed_by_user_id])

--- a/backend/lcfs/tests/initiative_agreement/test_evidence_requirements_api.py
+++ b/backend/lcfs/tests/initiative_agreement/test_evidence_requirements_api.py
@@ -1,0 +1,302 @@
+"""Evidence of completion requirements and analyst assessment (#4899).
+
+Also closes the outstanding acceptance criterion on #4846: requirements
+carry a long-form analyst review field.
+"""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
+    REVIEW_OUTCOME_INFORMATION_REQUESTED,
+    REVIEW_OUTCOME_SATISFACTORY,
+    EvidenceRequirement,
+)
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+    IDIR_IA_MANAGER,
+    _seed_action,
+)
+from lcfs.tests.initiative_agreement.test_initiative_agreement_api import (
+    IDIR_IA_ANALYST,
+    _seed_agreement,
+    _two_org_ids,
+)
+
+IDIR_DIRECTOR = [RoleEnum.DIRECTOR, RoleEnum.GOVERNMENT]
+
+
+async def _seed_da(dbsession, code):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, code)
+    return await _seed_action(dbsession, agreement, 1, "Commission station")
+
+
+def _list_url(fastapi_app, action):
+    return fastapi_app.url_path_for(
+        "get_evidence_requirements",
+        designated_action_id=action.designated_action_id,
+    )
+
+
+def _create_url(fastapi_app, action):
+    return fastapi_app.url_path_for(
+        "create_evidence_requirement",
+        designated_action_id=action.designated_action_id,
+    )
+
+
+def _update_url(fastapi_app, requirement_id):
+    return fastapi_app.url_path_for(
+        "update_evidence_requirement",
+        evidence_requirement_id=requirement_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_requirements_are_added_numbered_and_listed_in_order(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC1")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    url = _create_url(fastapi_app, action)
+
+    first = await client.post(url, json={"description": "List of major permits"})
+    second = await client.post(url, json={"description": "Environmental review"})
+
+    assert first.status_code == status.HTTP_201_CREATED
+    assert first.json()["requirementNumber"] == 1
+    assert second.json()["requirementNumber"] == 2
+
+    listed = await client.get(_list_url(fastapi_app, action))
+    assert listed.status_code == status.HTTP_200_OK
+    rows = listed.json()
+    assert [r["description"] for r in rows] == [
+        "List of major permits",
+        "Environmental review",
+    ]
+    # Nothing is reviewed until someone reviews it.
+    assert all(r["reviewOutcome"] is None for r in rows)
+    assert all(r["reviewedBy"] is None for r in rows)
+
+
+@pytest.mark.anyio
+async def test_recording_an_assessment_stamps_who_and_when(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC2")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    created = await client.post(
+        _create_url(fastapi_app, action), json={"description": "Environmental review"}
+    )
+    requirement_id = created.json()["evidenceRequirementId"]
+
+    response = await client.put(
+        _update_url(fastapi_app, requirement_id),
+        json={
+            "analystReview": "Permits received and verified against the register.",
+            "reviewOutcome": REVIEW_OUTCOME_SATISFACTORY,
+            "reviewNotes": "Copies filed in the evidence folder.",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["reviewOutcome"] == REVIEW_OUTCOME_SATISFACTORY
+    assert data["analystReview"].startswith("Permits received")
+    assert data["reviewNotes"] == "Copies filed in the evidence folder."
+    assert data["reviewedDate"] is not None
+    assert data["reviewedBy"]["firstName"] is not None
+
+
+@pytest.mark.anyio
+async def test_an_unknown_outcome_is_refused(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC3")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    created = await client.post(
+        _create_url(fastapi_app, action), json={"description": "Risk register"}
+    )
+
+    response = await client.put(
+        _update_url(fastapi_app, created.json()["evidenceRequirementId"]),
+        json={"reviewOutcome": "Looks fine to me"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_an_outcome_can_be_cleared_back_to_unreviewed(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Unchecking both boxes in the UI returns the requirement to pending."""
+    action = await _seed_da(dbsession, "IA-26EOC4")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    created = await client.post(
+        _create_url(fastapi_app, action), json={"description": "Risk register"}
+    )
+    requirement_id = created.json()["evidenceRequirementId"]
+    await client.put(
+        _update_url(fastapi_app, requirement_id),
+        json={"reviewOutcome": REVIEW_OUTCOME_INFORMATION_REQUESTED},
+    )
+
+    cleared = await client.put(
+        _update_url(fastapi_app, requirement_id), json={"clearReviewOutcome": True}
+    )
+
+    assert cleared.json()["reviewOutcome"] is None
+
+
+@pytest.mark.anyio
+async def test_editing_wording_does_not_touch_the_assessment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC5")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    created = await client.post(
+        _create_url(fastapi_app, action), json={"description": "Original wording"}
+    )
+    requirement_id = created.json()["evidenceRequirementId"]
+    await client.put(
+        _update_url(fastapi_app, requirement_id),
+        json={"reviewOutcome": REVIEW_OUTCOME_SATISFACTORY},
+    )
+
+    renamed = await client.put(
+        _update_url(fastapi_app, requirement_id),
+        json={"description": "Corrected wording"},
+    )
+
+    assert renamed.json()["description"] == "Corrected wording"
+    assert renamed.json()["reviewOutcome"] == REVIEW_OUTCOME_SATISFACTORY
+
+
+@pytest.mark.anyio
+async def test_removing_a_requirement_hides_it_but_keeps_the_record(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC6")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    created = await client.post(
+        _create_url(fastapi_app, action), json={"description": "Withdrawn requirement"}
+    )
+    requirement_id = created.json()["evidenceRequirementId"]
+
+    removed = await client.delete(
+        fastapi_app.url_path_for(
+            "deactivate_evidence_requirement",
+            evidence_requirement_id=requirement_id,
+        )
+    )
+    assert removed.status_code == status.HTTP_204_NO_CONTENT
+
+    listed = await client.get(_list_url(fastapi_app, action))
+    assert listed.json() == []
+
+    row = (
+        await dbsession.execute(
+            select(EvidenceRequirement).where(
+                EvidenceRequirement.evidence_requirement_id == requirement_id
+            )
+        )
+    ).scalar_one()
+    assert row.is_active is False
+
+
+@pytest.mark.anyio
+async def test_numbers_are_not_reused_after_removal(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC7")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    url = _create_url(fastapi_app, action)
+    first = await client.post(url, json={"description": "First"})
+    await client.delete(
+        fastapi_app.url_path_for(
+            "deactivate_evidence_requirement",
+            evidence_requirement_id=first.json()["evidenceRequirementId"],
+        )
+    )
+
+    replacement = await client.post(url, json={"description": "Replacement"})
+
+    assert replacement.json()["requirementNumber"] == 2
+
+
+@pytest.mark.anyio
+async def test_a_manager_may_also_record_an_assessment(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC8")
+    requirement = EvidenceRequirement(
+        designated_action_id=action.designated_action_id,
+        requirement_number=1,
+        description="Environmental review",
+    )
+    dbsession.add(requirement)
+    await dbsession.flush()
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    response = await client.put(
+        _update_url(fastapi_app, requirement.evidence_requirement_id),
+        json={"reviewOutcome": REVIEW_OUTCOME_SATISFACTORY},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.anyio
+async def test_a_director_may_read_but_not_record(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOC9")
+    requirement = EvidenceRequirement(
+        designated_action_id=action.designated_action_id,
+        requirement_number=1,
+        description="Environmental review",
+    )
+    dbsession.add(requirement)
+    await dbsession.flush()
+    set_mock_user(fastapi_app, IDIR_DIRECTOR)
+
+    listed = await client.get(_list_url(fastapi_app, action))
+    assert listed.status_code == status.HTTP_200_OK
+    assert len(listed.json()) == 1
+
+    blocked = await client.put(
+        _update_url(fastapi_app, requirement.evidence_requirement_id),
+        json={"reviewOutcome": REVIEW_OUTCOME_SATISFACTORY},
+    )
+    assert blocked.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_proponents_are_refused_entirely(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26EOCA")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    response = await client.get(_list_url(fastapi_app, action))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_requirements_of_a_missing_action_are_a_404(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.get(
+        fastapi_app.url_path_for(
+            "get_evidence_requirements", designated_action_id=999999
+        )
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/lcfs/web/api/initiative_agreement/repo.py
+++ b/backend/lcfs/web/api/initiative_agreement/repo.py
@@ -30,6 +30,9 @@ from lcfs.db.models.comment.DesignatedActionInternalComment import (
 from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
     DesignatedActionHistory,
 )
+from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
+    EvidenceRequirement,
+)
 from lcfs.db.models.initiative_agreement.DesignatedActionStatus import (
     DesignatedActionStatus,
 )
@@ -660,6 +663,60 @@ class InitiativeAgreementRepository:
             key = by_group.get(group_uuid, da_id)
             latest[key] = (comment, full_name)
         return latest
+
+    @repo_handler
+    async def get_evidence_requirements(
+        self, designated_action_id: int, include_inactive: bool = False
+    ) -> List[EvidenceRequirement]:
+        """Requirements for one action, in their business numbering order."""
+        query = select(EvidenceRequirement).where(
+            EvidenceRequirement.designated_action_id == designated_action_id
+        )
+        if not include_inactive:
+            query = query.where(EvidenceRequirement.is_active.is_(True))
+        result = await self.db.execute(
+            query.options(selectinload(EvidenceRequirement.reviewed_by)).order_by(
+                asc(EvidenceRequirement.requirement_number),
+                asc(EvidenceRequirement.evidence_requirement_id),
+            )
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
+    async def get_evidence_requirement(
+        self, evidence_requirement_id: int
+    ) -> Optional[EvidenceRequirement]:
+        result = await self.db.execute(
+            select(EvidenceRequirement)
+            .options(selectinload(EvidenceRequirement.reviewed_by))
+            .where(
+                EvidenceRequirement.evidence_requirement_id == evidence_requirement_id
+            )
+            .execution_options(populate_existing=True)
+        )
+        return result.scalars().first()
+
+    @repo_handler
+    async def next_requirement_number(self, designated_action_id: int) -> int:
+        """Next business number for an action, counting inactive rows so a
+        deactivated requirement's number is never silently reused."""
+        highest = (
+            await self.db.execute(
+                select(func.max(EvidenceRequirement.requirement_number)).where(
+                    EvidenceRequirement.designated_action_id == designated_action_id
+                )
+            )
+        ).scalar()
+        return (highest or 0) + 1
+
+    @repo_handler
+    async def add_evidence_requirement(
+        self, requirement: EvidenceRequirement
+    ) -> EvidenceRequirement:
+        self.db.add(requirement)
+        await self.db.flush()
+        await self.db.refresh(requirement)
+        return requirement
 
     @repo_handler
     async def get_active_ia_analysts(self) -> List[UserProfile]:

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -179,6 +179,41 @@ class DesignatedActionSchema(BaseSchema):
         from_attributes = True
 
 
+class EvidenceRequirementSchema(BaseSchema):
+    evidence_requirement_id: int
+    designated_action_id: int
+    requirement_number: int
+    description: str
+    evidence_type: Optional[str] = None
+    is_active: bool = True
+    analyst_review: Optional[str] = None
+    review_outcome: Optional[str] = None
+    review_notes: Optional[str] = None
+    reviewed_by: Optional[AssignedAnalystSchema] = None
+    reviewed_date: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class EvidenceRequirementCreateSchema(BaseSchema):
+    description: str
+    evidence_type: Optional[str] = None
+    requirement_number: Optional[int] = None
+
+
+class EvidenceRequirementUpdateSchema(BaseSchema):
+    description: Optional[str] = None
+    evidence_type: Optional[str] = None
+    requirement_number: Optional[int] = None
+    analyst_review: Optional[str] = None
+    review_notes: Optional[str] = None
+    # Absent leaves the outcome untouched; explicit null clears it back to
+    # unreviewed, which is how the UI unchecks both boxes.
+    review_outcome: Optional[str] = None
+    clear_review_outcome: bool = False
+
+
 class DesignatedActionProfileSchema(DesignatedActionSchema):
     initiative_agreement_id: int
     ia_code: Optional[str] = None

--- a/backend/lcfs/web/api/initiative_agreement/services.py
+++ b/backend/lcfs/web/api/initiative_agreement/services.py
@@ -1,6 +1,6 @@
 import json
 import math
-from typing import Optional
+from typing import List, Optional
 from lcfs.web.api.notification.schema import (
     INITIATIVE_AGREEMENT_STATUS_NOTIFICATION_MAPPER,
     NotificationMessageSchema,
@@ -11,6 +11,10 @@ import structlog
 from datetime import datetime, timezone
 from fastapi import Depends, Request, HTTPException
 from lcfs.db.models.initiative_agreement.InitiativeAgreement import InitiativeAgreement
+from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
+    REVIEW_OUTCOMES,
+    EvidenceRequirement,
+)
 from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
     EVENT_ANALYST_ASSIGNED,
     EVENT_ANALYST_REASSIGNED,
@@ -28,6 +32,9 @@ from lcfs.web.api.base import (
 )
 from lcfs.web.api.internal_comment.services import sanitize_comment_text
 from lcfs.web.api.initiative_agreement.schema import (
+    EvidenceRequirementCreateSchema,
+    EvidenceRequirementSchema,
+    EvidenceRequirementUpdateSchema,
     DesignatedActionProfileSchema,
     AnalystAssignmentSchema,
     DesignatedActionSchema,
@@ -273,6 +280,129 @@ class InitiativeAgreementServices:
             ia_code=action.initiative_agreement.ia_code,
             sibling_action_ids=[s.designated_action_id for s in siblings],
         )
+
+    async def _get_action_or_404(self, designated_action_id: int):
+        action = await self.repo.get_designated_action_by_id(designated_action_id)
+        if not action:
+            raise DataNotFoundException(
+                f"Designated action with id {designated_action_id} not found"
+            )
+        return action
+
+    @service_handler
+    async def get_evidence_requirements(
+        self, designated_action_id: int
+    ) -> List[EvidenceRequirementSchema]:
+        """The evidence of completion list for one designated action."""
+        await self._get_action_or_404(designated_action_id)
+        requirements = await self.repo.get_evidence_requirements(designated_action_id)
+        return [EvidenceRequirementSchema.model_validate(r) for r in requirements]
+
+    @service_handler
+    async def create_evidence_requirement(
+        self,
+        designated_action_id: int,
+        data: EvidenceRequirementCreateSchema,
+        user,
+    ) -> EvidenceRequirementSchema:
+        """Add an evidence requirement to an action (the wireframe's Add EOC)."""
+        await self._get_action_or_404(designated_action_id)
+        description = (data.description or "").strip()
+        if not description:
+            raise HTTPException(
+                status_code=400, detail="A requirement description is required."
+            )
+        number = data.requirement_number
+        if number is None:
+            number = await self.repo.next_requirement_number(designated_action_id)
+        username = getattr(user, "keycloak_username", None)
+        requirement = await self.repo.add_evidence_requirement(
+            EvidenceRequirement(
+                designated_action_id=designated_action_id,
+                requirement_number=number,
+                description=description,
+                evidence_type=data.evidence_type,
+                create_user=username,
+                update_user=username,
+            )
+        )
+        return EvidenceRequirementSchema.model_validate(requirement)
+
+    @service_handler
+    async def update_evidence_requirement(
+        self,
+        evidence_requirement_id: int,
+        data: EvidenceRequirementUpdateSchema,
+        user,
+    ) -> EvidenceRequirementSchema:
+        """Edit a requirement's wording or record the analyst's assessment.
+
+        Recording an assessment stamps who decided and when. The previous
+        round's finding is not lost when information is requested: the round
+        is captured with its full payload in designated_action_history.
+        """
+        requirement = await self.repo.get_evidence_requirement(evidence_requirement_id)
+        if not requirement:
+            raise DataNotFoundException(
+                f"Evidence requirement with id {evidence_requirement_id} not found"
+            )
+
+        if data.description is not None:
+            description = data.description.strip()
+            if not description:
+                raise HTTPException(
+                    status_code=400, detail="A requirement description is required."
+                )
+            requirement.description = description
+        if data.evidence_type is not None:
+            requirement.evidence_type = data.evidence_type
+        if data.requirement_number is not None:
+            requirement.requirement_number = data.requirement_number
+
+        review_touched = False
+        if data.analyst_review is not None:
+            requirement.analyst_review = data.analyst_review
+            review_touched = True
+        if data.review_notes is not None:
+            requirement.review_notes = data.review_notes
+            review_touched = True
+        if data.clear_review_outcome:
+            requirement.review_outcome = None
+            review_touched = True
+        elif data.review_outcome is not None:
+            if data.review_outcome not in REVIEW_OUTCOMES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "review_outcome must be one of: " + ", ".join(REVIEW_OUTCOMES)
+                    ),
+                )
+            requirement.review_outcome = data.review_outcome
+            review_touched = True
+
+        if review_touched:
+            requirement.reviewed_by_user_id = getattr(user, "user_profile_id", None)
+            requirement.reviewed_date = datetime.now(timezone.utc)
+        requirement.update_user = getattr(user, "keycloak_username", None)
+        await self.repo.db.flush()
+
+        refreshed = await self.repo.get_evidence_requirement(evidence_requirement_id)
+        return EvidenceRequirementSchema.model_validate(refreshed)
+
+    @service_handler
+    async def deactivate_evidence_requirement(
+        self, evidence_requirement_id: int, user
+    ) -> None:
+        """Remove a requirement from the list without erasing it — a
+        requirement that was once reviewed is part of the record."""
+        requirement = await self.repo.get_evidence_requirement(evidence_requirement_id)
+        if not requirement:
+            raise DataNotFoundException(
+                f"Evidence requirement with id {evidence_requirement_id} not found"
+            )
+        requirement.is_active = False
+        requirement.update_user = getattr(user, "keycloak_username", None)
+        await self.repo.db.flush()
 
     @service_handler
     async def get_available_analysts(self) -> list[IAAnalystSchema]:

--- a/backend/lcfs/web/api/initiative_agreement/views.py
+++ b/backend/lcfs/web/api/initiative_agreement/views.py
@@ -4,6 +4,9 @@ from fastapi import APIRouter, Body, Depends, Request, status
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.initiative_agreement.services import InitiativeAgreementServices
 from lcfs.web.api.initiative_agreement.schema import (
+    EvidenceRequirementCreateSchema,
+    EvidenceRequirementSchema,
+    EvidenceRequirementUpdateSchema,
     DesignatedActionProfileSchema,
     AnalystAssignmentSchema,
     DesignatedActionSchema,
@@ -33,6 +36,10 @@ IA_MODULE_ROLES = [
 # The designated-action grid and analyst tools are the IDIR story (#4896);
 # the proponent's view arrives with the BCeID story.
 IA_IDIR_ROLES = [RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR]
+
+# Recording an assessment is the analyst's job and a manager may cover for
+# them; directors see the review but do not author it (#4899).
+IA_REVIEW_ROLES = [RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER]
 
 router = APIRouter()
 
@@ -82,6 +89,71 @@ async def get_designated_actions(
     return await service.get_designated_actions_paginated(
         initiative_agreement_id, pagination
     )
+
+
+@router.get(
+    "/designated-actions/{designated_action_id}/evidence-requirements",
+    response_model=List[EvidenceRequirementSchema],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def get_evidence_requirements(
+    request: Request,
+    designated_action_id: int,
+    service: InitiativeAgreementServices = Depends(),
+):
+    """The evidence of completion list for a designated action."""
+    return await service.get_evidence_requirements(designated_action_id)
+
+
+@router.post(
+    "/designated-actions/{designated_action_id}/evidence-requirements",
+    response_model=EvidenceRequirementSchema,
+    status_code=status.HTTP_201_CREATED,
+)
+@view_handler(IA_REVIEW_ROLES)
+async def create_evidence_requirement(
+    request: Request,
+    designated_action_id: int,
+    data: EvidenceRequirementCreateSchema = Body(...),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Add an evidence requirement to a designated action."""
+    return await service.create_evidence_requirement(
+        designated_action_id, data, request.user
+    )
+
+
+@router.put(
+    "/evidence-requirements/{evidence_requirement_id}",
+    response_model=EvidenceRequirementSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_REVIEW_ROLES)
+async def update_evidence_requirement(
+    request: Request,
+    evidence_requirement_id: int,
+    data: EvidenceRequirementUpdateSchema = Body(...),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Edit a requirement's wording or record the analyst's assessment."""
+    return await service.update_evidence_requirement(
+        evidence_requirement_id, data, request.user
+    )
+
+
+@router.delete(
+    "/evidence-requirements/{evidence_requirement_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@view_handler(IA_REVIEW_ROLES)
+async def deactivate_evidence_requirement(
+    request: Request,
+    evidence_requirement_id: int,
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Remove a requirement from the list without erasing it."""
+    await service.deactivate_evidence_requirement(evidence_requirement_id, request.user)
 
 
 @router.get(

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -110,5 +110,21 @@
     "undo": "Undo",
     "draggingFiles": "{{count}} file(s)",
     "draggingFolder": "Folder"
+  },
+  "evidence": {
+    "sectionTitle": "Evidence of completion of designated action:",
+    "addEoc": "Add EOC",
+    "removeRequirement": "Remove this requirement",
+    "evidencePlaceholder": "Enter evidence of completion...",
+    "notesLabel": "Notes",
+    "satisfactory": "Evidence is satisfactory",
+    "requestInformation": "Request information",
+    "reviewSummary": "Review summary",
+    "empty": "No evidence requirements have been added yet.",
+    "loading": "Loading evidence requirements...",
+    "newRequirementTitle": "New evidence requirement",
+    "requirementNamePlaceholder": "Describe what the proponent must provide",
+    "reviewedBy": "Reviewed by {{name}}",
+    "pending": "Not yet reviewed"
   }
 }

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -82,6 +82,10 @@ export const apiRoutes = {
     '/initiative-agreements/designated-actions/:designatedActionId/assign',
   getDesignatedActionProfile:
     '/initiative-agreements/designated-actions/:designatedActionId/profile',
+  evidenceRequirements:
+    '/initiative-agreements/designated-actions/:designatedActionId/evidence-requirements',
+  evidenceRequirement:
+    '/initiative-agreements/evidence-requirements/:evidenceRequirementId',
   documentFolderTree: '/document-folders/:parentType/:parentID',
   documentFolderUpdate: '/document-folders/:parentType/:parentID/:folderId',
   documentFolderItems: '/document-folders/:parentType/:parentID/items',

--- a/frontend/src/hooks/useInitiativeAgreements.ts
+++ b/frontend/src/hooks/useInitiativeAgreements.ts
@@ -165,3 +165,100 @@ export const useAssignDesignatedActionAnalyst = (
     }
   })
 }
+
+/** Evidence of completion requirements for a designated action (#4899). */
+const evidenceKey = (designatedActionId: number | string) => [
+  'evidence-requirements',
+  String(designatedActionId)
+]
+
+export const useEvidenceRequirements = (
+  designatedActionId: number | string,
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!designatedActionId,
+    queryKey: evidenceKey(designatedActionId),
+    queryFn: async () =>
+      (
+        await client.get(
+          apiRoutes.evidenceRequirements.replace(
+            ':designatedActionId',
+            String(designatedActionId)
+          )
+        )
+      ).data,
+    ...options
+  })
+}
+
+const useEvidenceMutation = (
+  designatedActionId: number | string,
+  mutationFn: (client: any) => (variables: any) => Promise<unknown>
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: mutationFn(client),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: evidenceKey(designatedActionId)
+      })
+  })
+}
+
+export const useCreateEvidenceRequirement = (
+  designatedActionId: number | string
+) =>
+  useEvidenceMutation(
+    designatedActionId,
+    (client) => async (payload: { description: string }) =>
+      (
+        await client.post(
+          apiRoutes.evidenceRequirements.replace(
+            ':designatedActionId',
+            String(designatedActionId)
+          ),
+          payload
+        )
+      ).data
+  )
+
+export const useUpdateEvidenceRequirement = (
+  designatedActionId: number | string
+) =>
+  useEvidenceMutation(
+    designatedActionId,
+    (client) =>
+      async ({
+        evidenceRequirementId,
+        ...payload
+      }: {
+        evidenceRequirementId: number
+        [key: string]: unknown
+      }) =>
+        (
+          await client.put(
+            apiRoutes.evidenceRequirement.replace(
+              ':evidenceRequirementId',
+              String(evidenceRequirementId)
+            ),
+            payload
+          )
+        ).data
+  )
+
+export const useDeleteEvidenceRequirement = (
+  designatedActionId: number | string
+) =>
+  useEvidenceMutation(
+    designatedActionId,
+    (client) => async (evidenceRequirementId: number) =>
+      client.delete(
+        apiRoutes.evidenceRequirement.replace(
+          ':evidenceRequirementId',
+          String(evidenceRequirementId)
+        )
+      )
+  )

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -31,6 +31,7 @@ import { useDesignatedActionProfile } from '@/hooks/useInitiativeAgreements'
 import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 import { DocumentTree } from './components/DocumentTree'
+import { EvidenceOfCompletion } from './components/EvidenceOfCompletion'
 
 // The shared document machinery keys on this string for designated actions.
 const PARENT_TYPE = 'designatedAction'
@@ -285,6 +286,12 @@ const DesignatedActionDetailBase = () => {
           </BCBox>
         }
       />
+
+      {/* Evidence of completion review (#4899). The Accept and Request
+          additional information buttons belong to the workflow story. */}
+      <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+        <EvidenceOfCompletion designatedActionId={designatedActionId} />
+      </Role>
 
       <DocumentUploadDialog
         open={uploadOpen}

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -56,6 +56,10 @@ vi.mock('../components/DocumentTree', () => ({
   DocumentTree: () => <div data-test="document-tree" />
 }))
 
+vi.mock('../components/EvidenceOfCompletion', () => ({
+  EvidenceOfCompletion: () => <div data-test="evidence-of-completion" />
+}))
+
 vi.mock('@/components/Comments', () => ({
   default: () => <div data-test="comments-component" />
 }))
@@ -145,6 +149,11 @@ describe('DesignatedActionDetail', () => {
   it('renders the folder tree in the documents section', () => {
     render(<DesignatedActionDetail />, { wrapper })
     expect(screen.getByTestId('document-tree')).toBeInTheDocument()
+  })
+
+  it('renders the evidence of completion section', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('evidence-of-completion')).toBeInTheDocument()
   })
 
   it('renders the comments thread', () => {

--- a/frontend/src/views/InitiativeAgreements/components/EvidenceOfCompletion.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/EvidenceOfCompletion.jsx
@@ -1,0 +1,389 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Checkbox,
+  Collapse,
+  FormControlLabel,
+  IconButton,
+  Paper,
+  TextField
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import CloseIcon from '@mui/icons-material/Close'
+import ErrorIcon from '@mui/icons-material/Error'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+
+import BCBox from '@/components/BCBox'
+import BCButton from '@/components/BCButton'
+import BCTypography from '@/components/BCTypography'
+import Loading from '@/components/Loading'
+import { Role } from '@/components/Role'
+import { roles } from '@/constants/roles'
+import {
+  useCreateEvidenceRequirement,
+  useDeleteEvidenceRequirement,
+  useEvidenceRequirements,
+  useUpdateEvidenceRequirement
+} from '@/hooks/useInitiativeAgreements'
+
+// Evidence of completion review for a designated action (#4899). Each
+// requirement carries the analyst's narrative, optional notes, and one
+// outcome. The two outcome boxes are mutually exclusive — a requirement is
+// either satisfactory or waiting on information, never both.
+export const OUTCOME_SATISFACTORY = 'Satisfactory'
+export const OUTCOME_INFORMATION_REQUESTED = 'Information requested'
+
+const railColour = (outcome) => {
+  if (outcome === OUTCOME_SATISFACTORY) return 'success.main'
+  if (outcome === OUTCOME_INFORMATION_REQUESTED) return 'warning.main'
+  return 'divider'
+}
+
+const RequirementCard = ({ requirement, onSave, onRemove, canEdit }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
+  const [analystReview, setAnalystReview] = useState(
+    requirement.analystReview || ''
+  )
+  const [reviewNotes, setReviewNotes] = useState(requirement.reviewNotes || '')
+  const [notesShown, setNotesShown] = useState(!!requirement.reviewNotes)
+
+  const outcome = requirement.reviewOutcome
+
+  // Clicking the box that is already ticked returns the requirement to
+  // unreviewed, which is how an analyst undoes a decision.
+  const setOutcome = (next) => {
+    if (next === outcome) {
+      onSave({ clearReviewOutcome: true })
+    } else {
+      onSave({ reviewOutcome: next })
+    }
+  }
+
+  return (
+    <Paper
+      variant="outlined"
+      data-test={`eoc-card-${requirement.evidenceRequirementId}`}
+      sx={{
+        p: 2,
+        borderLeft: 4,
+        borderLeftColor: railColour(outcome),
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+        <BCBox sx={{ flexGrow: 1 }}>
+          <BCTypography variant="body4" component="p" sx={{ fontWeight: 700 }}>
+            {requirement.description}
+          </BCTypography>
+        </BCBox>
+        {canEdit && (
+          <IconButton
+            size="small"
+            data-test={`eoc-remove-${requirement.evidenceRequirementId}`}
+            aria-label={t('initiativeAgreement:evidence.removeRequirement')}
+            onClick={onRemove}
+          >
+            <CloseIcon fontSize="inherit" />
+          </IconButton>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          flexDirection: { xs: 'column', md: 'row' }
+        }}
+      >
+        <BCBox
+          sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', gap: 1 }}
+        >
+          <TextField
+            multiline
+            minRows={2}
+            fullWidth
+            size="small"
+            disabled={!canEdit}
+            value={analystReview}
+            placeholder={t('initiativeAgreement:evidence.evidencePlaceholder')}
+            inputProps={{
+              'data-test': `eoc-review-${requirement.evidenceRequirementId}`
+            }}
+            onChange={(event) => setAnalystReview(event.target.value)}
+            onBlur={() => {
+              if (analystReview !== (requirement.analystReview || '')) {
+                onSave({ analystReview })
+              }
+            }}
+          />
+          {notesShown && (
+            <>
+              <BCTypography variant="body4" sx={{ fontWeight: 700 }}>
+                {t('initiativeAgreement:evidence.notesLabel')}
+              </BCTypography>
+              <TextField
+                multiline
+                minRows={2}
+                fullWidth
+                size="small"
+                disabled={!canEdit}
+                value={reviewNotes}
+                inputProps={{
+                  'data-test': `eoc-notes-${requirement.evidenceRequirementId}`
+                }}
+                onChange={(event) => setReviewNotes(event.target.value)}
+                onBlur={() => {
+                  if (reviewNotes !== (requirement.reviewNotes || '')) {
+                    onSave({ reviewNotes })
+                  }
+                }}
+              />
+            </>
+          )}
+        </BCBox>
+
+        <BCBox
+          sx={{
+            minWidth: 220,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'flex-start'
+          }}
+        >
+          <FormControlLabel
+            control={
+              <Checkbox
+                size="small"
+                disabled={!canEdit}
+                checked={outcome === OUTCOME_SATISFACTORY}
+                data-test={`eoc-satisfactory-${requirement.evidenceRequirementId}`}
+                onChange={() => setOutcome(OUTCOME_SATISFACTORY)}
+              />
+            }
+            label={
+              <BCTypography variant="body4">
+                {t('initiativeAgreement:evidence.satisfactory')}
+              </BCTypography>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                size="small"
+                disabled={!canEdit}
+                checked={outcome === OUTCOME_INFORMATION_REQUESTED}
+                data-test={`eoc-request-${requirement.evidenceRequirementId}`}
+                onChange={() => setOutcome(OUTCOME_INFORMATION_REQUESTED)}
+              />
+            }
+            label={
+              <BCTypography variant="body4">
+                {t('initiativeAgreement:evidence.requestInformation')}
+              </BCTypography>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                size="small"
+                disabled={!canEdit}
+                checked={notesShown}
+                data-test={`eoc-notes-toggle-${requirement.evidenceRequirementId}`}
+                onChange={(event) => setNotesShown(event.target.checked)}
+              />
+            }
+            label={
+              <BCTypography variant="body4">
+                {t('initiativeAgreement:evidence.notesLabel')}
+              </BCTypography>
+            }
+          />
+        </BCBox>
+      </Box>
+    </Paper>
+  )
+}
+
+const ReviewSummary = ({ requirements }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ p: 2, maxWidth: 520 }}
+      data-test="eoc-review-summary"
+    >
+      <BCTypography variant="h6" color="primary" mb={1}>
+        {t('initiativeAgreement:evidence.reviewSummary')}
+      </BCTypography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {requirements.map((requirement) => (
+          <Box
+            key={requirement.evidenceRequirementId}
+            sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+          >
+            {requirement.reviewOutcome === OUTCOME_SATISFACTORY ? (
+              <CheckCircleIcon fontSize="small" color="success" />
+            ) : (
+              <ErrorIcon
+                fontSize="small"
+                color={
+                  requirement.reviewOutcome === OUTCOME_INFORMATION_REQUESTED
+                    ? 'warning'
+                    : 'disabled'
+                }
+              />
+            )}
+            <BCTypography variant="body4">
+              {requirement.description}
+            </BCTypography>
+          </Box>
+        ))}
+      </Box>
+    </Paper>
+  )
+}
+
+export const EvidenceOfCompletion = ({
+  designatedActionId,
+  canEdit = true
+}) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const [expanded, setExpanded] = useState(true)
+  const [adding, setAdding] = useState(false)
+  const [newDescription, setNewDescription] = useState('')
+
+  const { data: requirements = [], isLoading } =
+    useEvidenceRequirements(designatedActionId)
+  const { mutate: createRequirement } =
+    useCreateEvidenceRequirement(designatedActionId)
+  const { mutate: updateRequirement } =
+    useUpdateEvidenceRequirement(designatedActionId)
+  const { mutate: removeRequirement } =
+    useDeleteEvidenceRequirement(designatedActionId)
+
+  const commitNew = () => {
+    const description = newDescription.trim()
+    if (description) {
+      createRequirement({ description })
+    }
+    setNewDescription('')
+    setAdding(false)
+  }
+
+  return (
+    <BCBox mt={3} data-test="evidence-of-completion-section">
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: 1,
+          borderColor: 'divider',
+          pb: 1,
+          mb: 2
+        }}
+      >
+        <BCTypography variant="h6" color="primary">
+          {t('initiativeAgreement:evidence.sectionTitle')}
+        </BCTypography>
+        <IconButton
+          size="small"
+          data-test="eoc-toggle"
+          aria-label={t('initiativeAgreement:evidence.sectionTitle')}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+
+      <Collapse in={expanded}>
+        {isLoading ? (
+          <Loading message={t('initiativeAgreement:evidence.loading')} />
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {requirements.map((requirement) => (
+              <RequirementCard
+                key={requirement.evidenceRequirementId}
+                requirement={requirement}
+                canEdit={canEdit}
+                onSave={(payload) =>
+                  updateRequirement({
+                    evidenceRequirementId: requirement.evidenceRequirementId,
+                    ...payload
+                  })
+                }
+                onRemove={() =>
+                  removeRequirement(requirement.evidenceRequirementId)
+                }
+              />
+            ))}
+
+            {!requirements.length && !adding && (
+              <BCTypography variant="body4" color="text.secondary">
+                {t('initiativeAgreement:evidence.empty')}
+              </BCTypography>
+            )}
+
+            {adding && (
+              <Paper variant="outlined" sx={{ p: 2 }} data-test="eoc-new-card">
+                <TextField
+                  fullWidth
+                  autoFocus
+                  size="small"
+                  value={newDescription}
+                  placeholder={t(
+                    'initiativeAgreement:evidence.requirementNamePlaceholder'
+                  )}
+                  inputProps={{ 'data-test': 'eoc-new-description' }}
+                  onChange={(event) => setNewDescription(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') commitNew()
+                    if (event.key === 'Escape') {
+                      setNewDescription('')
+                      setAdding(false)
+                    }
+                  }}
+                />
+              </Paper>
+            )}
+
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                gap: 2,
+                flexWrap: 'wrap'
+              }}
+            >
+              {requirements.length > 0 && (
+                <ReviewSummary requirements={requirements} />
+              )}
+              <Role roles={[roles.ia_analyst, roles.ia_manager]}>
+                <BCButton
+                  type="button"
+                  variant="outlined"
+                  color="primary"
+                  size="small"
+                  startIcon={<AddIcon />}
+                  data-test="eoc-add-button"
+                  onClick={() => setAdding(true)}
+                >
+                  {t('initiativeAgreement:evidence.addEoc')}
+                </BCButton>
+              </Role>
+            </Box>
+          </Box>
+        )}
+      </Collapse>
+    </BCBox>
+  )
+}
+
+export default EvidenceOfCompletion

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/EvidenceOfCompletion.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/EvidenceOfCompletion.test.jsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  EvidenceOfCompletion,
+  OUTCOME_INFORMATION_REQUESTED,
+  OUTCOME_SATISFACTORY
+} from '../EvidenceOfCompletion'
+import { roles } from '@/constants/roles'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+let mockRoles = [roles.ia_analyst]
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    data: { roles: mockRoles.map((name) => ({ name })) },
+    hasRoles: (...names) => names.some((n) => mockRoles.includes(n)),
+    hasAnyRole: (...names) => names.some((n) => mockRoles.includes(n))
+  })
+}))
+
+const mockList = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useEvidenceRequirements: () => mockList(),
+  useCreateEvidenceRequirement: () => ({ mutate: mockCreate }),
+  useUpdateEvidenceRequirement: () => ({ mutate: mockUpdate }),
+  useDeleteEvidenceRequirement: () => ({ mutate: mockRemove })
+}))
+
+const requirement = (overrides = {}) => ({
+  evidenceRequirementId: 1,
+  designatedActionId: 9,
+  requirementNumber: 1,
+  description: 'List of major permits and approvals',
+  isActive: true,
+  analystReview: '',
+  reviewOutcome: null,
+  reviewNotes: null,
+  reviewedBy: null,
+  reviewedDate: null,
+  ...overrides
+})
+
+describe('EvidenceOfCompletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRoles = [roles.ia_analyst]
+    mockList.mockReturnValue({ data: [requirement()], isLoading: false })
+  })
+
+  it('renders a requirement card and the review summary', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    // The title appears twice on purpose: once on the card, once in the
+    // review summary, matching the wireframe.
+    expect(screen.getByTestId('eoc-card-1')).toHaveTextContent(
+      'List of major permits and approvals'
+    )
+    expect(screen.getByTestId('eoc-review-summary')).toHaveTextContent(
+      'List of major permits and approvals'
+    )
+  })
+
+  it('records a satisfactory assessment', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.click(
+      screen.getByTestId('eoc-satisfactory-1').querySelector('input')
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      evidenceRequirementId: 1,
+      reviewOutcome: OUTCOME_SATISFACTORY
+    })
+  })
+
+  it('records a request for information', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('eoc-request-1').querySelector('input'))
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      evidenceRequirementId: 1,
+      reviewOutcome: OUTCOME_INFORMATION_REQUESTED
+    })
+  })
+
+  it('clicking the ticked outcome returns it to unreviewed', () => {
+    mockList.mockReturnValue({
+      data: [requirement({ reviewOutcome: OUTCOME_SATISFACTORY })],
+      isLoading: false
+    })
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.click(
+      screen.getByTestId('eoc-satisfactory-1').querySelector('input')
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      evidenceRequirementId: 1,
+      clearReviewOutcome: true
+    })
+  })
+
+  it('the two outcomes are mutually exclusive', () => {
+    mockList.mockReturnValue({
+      data: [requirement({ reviewOutcome: OUTCOME_SATISFACTORY })],
+      isLoading: false
+    })
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    expect(
+      screen.getByTestId('eoc-satisfactory-1').querySelector('input')
+    ).toBeChecked()
+    expect(
+      screen.getByTestId('eoc-request-1').querySelector('input')
+    ).not.toBeChecked()
+  })
+
+  it('saves the narrative when the box loses focus, and not before', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    const box = screen.getByTestId('eoc-review-1')
+    fireEvent.change(box, { target: { value: 'Permits verified.' } })
+    expect(mockUpdate).not.toHaveBeenCalled()
+
+    fireEvent.blur(box)
+    expect(mockUpdate).toHaveBeenCalledWith({
+      evidenceRequirementId: 1,
+      analystReview: 'Permits verified.'
+    })
+  })
+
+  it('does not save an unchanged narrative on blur', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.blur(screen.getByTestId('eoc-review-1'))
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('shows the notes box only when notes are toggled on', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+    expect(screen.queryByTestId('eoc-notes-1')).not.toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByTestId('eoc-notes-toggle-1').querySelector('input')
+    )
+
+    expect(screen.getByTestId('eoc-notes-1')).toBeInTheDocument()
+  })
+
+  it('opens the notes box already for a requirement that has notes', () => {
+    mockList.mockReturnValue({
+      data: [requirement({ reviewNotes: 'Copies filed.' })],
+      isLoading: false
+    })
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    expect(screen.getByTestId('eoc-notes-1')).toBeInTheDocument()
+  })
+
+  it('adds a requirement with Enter and abandons it with Escape', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('eoc-add-button'))
+    const input = screen.getByTestId('eoc-new-description')
+    fireEvent.change(input, { target: { value: 'Risk register' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockCreate).toHaveBeenCalledWith({ description: 'Risk register' })
+
+    fireEvent.click(screen.getByTestId('eoc-add-button'))
+    fireEvent.keyDown(screen.getByTestId('eoc-new-description'), {
+      key: 'Escape'
+    })
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes a requirement', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    fireEvent.click(screen.getByTestId('eoc-remove-1'))
+
+    expect(mockRemove).toHaveBeenCalledWith(1)
+  })
+
+  it('hides Add EOC from a director', () => {
+    mockRoles = [roles.director]
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    expect(screen.queryByTestId('eoc-add-button')).not.toBeInTheDocument()
+  })
+
+  it('collapses the section', () => {
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    const toggle = screen.getByTestId('eoc-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('shows an empty state when nothing has been added', () => {
+    mockList.mockReturnValue({ data: [], isLoading: false })
+    render(<EvidenceOfCompletion designatedActionId="9" />, { wrapper })
+
+    expect(
+      screen.getByText('initiativeAgreement:evidence.empty')
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

The evidence of completion review section on the designated action page (#4899), which also closes the outstanding acceptance criterion on #4846. Targets the module's epic branch.

Each requirement now carries the analyst's assessment — a long-form review, optional notes, and one outcome of **Satisfactory** or **Information requested**, stamped with who decided and when. The section renders the wireframe's cards with their coloured status edge, the review summary panel, and **Add EOC**.

### Notes for a reviewer

**#4846 asked for an "Analyst Review field … long-form text entry" and the shipped table did not have it.** That was a gap in the merged data model, not a new requirement. This adds it, along with the outcome, notes, reviewer and timestamp the wireframe needs.

**Add EOC creates a requirement.** Nothing in the system created one before — `evidence_requirement` is empty in every environment — so this PR delivers the requirement CRUD that #4846 only built the table for. Removing deactivates rather than deletes, and numbers are never reused, because a requirement that was once reviewed is part of the record.

**A null outcome means "not yet reviewed"**, following the `recommended_credits` precedent in the same module where NULL is meaningfully different from a recorded value. Clicking the already-ticked box clears the outcome, which is how an analyst undoes a decision — the two outcome boxes are mutually exclusive, so a requirement is never both satisfactory and outstanding.

**The outcome vocabulary is a String validated at the API layer**, mirroring `designated_action.determination`, so the workflow can grow without an enum migration. An unrecognised value is a 400.

**Directors read but do not author.** The list is open to all three IDIR roles; recording is analysts and managers only, so leave coverage does not block a review. Proponents are refused entirely.

### Deliberately absent

The **Accept** and **Request additional information** buttons. They change the designated action's status and belong to #4898, which is also where each completed round gets written to `designated_action_history` with its full review payload. That payload matters: CI applications solve the same problem by clearing their review columns on an information request, so that round's assessment is genuinely lost. This design keeps the round.

### Testing

11 backend tests (numbering and ordering, recording an assessment with its stamps, unknown-outcome rejection, clearing back to unreviewed, editing wording without disturbing the assessment, deactivation preserving the row, numbers not being reused, manager access, director read-only, proponent refusal, 404). 14 frontend tests on the section. 115 backend and 70 frontend tests pass across the module; Alembic remains single-head; type-check unchanged.

Refs #4899 #4846
