### PR TITLE
Feat: Designated action workflow status and recommendations - 4898

### DIFF
--- a/backend/lcfs/tests/initiative_agreement/test_designated_action_workflow.py
+++ b/backend/lcfs/tests/initiative_agreement/test_designated_action_workflow.py
@@ -1,0 +1,445 @@
+"""Designated action workflow: statuses, recommendations, audit (#4898).
+
+The transition table is the feature, so most of these assert against it
+directly: who may act, from where, what lands, and what the audit trail
+keeps. Credit issuance is out of scope for this story and no test here
+expects any transaction to move.
+"""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
+    EVENT_CREDITS_RECOMMENDED,
+    EVENT_EVIDENCE_REVIEWED,
+    EVENT_INFORMATION_REQUESTED,
+    EVENT_STATUS_CHANGE,
+    DesignatedActionHistory,
+)
+from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
+    REVIEW_OUTCOME_INFORMATION_REQUESTED,
+    REVIEW_OUTCOME_SATISFACTORY,
+    EvidenceRequirement,
+)
+from lcfs.db.models.user.Role import RoleEnum
+from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+    IDIR_IA_MANAGER,
+    _action_status_id,
+    _seed_action,
+)
+from lcfs.tests.initiative_agreement.test_initiative_agreement_api import (
+    IDIR_IA_ANALYST,
+    _seed_agreement,
+    _two_org_ids,
+)
+
+IDIR_DIRECTOR = [RoleEnum.DIRECTOR, RoleEnum.GOVERNMENT]
+
+
+async def _seed_da(dbsession, code, status_name="Underway", credits=1850):
+    org_id, _ = await _two_org_ids(dbsession)
+    agreement = await _seed_agreement(dbsession, org_id, code)
+    action = await _seed_action(dbsession, agreement, 1, "Commission station", credits)
+    action.current_status_id = await _action_status_id(dbsession, status_name)
+    await dbsession.flush()
+    return action
+
+
+async def _seed_requirement(dbsession, action, outcome=REVIEW_OUTCOME_SATISFACTORY):
+    requirement = EvidenceRequirement(
+        designated_action_id=action.designated_action_id,
+        requirement_number=1,
+        description="List of major permits",
+        analyst_review="Permits verified.",
+        review_outcome=outcome,
+    )
+    dbsession.add(requirement)
+    await dbsession.flush()
+    return requirement
+
+
+def _workflow_url(fastapi_app, action):
+    return fastapi_app.url_path_for(
+        "perform_designated_action_workflow",
+        designated_action_id=action.designated_action_id,
+    )
+
+
+async def _status_of(dbsession, action):
+    from lcfs.db.models.initiative_agreement.DesignatedActionStatus import (
+        DesignatedActionStatus,
+    )
+
+    await dbsession.refresh(action)
+    return (
+        await dbsession.execute(
+            select(DesignatedActionStatus.status).where(
+                DesignatedActionStatus.designated_action_status_id
+                == action.current_status_id
+            )
+        )
+    ).scalar_one()
+
+
+async def _history(dbsession, action):
+    result = await dbsession.execute(
+        select(DesignatedActionHistory)
+        .where(
+            DesignatedActionHistory.designated_action_id == action.designated_action_id
+        )
+        .order_by(DesignatedActionHistory.designated_action_history_id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.anyio
+async def test_requesting_information_keeps_the_round_in_the_audit_trail(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The snapshot carries the review itself, not just the fact that a
+    round happened — otherwise the next round overwrites this one's
+    findings and they are gone."""
+    action = await _seed_da(dbsession, "IA-26WF1")
+    await _seed_requirement(dbsession, action, REVIEW_OUTCOME_INFORMATION_REQUESTED)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={
+            "action": "request_information",
+            "comment": "Please send the signed permit for stage two.",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert await _status_of(dbsession, action) == "Information requested"
+
+    entries = await _history(dbsession, action)
+    assert [e.event for e in entries] == [EVENT_INFORMATION_REQUESTED]
+    snapshot = entries[0].snapshot
+    assert snapshot["comment"] == "Please send the signed permit for stage two."
+    captured = snapshot["evidence_requirements"]
+    assert captured[0]["analyst_review"] == "Permits verified."
+    assert captured[0]["review_outcome"] == REVIEW_OUTCOME_INFORMATION_REQUESTED
+
+
+@pytest.mark.anyio
+async def test_requesting_information_requires_saying_what_is_needed(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF2")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "request_information"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_accepting_evidence_requires_every_requirement_satisfactory(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF3")
+    requirement = await _seed_requirement(
+        dbsession, action, REVIEW_OUTCOME_INFORMATION_REQUESTED
+    )
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    blocked = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "accept_evidence"}
+    )
+    assert blocked.status_code == status.HTTP_400_BAD_REQUEST
+    assert not await _history(dbsession, action)
+
+    requirement.review_outcome = REVIEW_OUTCOME_SATISFACTORY
+    await dbsession.flush()
+
+    accepted = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "accept_evidence"}
+    )
+    assert accepted.status_code == status.HTTP_200_OK
+    entries = await _history(dbsession, action)
+    assert [e.event for e in entries] == [EVENT_EVIDENCE_REVIEWED]
+    # Accepting records what was accepted; it is not a status hand-off.
+    assert entries[0].snapshot["evidence_requirements"][0]["review_outcome"] == (
+        REVIEW_OUTCOME_SATISFACTORY
+    )
+
+
+@pytest.mark.anyio
+async def test_the_analyst_recommends_with_an_amount(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF4", credits=1850)
+    await _seed_requirement(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "recommend_to_manager", "recommendedCredits": 1200},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["recommendedCredits"] == 1200
+    assert await _status_of(dbsession, action) == "Recommended to manager"
+
+    entries = await _history(dbsession, action)
+    assert entries[-1].event == EVENT_CREDITS_RECOMMENDED
+    assert entries[-1].snapshot["recommended_credits"] == 1200
+
+
+@pytest.mark.anyio
+async def test_recommending_needs_an_amount_and_satisfactory_evidence(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF5")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    # No requirements reviewed yet.
+    no_evidence = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "recommend_to_manager", "recommendedCredits": 10},
+    )
+    assert no_evidence.status_code == status.HTTP_400_BAD_REQUEST
+
+    await _seed_requirement(dbsession, action)
+    no_amount = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "recommend_to_manager"}
+    )
+    assert no_amount.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_a_recommendation_cannot_exceed_the_allocation(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF6", credits=1000)
+    await _seed_requirement(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "recommend_to_manager", "recommendedCredits": 1001},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_zero_is_a_real_recommendation(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Nought credits is a decision, not a missing value."""
+    action = await _seed_da(dbsession, "IA-26WF7", credits=1000)
+    await _seed_requirement(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "recommend_to_manager", "recommendedCredits": 0},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["recommendedCredits"] == 0
+
+
+@pytest.mark.anyio
+async def test_the_manager_returns_or_advances_to_the_director(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WF8", status_name="Recommended to manager")
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    returned = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "return", "comment": "Please revisit requirement two."},
+    )
+    assert returned.status_code == status.HTTP_200_OK
+    assert await _status_of(dbsession, action) == "Returned"
+
+    action.current_status_id = await _action_status_id(
+        dbsession, "Recommended to manager"
+    )
+    await dbsession.flush()
+
+    advanced = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "recommend_to_director"}
+    )
+    assert advanced.status_code == status.HTTP_200_OK
+    assert await _status_of(dbsession, action) == "Recommended to director"
+
+
+@pytest.mark.anyio
+async def test_the_director_approves(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Approved is the terminal reviewed state the ticket calls Completed.
+    No credits move — issuance is a separate step."""
+    action = await _seed_da(
+        dbsession, "IA-26WF9", status_name="Recommended to director"
+    )
+    await _seed_requirement(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_DIRECTOR)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "approve"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert await _status_of(dbsession, action) == "Approved"
+    assert response.json()["transactionId"] is None
+
+    entries = await _history(dbsession, action)
+    assert entries[-1].event == EVENT_STATUS_CHANGE
+    # The approval preserves what was approved.
+    assert "evidence_requirements" in entries[-1].snapshot
+
+
+@pytest.mark.anyio
+async def test_the_director_rejects_with_a_reason(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(
+        dbsession, "IA-26WFA", status_name="Recommended to director"
+    )
+    set_mock_user(fastapi_app, IDIR_DIRECTOR)
+
+    no_reason = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "reject"}
+    )
+    assert no_reason.status_code == status.HTTP_400_BAD_REQUEST
+
+    rejected = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "reject", "comment": "Evidence does not support the claim."},
+    )
+    assert rejected.status_code == status.HTTP_200_OK
+    assert await _status_of(dbsession, action) == "Rejected"
+
+
+@pytest.mark.anyio
+async def test_an_analyst_cannot_approve(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(
+        dbsession, "IA-26WFB", status_name="Recommended to director"
+    )
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "approve"}
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_a_manager_cannot_approve_their_own_recommendation(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Approval is the director's alone; a manager may only advance it."""
+    action = await _seed_da(
+        dbsession, "IA-26WFC", status_name="Recommended to director"
+    )
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "approve"}
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_an_action_cannot_skip_the_chain(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WFD", status_name="Underway")
+    set_mock_user(fastapi_app, IDIR_DIRECTOR)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "approve"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_an_unknown_action_is_refused(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WFE")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "issue_the_credits"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_proponents_are_refused_the_workflow(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WFF")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    response = await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "request_information", "comment": "hello"},
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_the_profile_offers_only_the_actions_this_caller_can_take(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(
+        dbsession, "IA-26WFG", status_name="Recommended to director"
+    )
+    set_mock_user(fastapi_app, IDIR_DIRECTOR)
+
+    profile = await client.get(
+        fastapi_app.url_path_for(
+            "get_designated_action_profile",
+            designated_action_id=action.designated_action_id,
+        )
+    )
+
+    available = profile.json()["availableActions"]
+    assert set(available) == {"approve", "reject", "return"}
+
+
+@pytest.mark.anyio
+async def test_the_history_endpoint_returns_the_trail_newest_first(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26WFH")
+    await _seed_requirement(dbsession, action)
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    await client.put(
+        _workflow_url(fastapi_app, action), json={"action": "accept_evidence"}
+    )
+    await client.put(
+        _workflow_url(fastapi_app, action),
+        json={"action": "recommend_to_manager", "recommendedCredits": 5},
+    )
+
+    response = await client.get(
+        fastapi_app.url_path_for(
+            "get_designated_action_history",
+            designated_action_id=action.designated_action_id,
+        )
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    events = [entry["event"] for entry in response.json()]
+    assert events == [EVENT_CREDITS_RECOMMENDED, EVENT_EVIDENCE_REVIEWED]

--- a/backend/lcfs/web/api/initiative_agreement/repo.py
+++ b/backend/lcfs/web/api/initiative_agreement/repo.py
@@ -737,6 +737,30 @@ class InitiativeAgreementRepository:
         return list(result.scalars().all())
 
     @repo_handler
+    async def get_designated_action_status_by_name(
+        self, status: str
+    ) -> Optional[DesignatedActionStatus]:
+        result = await self.db.execute(
+            select(DesignatedActionStatus).where(
+                DesignatedActionStatus.status == status
+            )
+        )
+        return result.scalars().first()
+
+    @repo_handler
+    async def get_designated_action_history(
+        self, designated_action_id: int
+    ) -> List[DesignatedActionHistory]:
+        """The action's audit trail, newest first."""
+        result = await self.db.execute(
+            select(DesignatedActionHistory)
+            .options(selectinload(DesignatedActionHistory.status))
+            .where(DesignatedActionHistory.designated_action_id == designated_action_id)
+            .order_by(desc(DesignatedActionHistory.designated_action_history_id))
+        )
+        return list(result.scalars().all())
+
+    @repo_handler
     async def add_designated_action_history(
         self, history: DesignatedActionHistory
     ) -> DesignatedActionHistory:

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -214,9 +214,36 @@ class EvidenceRequirementUpdateSchema(BaseSchema):
     clear_review_outcome: bool = False
 
 
+class DesignatedActionWorkflowSchema(BaseSchema):
+    action: str
+    # The dedicated text area behind Request additional information, and the
+    # reason a manager or director returns or rejects (#4898).
+    comment: Optional[str] = None
+    recommended_credits: Optional[int] = None
+
+
+class RecommendedCreditsSchema(BaseSchema):
+    recommended_credits: Optional[int] = None
+
+
+class DesignatedActionHistorySchema(BaseSchema):
+    designated_action_history_id: int
+    event: str
+    display_name: Optional[str] = None
+    create_date: Optional[datetime] = None
+    status: Optional[DesignatedActionStatusSchema] = None
+    snapshot: Optional[dict] = None
+
+    class Config:
+        from_attributes = True
+
+
 class DesignatedActionProfileSchema(DesignatedActionSchema):
     initiative_agreement_id: int
     ia_code: Optional[str] = None
+    # Which workflow actions this caller may take right now. Derived from
+    # the transition table so the page and the API cannot disagree.
+    available_actions: List[str] = []
     # Current-version sibling ids in action_number order, for the detail
     # page's previous/next navigation.
     sibling_action_ids: List[int] = []

--- a/backend/lcfs/web/api/initiative_agreement/services.py
+++ b/backend/lcfs/web/api/initiative_agreement/services.py
@@ -15,6 +15,9 @@ from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
     REVIEW_OUTCOMES,
     EvidenceRequirement,
 )
+from lcfs.db.models.initiative_agreement.EvidenceRequirement import (
+    REVIEW_OUTCOME_SATISFACTORY,
+)
 from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
     EVENT_ANALYST_ASSIGNED,
     EVENT_ANALYST_REASSIGNED,
@@ -32,6 +35,8 @@ from lcfs.web.api.base import (
 )
 from lcfs.web.api.internal_comment.services import sanitize_comment_text
 from lcfs.web.api.initiative_agreement.schema import (
+    DesignatedActionHistorySchema,
+    DesignatedActionWorkflowSchema,
     EvidenceRequirementCreateSchema,
     EvidenceRequirementSchema,
     EvidenceRequirementUpdateSchema,
@@ -49,6 +54,10 @@ from lcfs.web.api.initiative_agreement.schema import (
     InitiativeAgreementsListSchema,
 )
 from lcfs.web.api.initiative_agreement.repo import InitiativeAgreementRepository
+from lcfs.web.api.initiative_agreement.workflow import (
+    TRANSITIONS,
+    WORKFLOW_ACTIONS,
+)
 from lcfs.web.exception.exceptions import DataNotFoundException
 from lcfs.web.core.decorators import service_handler
 from lcfs.web.api.role.schema import user_has_roles
@@ -279,6 +288,9 @@ class InitiativeAgreementServices:
             initiative_agreement_id=action.initiative_agreement_id,
             ia_code=action.initiative_agreement.ia_code,
             sibling_action_ids=[s.designated_action_id for s in siblings],
+            available_actions=self._available_actions(
+                action, self.request.user if self.request else None
+            ),
         )
 
     async def _get_action_or_404(self, designated_action_id: int):
@@ -288,6 +300,198 @@ class InitiativeAgreementServices:
                 f"Designated action with id {designated_action_id} not found"
             )
         return action
+
+    def _user_may(self, transition, user) -> bool:
+        return any(user_has_roles(user, [role]) for role in transition.roles)
+
+    def _available_actions(self, action, user) -> List[str]:
+        """Actions this caller may take on this action right now."""
+        if user is None:
+            return []
+        current = action.current_status.status if action.current_status else None
+        return [
+            name
+            for name, transition in TRANSITIONS.items()
+            if self._user_may(transition, user) and current in transition.from_statuses
+        ]
+
+    async def _evidence_snapshot(self, designated_action_id: int) -> dict:
+        """Every requirement's review exactly as it stands.
+
+        Stored on the history event so a round's findings survive the next
+        one — requesting more information must never be the reason an
+        earlier assessment becomes unreadable.
+        """
+        requirements = await self.repo.get_evidence_requirements(designated_action_id)
+        return {
+            "evidence_requirements": [
+                {
+                    "evidence_requirement_id": r.evidence_requirement_id,
+                    "requirement_number": r.requirement_number,
+                    "description": r.description,
+                    "analyst_review": r.analyst_review,
+                    "review_outcome": r.review_outcome,
+                    "review_notes": r.review_notes,
+                    "reviewed_date": (
+                        r.reviewed_date.isoformat() if r.reviewed_date else None
+                    ),
+                }
+                for r in requirements
+            ]
+        }
+
+    async def _all_evidence_satisfactory(self, designated_action_id: int) -> bool:
+        requirements = await self.repo.get_evidence_requirements(designated_action_id)
+        if not requirements:
+            return False
+        return all(
+            r.review_outcome == REVIEW_OUTCOME_SATISFACTORY for r in requirements
+        )
+
+    @service_handler
+    async def set_recommended_credits(
+        self, designated_action_id: int, credits: Optional[int], user
+    ) -> DesignatedActionSchema:
+        """Persist the analyst's recommended amount before they recommend.
+
+        No history event: this is a working value until a recommendation is
+        actually made, and that event records the figure that counted.
+        """
+        action = await self._get_action_or_404(designated_action_id)
+        if credits is not None:
+            if credits < 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Recommended credits cannot be negative.",
+                )
+            if (
+                action.credit_allocation is not None
+                and credits > action.credit_allocation
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Recommended credits cannot exceed the "
+                        f"{action.credit_allocation} allocated to this action."
+                    ),
+                )
+        action.recommended_credits = credits
+        action.update_user = getattr(user, "keycloak_username", None)
+        await self.repo.db.flush()
+        refreshed = await self.repo.get_designated_action_by_id(designated_action_id)
+        return DesignatedActionSchema.model_validate(refreshed)
+
+    @service_handler
+    async def perform_workflow_action(
+        self, designated_action_id: int, data: DesignatedActionWorkflowSchema, user
+    ) -> DesignatedActionSchema:
+        """Advance a designated action through its review workflow (#4898)."""
+        action = await self._get_action_or_404(designated_action_id)
+
+        transition = TRANSITIONS.get(data.action)
+        if transition is None:
+            raise HTTPException(
+                status_code=400,
+                detail="action must be one of: " + ", ".join(WORKFLOW_ACTIONS),
+            )
+        if not self._user_may(transition, user):
+            raise HTTPException(
+                status_code=403,
+                detail="Your role may not take this action.",
+            )
+
+        current = action.current_status.status if action.current_status else None
+        if current not in transition.from_statuses:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"A designated action that is '{current}' cannot be "
+                    f"'{data.action}'."
+                ),
+            )
+
+        comment = (data.comment or "").strip()
+        if transition.requires_comment and not comment:
+            raise HTTPException(
+                status_code=400,
+                detail="This action requires a comment explaining it.",
+            )
+
+        if transition.requires_all_evidence_satisfactory:
+            if not await self._all_evidence_satisfactory(designated_action_id):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Every evidence requirement must be marked satisfactory "
+                        "first."
+                    ),
+                )
+
+        if transition.requires_credits:
+            credits = (
+                data.recommended_credits
+                if data.recommended_credits is not None
+                else action.recommended_credits
+            )
+            if credits is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="A recommended credit amount is required.",
+                )
+            await self.set_recommended_credits(designated_action_id, credits, user)
+            action = await self.repo.get_designated_action_by_id(designated_action_id)
+
+        snapshot = {}
+        if comment:
+            snapshot["comment"] = comment
+        if transition.captures_evidence:
+            snapshot.update(await self._evidence_snapshot(designated_action_id))
+        if transition.requires_credits:
+            snapshot["recommended_credits"] = action.recommended_credits
+
+        status_id = action.current_status_id
+        if transition.to_status is not None:
+            new_status = await self.repo.get_designated_action_status_by_name(
+                transition.to_status
+            )
+            if new_status is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Status '{transition.to_status}' is not configured.",
+                )
+            action.current_status_id = new_status.designated_action_status_id
+            status_id = new_status.designated_action_status_id
+
+        display_name = " ".join(
+            p
+            for p in (getattr(user, "first_name", ""), getattr(user, "last_name", ""))
+            if p
+        ).strip()
+        await self.repo.add_designated_action_history(
+            DesignatedActionHistory(
+                designated_action_id=action.designated_action_id,
+                designated_action_group_uuid=action.group_uuid,
+                event=transition.event,
+                status_id=status_id,
+                user_profile_id=getattr(user, "user_profile_id", None),
+                display_name=display_name or None,
+                snapshot=snapshot or None,
+            )
+        )
+        action.update_user = getattr(user, "keycloak_username", None)
+        await self.repo.db.flush()
+
+        refreshed = await self.repo.get_designated_action_by_id(designated_action_id)
+        return DesignatedActionSchema.model_validate(refreshed)
+
+    @service_handler
+    async def get_designated_action_history(
+        self, designated_action_id: int
+    ) -> List[DesignatedActionHistorySchema]:
+        """The audit trail behind the action, newest first."""
+        await self._get_action_or_404(designated_action_id)
+        history = await self.repo.get_designated_action_history(designated_action_id)
+        return [DesignatedActionHistorySchema.model_validate(h) for h in history]
 
     @service_handler
     async def get_evidence_requirements(

--- a/backend/lcfs/web/api/initiative_agreement/views.py
+++ b/backend/lcfs/web/api/initiative_agreement/views.py
@@ -4,6 +4,9 @@ from fastapi import APIRouter, Body, Depends, Request, status
 from lcfs.web.api.base import PaginationRequestSchema
 from lcfs.web.api.initiative_agreement.services import InitiativeAgreementServices
 from lcfs.web.api.initiative_agreement.schema import (
+    DesignatedActionHistorySchema,
+    DesignatedActionWorkflowSchema,
+    RecommendedCreditsSchema,
     EvidenceRequirementCreateSchema,
     EvidenceRequirementSchema,
     EvidenceRequirementUpdateSchema,
@@ -89,6 +92,61 @@ async def get_designated_actions(
     return await service.get_designated_actions_paginated(
         initiative_agreement_id, pagination
     )
+
+
+@router.put(
+    "/designated-actions/{designated_action_id}/workflow",
+    response_model=DesignatedActionSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def perform_designated_action_workflow(
+    request: Request,
+    designated_action_id: int,
+    data: DesignatedActionWorkflowSchema = Body(...),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Advance a designated action through its review workflow.
+
+    Gated to the Initiative Agreement roles at the door; which specific
+    action each role may take is enforced against the transition table.
+    """
+    return await service.perform_workflow_action(
+        designated_action_id, data, request.user
+    )
+
+
+@router.put(
+    "/designated-actions/{designated_action_id}/recommended-credits",
+    response_model=DesignatedActionSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_REVIEW_ROLES)
+async def set_designated_action_recommended_credits(
+    request: Request,
+    designated_action_id: int,
+    data: RecommendedCreditsSchema = Body(...),
+    service: InitiativeAgreementServices = Depends(),
+):
+    """Save the recommended amount before recommending."""
+    return await service.set_recommended_credits(
+        designated_action_id, data.recommended_credits, request.user
+    )
+
+
+@router.get(
+    "/designated-actions/{designated_action_id}/history",
+    response_model=List[DesignatedActionHistorySchema],
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(IA_IDIR_ROLES)
+async def get_designated_action_history(
+    request: Request,
+    designated_action_id: int,
+    service: InitiativeAgreementServices = Depends(),
+):
+    """The audit trail behind a designated action."""
+    return await service.get_designated_action_history(designated_action_id)
 
 
 @router.get(

--- a/backend/lcfs/web/api/initiative_agreement/workflow.py
+++ b/backend/lcfs/web/api/initiative_agreement/workflow.py
@@ -1,0 +1,146 @@
+"""Designated action workflow transitions (#4898).
+
+The whole workflow is one declarative table: who may take each action,
+which statuses it may be taken from, where it lands, and what it records.
+Keeping it here rather than scattered through the service means the rules
+can be read — and reviewed — in one place, and the tests assert against
+the same table the API enforces.
+
+Credit issuance is deliberately absent. Approving a designated action
+concludes its review; moving credits is a separate step, per #4898.
+"""
+
+from lcfs.db.models.initiative_agreement.DesignatedActionHistory import (
+    EVENT_CREDITS_RECOMMENDED,
+    EVENT_EVIDENCE_REVIEWED,
+    EVENT_INFORMATION_REQUESTED,
+    EVENT_STATUS_CHANGE,
+)
+from lcfs.db.models.user.Role import RoleEnum
+
+# Status names as seeded in designated_action_status. "Approved" is the
+# terminal reviewed state — the ticket calls it "Completed"; there is one
+# status and these are two names for it.
+STATUS_NOT_STARTED = "Not started"
+STATUS_SUBMISSION_RECEIVED = "Submission received"
+STATUS_UNDERWAY = "Underway"
+STATUS_INFORMATION_REQUESTED = "Information requested"
+STATUS_RECOMMENDED_TO_MANAGER = "Recommended to manager"
+STATUS_RECOMMENDED_TO_DIRECTOR = "Recommended to director"
+STATUS_APPROVED = "Approved"
+STATUS_RETURNED = "Returned"
+STATUS_REJECTED = "Rejected"
+STATUS_CANCELLED = "Cancelled"
+
+# Where an action can sit while an analyst is still working it.
+IN_REVIEW_STATUSES = (
+    STATUS_NOT_STARTED,
+    STATUS_SUBMISSION_RECEIVED,
+    STATUS_UNDERWAY,
+    STATUS_INFORMATION_REQUESTED,
+    STATUS_RETURNED,
+)
+
+ACTION_ACCEPT_EVIDENCE = "accept_evidence"
+ACTION_REQUEST_INFORMATION = "request_information"
+ACTION_RECOMMEND_TO_MANAGER = "recommend_to_manager"
+ACTION_RETURN = "return"
+ACTION_RECOMMEND_TO_DIRECTOR = "recommend_to_director"
+ACTION_APPROVE = "approve"
+ACTION_REJECT = "reject"
+
+
+class Transition:
+    """One workflow action.
+
+    ``to_status`` of None means the action records a decision without
+    moving the designated action — accepting the evidence is a review
+    milestone, not a change of hands.
+    """
+
+    def __init__(
+        self,
+        *,
+        roles,
+        from_statuses,
+        to_status,
+        event,
+        requires_comment=False,
+        requires_credits=False,
+        requires_all_evidence_satisfactory=False,
+        captures_evidence=False,
+    ):
+        self.roles = roles
+        self.from_statuses = from_statuses
+        self.to_status = to_status
+        self.event = event
+        self.requires_comment = requires_comment
+        self.requires_credits = requires_credits
+        self.requires_all_evidence_satisfactory = requires_all_evidence_satisfactory
+        self.captures_evidence = captures_evidence
+
+
+TRANSITIONS = {
+    # The analyst concludes the evidence review. Every active requirement
+    # must be satisfactory, which is what the wireframe's greyed-out
+    # Accept button means.
+    ACTION_ACCEPT_EVIDENCE: Transition(
+        roles=(RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER),
+        from_statuses=IN_REVIEW_STATUSES,
+        to_status=STATUS_UNDERWAY,
+        event=EVENT_EVIDENCE_REVIEWED,
+        requires_all_evidence_satisfactory=True,
+        captures_evidence=True,
+    ),
+    # Sends the action back to the proponent for more evidence. The
+    # snapshot carries the full review, so this round's findings survive
+    # the next one.
+    ACTION_REQUEST_INFORMATION: Transition(
+        roles=(RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER),
+        from_statuses=IN_REVIEW_STATUSES,
+        to_status=STATUS_INFORMATION_REQUESTED,
+        event=EVENT_INFORMATION_REQUESTED,
+        requires_comment=True,
+        captures_evidence=True,
+    ),
+    ACTION_RECOMMEND_TO_MANAGER: Transition(
+        roles=(RoleEnum.IA_ANALYST, RoleEnum.IA_MANAGER),
+        from_statuses=IN_REVIEW_STATUSES,
+        to_status=STATUS_RECOMMENDED_TO_MANAGER,
+        event=EVENT_CREDITS_RECOMMENDED,
+        requires_credits=True,
+        requires_all_evidence_satisfactory=True,
+    ),
+    ACTION_RETURN: Transition(
+        roles=(RoleEnum.IA_MANAGER, RoleEnum.DIRECTOR),
+        from_statuses=(
+            STATUS_RECOMMENDED_TO_MANAGER,
+            STATUS_RECOMMENDED_TO_DIRECTOR,
+        ),
+        to_status=STATUS_RETURNED,
+        event=EVENT_STATUS_CHANGE,
+        requires_comment=True,
+    ),
+    ACTION_RECOMMEND_TO_DIRECTOR: Transition(
+        roles=(RoleEnum.IA_MANAGER,),
+        from_statuses=(STATUS_RECOMMENDED_TO_MANAGER,),
+        to_status=STATUS_RECOMMENDED_TO_DIRECTOR,
+        event=EVENT_STATUS_CHANGE,
+    ),
+    ACTION_APPROVE: Transition(
+        roles=(RoleEnum.DIRECTOR,),
+        from_statuses=(STATUS_RECOMMENDED_TO_DIRECTOR,),
+        to_status=STATUS_APPROVED,
+        event=EVENT_STATUS_CHANGE,
+        captures_evidence=True,
+    ),
+    ACTION_REJECT: Transition(
+        roles=(RoleEnum.DIRECTOR,),
+        from_statuses=(STATUS_RECOMMENDED_TO_DIRECTOR,),
+        to_status=STATUS_REJECTED,
+        event=EVENT_STATUS_CHANGE,
+        requires_comment=True,
+    ),
+}
+
+WORKFLOW_ACTIONS = tuple(TRANSITIONS)

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -126,5 +126,24 @@
     "requirementNamePlaceholder": "Describe what the proponent must provide",
     "reviewedBy": "Reviewed by {{name}}",
     "pending": "Not yet reviewed"
+  },
+  "workflow": {
+    "accept": "Accept",
+    "requestInformation": "Request additional information",
+    "recommendToManager": "Recommend to manager",
+    "recommendToDirector": "Recommend to director",
+    "approve": "Approve",
+    "return": "Return for further work",
+    "reject": "Reject",
+    "submit": "Submit",
+    "commentPrompt": "Explain what is needed. This is kept with the designated action's history.",
+    "actionFailed": "That action could not be completed.",
+    "history": "Activity",
+    "noHistory": "Nothing has happened on this designated action yet.",
+    "confirm": {
+      "request_information": "Request additional information",
+      "return": "Return for further work",
+      "reject": "Reject this designated action"
+    }
   }
 }

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -86,6 +86,12 @@ export const apiRoutes = {
     '/initiative-agreements/designated-actions/:designatedActionId/evidence-requirements',
   evidenceRequirement:
     '/initiative-agreements/evidence-requirements/:evidenceRequirementId',
+  designatedActionWorkflow:
+    '/initiative-agreements/designated-actions/:designatedActionId/workflow',
+  designatedActionRecommendedCredits:
+    '/initiative-agreements/designated-actions/:designatedActionId/recommended-credits',
+  designatedActionHistory:
+    '/initiative-agreements/designated-actions/:designatedActionId/history',
   documentFolderTree: '/document-folders/:parentType/:parentID',
   documentFolderUpdate: '/document-folders/:parentType/:parentID/:folderId',
   documentFolderItems: '/document-folders/:parentType/:parentID/items',

--- a/frontend/src/hooks/useInitiativeAgreements.ts
+++ b/frontend/src/hooks/useInitiativeAgreements.ts
@@ -262,3 +262,72 @@ export const useDeleteEvidenceRequirement = (
         )
       )
   )
+
+/** Designated action workflow transitions and audit trail (#4898). */
+const actionPath = (template: string, designatedActionId: number | string) =>
+  template.replace(':designatedActionId', String(designatedActionId))
+
+export const useDesignatedActionWorkflow = (
+  designatedActionId: number | string
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: {
+      action: string
+      comment?: string
+      recommendedCredits?: number | null
+    }) =>
+      (
+        await client.put(
+          actionPath(apiRoutes.designatedActionWorkflow, designatedActionId),
+          payload
+        )
+      ).data,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['designated-actions'] })
+      queryClient.invalidateQueries({
+        queryKey: ['designated-action-history', String(designatedActionId)]
+      })
+    }
+  })
+}
+
+export const useSetRecommendedCredits = (
+  designatedActionId: number | string
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (recommendedCredits: number | null) =>
+      (
+        await client.put(
+          actionPath(
+            apiRoutes.designatedActionRecommendedCredits,
+            designatedActionId
+          ),
+          { recommendedCredits }
+        )
+      ).data,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['designated-actions'] })
+  })
+}
+
+export const useDesignatedActionHistory = (
+  designatedActionId: number | string,
+  options: QueryOptions<unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!designatedActionId,
+    queryKey: ['designated-action-history', String(designatedActionId)],
+    queryFn: async () =>
+      (
+        await client.get(
+          actionPath(apiRoutes.designatedActionHistory, designatedActionId)
+        )
+      ).data,
+    ...options
+  })
+}

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -27,11 +27,16 @@ import { ROUTES, buildPath } from '@/routes/routes'
 import { dateFormatter } from '@/utils/formatters'
 import withRole from '@/utils/withRole'
 
-import { useDesignatedActionProfile } from '@/hooks/useInitiativeAgreements'
+import {
+  useDesignatedActionProfile,
+  useEvidenceRequirements
+} from '@/hooks/useInitiativeAgreements'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useInitiativeAgreementPageStore } from '@/stores/useInitiativeAgreementPageStore'
 import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 import { DocumentTree } from './components/DocumentTree'
 import { EvidenceOfCompletion } from './components/EvidenceOfCompletion'
+import { DesignatedActionWorkflow } from './components/DesignatedActionWorkflow'
 
 // The shared document machinery keys on this string for designated actions.
 const PARENT_TYPE = 'designatedAction'
@@ -69,7 +74,21 @@ const DesignatedActionDetailBase = () => {
     error
   } = useDesignatedActionProfile(designatedActionId)
 
+  const { hasRoles } = useCurrentUser()
+  const canRecommend =
+    hasRoles?.(roles.ia_analyst) || hasRoles?.(roles.ia_manager)
+
+  const { data: requirements = [] } =
+    useEvidenceRequirements(designatedActionId)
+  const allEvidenceSatisfactory =
+    requirements.length > 0 &&
+    requirements.every((r) => r.reviewOutcome === 'Satisfactory')
+
   const queryClient = useQueryClient()
+  const refreshAction = () => {
+    queryClient.invalidateQueries({ queryKey: ['designated-actions'] })
+    queryClient.invalidateQueries({ queryKey: ['evidence-requirements'] })
+  }
   const refreshTree = () =>
     queryClient.invalidateQueries({
       queryKey: ['document-tree', PARENT_TYPE, String(designatedActionId)]
@@ -291,6 +310,20 @@ const DesignatedActionDetailBase = () => {
           additional information buttons belong to the workflow story. */}
       <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
         <EvidenceOfCompletion designatedActionId={designatedActionId} />
+      </Role>
+
+      {/* Workflow actions (#4898). Which buttons appear comes from the
+          API, so the page cannot offer a transition the server refuses. */}
+      <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+        <DesignatedActionWorkflow
+          designatedActionId={designatedActionId}
+          availableActions={action.availableActions}
+          recommendedCredits={action.recommendedCredits}
+          creditAllocation={action.creditAllocation}
+          allEvidenceSatisfactory={allEvidenceSatisfactory}
+          canEditCredits={canRecommend}
+          onChanged={refreshAction}
+        />
       </Role>
 
       <DocumentUploadDialog

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -39,7 +39,10 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 const mockProfile = vi.fn()
 vi.mock('@/hooks/useInitiativeAgreements', () => ({
-  useDesignatedActionProfile: () => mockProfile()
+  useDesignatedActionProfile: () => mockProfile(),
+  useEvidenceRequirements: () => ({
+    data: [{ evidenceRequirementId: 1, reviewOutcome: 'Satisfactory' }]
+  })
 }))
 
 const mockDocuments = vi.fn()
@@ -60,6 +63,14 @@ vi.mock('../components/EvidenceOfCompletion', () => ({
   EvidenceOfCompletion: () => <div data-test="evidence-of-completion" />
 }))
 
+const workflowProps = vi.fn()
+vi.mock('../components/DesignatedActionWorkflow', () => ({
+  DesignatedActionWorkflow: (props) => {
+    workflowProps(props)
+    return <div data-test="designated-action-workflow" />
+  }
+}))
+
 vi.mock('@/components/Comments', () => ({
   default: () => <div data-test="comments-component" />
 }))
@@ -74,7 +85,8 @@ const action = {
   currentStatus: { status: 'Underway', displayOrder: 30 },
   initiativeAgreementId: 5,
   iaCode: 'IA-26ORG1',
-  siblingActionIds: [9, 12, 15]
+  siblingActionIds: [9, 12, 15],
+  availableActions: ['accept_evidence', 'recommend_to_manager']
 }
 
 describe('DesignatedActionDetail', () => {
@@ -154,6 +166,19 @@ describe('DesignatedActionDetail', () => {
   it('renders the evidence of completion section', () => {
     render(<DesignatedActionDetail />, { wrapper })
     expect(screen.getByTestId('evidence-of-completion')).toBeInTheDocument()
+  })
+
+  it('passes the available actions and evidence state to the workflow', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+
+    expect(screen.getByTestId('designated-action-workflow')).toBeInTheDocument()
+    expect(workflowProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        availableActions: ['accept_evidence', 'recommend_to_manager'],
+        allEvidenceSatisfactory: true,
+        creditAllocation: 1850
+      })
+    )
   })
 
   it('renders the comments thread', () => {

--- a/frontend/src/views/InitiativeAgreements/components/DesignatedActionWorkflow.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DesignatedActionWorkflow.jsx
@@ -1,0 +1,242 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, Stack, TextField } from '@mui/material'
+
+import BCBox from '@/components/BCBox'
+import BCButton from '@/components/BCButton'
+import BCModal from '@/components/BCModal'
+import BCTypography from '@/components/BCTypography'
+import {
+  useDesignatedActionWorkflow,
+  useSetRecommendedCredits
+} from '@/hooks/useInitiativeAgreements'
+
+// Workflow actions for a designated action (#4898). Which buttons appear
+// is decided by the API — availableActions comes from the same transition
+// table the endpoint enforces, so the page can never offer an action the
+// server would refuse.
+export const ACTION_ACCEPT = 'accept_evidence'
+export const ACTION_REQUEST_INFORMATION = 'request_information'
+export const ACTION_RECOMMEND_TO_MANAGER = 'recommend_to_manager'
+export const ACTION_RETURN = 'return'
+export const ACTION_RECOMMEND_TO_DIRECTOR = 'recommend_to_director'
+export const ACTION_APPROVE = 'approve'
+export const ACTION_REJECT = 'reject'
+
+// Actions that must say why. The API requires the comment too; asking for
+// it here means the user finds out before they lose the click.
+const REQUIRES_COMMENT = new Set([
+  ACTION_REQUEST_INFORMATION,
+  ACTION_RETURN,
+  ACTION_REJECT
+])
+
+const BUTTONS = [
+  {
+    action: ACTION_ACCEPT,
+    labelKey: 'accept',
+    variant: 'outlined',
+    colour: 'primary'
+  },
+  {
+    action: ACTION_REQUEST_INFORMATION,
+    labelKey: 'requestInformation',
+    variant: 'outlined',
+    colour: 'error'
+  },
+  {
+    action: ACTION_RECOMMEND_TO_MANAGER,
+    labelKey: 'recommendToManager',
+    variant: 'contained',
+    colour: 'primary'
+  },
+  {
+    action: ACTION_RECOMMEND_TO_DIRECTOR,
+    labelKey: 'recommendToDirector',
+    variant: 'contained',
+    colour: 'primary'
+  },
+  {
+    action: ACTION_APPROVE,
+    labelKey: 'approve',
+    variant: 'contained',
+    colour: 'primary'
+  },
+  {
+    action: ACTION_RETURN,
+    labelKey: 'return',
+    variant: 'outlined',
+    colour: 'primary'
+  },
+  {
+    action: ACTION_REJECT,
+    labelKey: 'reject',
+    variant: 'outlined',
+    colour: 'error'
+  }
+]
+
+export const DesignatedActionWorkflow = ({
+  designatedActionId,
+  availableActions = [],
+  recommendedCredits,
+  creditAllocation,
+  allEvidenceSatisfactory,
+  canEditCredits = false,
+  onChanged
+}) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const [pendingAction, setPendingAction] = useState(null)
+  const [comment, setComment] = useState('')
+  const [credits, setCredits] = useState(
+    recommendedCredits === null || recommendedCredits === undefined
+      ? ''
+      : String(recommendedCredits)
+  )
+  const [error, setError] = useState('')
+
+  const { mutate: performAction, isPending } =
+    useDesignatedActionWorkflow(designatedActionId)
+  const { mutate: saveCredits } = useSetRecommendedCredits(designatedActionId)
+
+  const run = (action, payload = {}) => {
+    setError('')
+    performAction(
+      { action, ...payload },
+      {
+        onSuccess: () => {
+          setPendingAction(null)
+          setComment('')
+          onChanged?.()
+        },
+        onError: (err) => {
+          setError(
+            err?.response?.data?.detail ||
+              err?.message ||
+              t('initiativeAgreement:workflow.actionFailed')
+          )
+        }
+      }
+    )
+  }
+
+  const start = (action) => {
+    setError('')
+    if (REQUIRES_COMMENT.has(action)) {
+      setPendingAction(action)
+      return
+    }
+    if (action === ACTION_RECOMMEND_TO_MANAGER) {
+      run(action, {
+        recommendedCredits: credits === '' ? null : Number(credits)
+      })
+      return
+    }
+    run(action)
+  }
+
+  const visible = BUTTONS.filter((button) =>
+    availableActions.includes(button.action)
+  )
+
+  // Accepting and recommending both need every requirement satisfactory;
+  // showing that as a disabled button explains itself better than a
+  // rejected click would.
+  const blockedByEvidence = (action) =>
+    (action === ACTION_ACCEPT || action === ACTION_RECOMMEND_TO_MANAGER) &&
+    !allEvidenceSatisfactory
+
+  return (
+    <BCBox mt={3} data-test="designated-action-workflow">
+      {canEditCredits && (
+        <Box sx={{ mb: 2, maxWidth: 360 }}>
+          <BCTypography variant="body4" component="p" sx={{ fontWeight: 700 }}>
+            {t('initiativeAgreement:actionDetail.recommendedCredits')}
+          </BCTypography>
+          <TextField
+            size="small"
+            fullWidth
+            type="number"
+            value={credits}
+            inputProps={{
+              min: 0,
+              max: creditAllocation ?? undefined,
+              'data-test': 'recommended-credits-input'
+            }}
+            onChange={(event) => setCredits(event.target.value)}
+            onBlur={() => {
+              const next = credits === '' ? null : Number(credits)
+              if (next !== (recommendedCredits ?? null)) {
+                saveCredits(next)
+              }
+            }}
+          />
+        </Box>
+      )}
+
+      {error && (
+        <BCTypography
+          variant="body4"
+          color="error"
+          component="p"
+          data-test="workflow-error"
+          sx={{ mb: 1 }}
+        >
+          {error}
+        </BCTypography>
+      )}
+
+      <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+        {visible.map((button) => (
+          <BCButton
+            key={button.action}
+            type="button"
+            variant={button.variant}
+            color={button.colour}
+            size="small"
+            disabled={isPending || blockedByEvidence(button.action)}
+            data-test={`workflow-${button.action}`}
+            onClick={() => start(button.action)}
+          >
+            {t(`initiativeAgreement:workflow.${button.labelKey}`)}
+          </BCButton>
+        ))}
+      </Stack>
+
+      <BCModal
+        open={!!pendingAction}
+        onClose={() => {
+          setPendingAction(null)
+          setComment('')
+        }}
+        data={{
+          title: pendingAction
+            ? t(`initiativeAgreement:workflow.confirm.${pendingAction}`)
+            : '',
+          primaryButtonText: t('initiativeAgreement:workflow.submit'),
+          primaryButtonAction: () => run(pendingAction, { comment }),
+          primaryButtonDisabled: !comment.trim(),
+          secondaryButtonText: t('common:cancelBtn'),
+          content: (
+            <Box sx={{ minWidth: { xs: 'auto', sm: 420 } }}>
+              <BCTypography variant="body4" component="p" sx={{ mb: 1 }}>
+                {t('initiativeAgreement:workflow.commentPrompt')}
+              </BCTypography>
+              <TextField
+                multiline
+                minRows={4}
+                fullWidth
+                autoFocus
+                value={comment}
+                inputProps={{ 'data-test': 'workflow-comment' }}
+                onChange={(event) => setComment(event.target.value)}
+              />
+            </Box>
+          )
+        }}
+      />
+    </BCBox>
+  )
+}
+
+export default DesignatedActionWorkflow

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionWorkflow.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionWorkflow.test.jsx
@@ -1,0 +1,209 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DesignatedActionWorkflow } from '../DesignatedActionWorkflow'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+const mockPerform = vi.fn()
+const mockSaveCredits = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useDesignatedActionWorkflow: () => ({
+    mutate: mockPerform,
+    isPending: false
+  }),
+  useSetRecommendedCredits: () => ({ mutate: mockSaveCredits })
+}))
+
+const analystActions = [
+  'accept_evidence',
+  'request_information',
+  'recommend_to_manager'
+]
+
+describe('DesignatedActionWorkflow', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows only the actions the API says are available', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={['approve', 'reject', 'return']}
+        allEvidenceSatisfactory
+      />,
+      { wrapper }
+    )
+
+    expect(screen.getByTestId('workflow-approve')).toBeInTheDocument()
+    expect(screen.getByTestId('workflow-reject')).toBeInTheDocument()
+    expect(screen.getByTestId('workflow-return')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('workflow-recommend_to_manager')
+    ).not.toBeInTheDocument()
+  })
+
+  it('disables accept and recommend until every requirement is satisfactory', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory={false}
+      />,
+      { wrapper }
+    )
+
+    expect(screen.getByTestId('workflow-accept_evidence')).toBeDisabled()
+    expect(screen.getByTestId('workflow-recommend_to_manager')).toBeDisabled()
+    // Requesting information is exactly what you do when it is not.
+    expect(
+      screen.getByTestId('workflow-request_information')
+    ).not.toBeDisabled()
+  })
+
+  it('accepts the evidence without asking for anything else', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('workflow-accept_evidence'))
+
+    expect(mockPerform).toHaveBeenCalledWith(
+      { action: 'accept_evidence' },
+      expect.anything()
+    )
+  })
+
+  it('asks what is needed before requesting information', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('workflow-request_information'))
+    expect(mockPerform).not.toHaveBeenCalled()
+
+    const box = screen.getByTestId('workflow-comment')
+    fireEvent.change(box, { target: { value: 'Send the signed permit.' } })
+    fireEvent.click(screen.getByText('initiativeAgreement:workflow.submit'))
+
+    expect(mockPerform).toHaveBeenCalledWith(
+      { action: 'request_information', comment: 'Send the signed permit.' },
+      expect.anything()
+    )
+  })
+
+  it('sends the recommended amount when recommending', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+        canEditCredits
+        recommendedCredits={null}
+        creditAllocation={1850}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.change(screen.getByTestId('recommended-credits-input'), {
+      target: { value: '1200' }
+    })
+    fireEvent.click(screen.getByTestId('workflow-recommend_to_manager'))
+
+    expect(mockPerform).toHaveBeenCalledWith(
+      { action: 'recommend_to_manager', recommendedCredits: 1200 },
+      expect.anything()
+    )
+  })
+
+  it('saves an edited amount when the field loses focus', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+        canEditCredits
+        recommendedCredits={null}
+        creditAllocation={1850}
+      />,
+      { wrapper }
+    )
+
+    const input = screen.getByTestId('recommended-credits-input')
+    fireEvent.change(input, { target: { value: '900' } })
+    fireEvent.blur(input)
+
+    expect(mockSaveCredits).toHaveBeenCalledWith(900)
+  })
+
+  it('does not offer the credits field to a director', () => {
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={['approve', 'reject', 'return']}
+        allEvidenceSatisfactory
+        canEditCredits={false}
+        recommendedCredits={1200}
+      />,
+      { wrapper }
+    )
+
+    expect(
+      screen.queryByTestId('recommended-credits-input')
+    ).not.toBeInTheDocument()
+  })
+
+  it('surfaces the reason the API refused an action', () => {
+    mockPerform.mockImplementation((_payload, handlers) =>
+      handlers.onError({
+        response: {
+          data: { detail: 'A recommended credit amount is required.' }
+        }
+      })
+    )
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('workflow-accept_evidence'))
+
+    expect(screen.getByTestId('workflow-error')).toHaveTextContent(
+      'A recommended credit amount is required.'
+    )
+  })
+
+  it('tells the caller when something changed', () => {
+    const onChanged = vi.fn()
+    mockPerform.mockImplementation((_payload, handlers) => handlers.onSuccess())
+    render(
+      <DesignatedActionWorkflow
+        designatedActionId="9"
+        availableActions={analystActions}
+        allEvidenceSatisfactory
+        onChanged={onChanged}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(screen.getByTestId('workflow-accept_evidence'))
+
+    expect(onChanged).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

The designated action review workflow (#4898). Targets the module's epic branch. Completes the designated action page: analysts request information or recommend an amount, managers return or advance, directors approve, return or reject.

**"Completed" is Approved.** The ticket asks for Underway, Completed and Cancelled; the seeded vocabulary has *Approved* as the terminal reviewed state and no *Completed*. Confirmed with Alex that these are two names for one status rather than a missing one. If the business area wants the word changed, it is a seed update, not a schema change.

**No credits move.** Issuance is excluded from this story, and a test asserts the approved action still has no transaction attached.

### The transition table is the feature

The whole workflow is one declarative table in `workflow.py` — who may take each action, which statuses it may be taken from, where it lands, what it records, and what it demands first. Three things follow:

- The rules can be read and reviewed in one place instead of being spread through a service.
- The tests assert against the same table the endpoint enforces.
- The page renders only the actions the caller can actually take, because the profile endpoint derives `availableActions` from it. The UI cannot offer a transition the server would refuse.

### Notes for a reviewer

**The audit entry carries the review, not just the event.** Requesting information and approving both snapshot every requirement's assessment into `designated_action_history`. This is deliberate and is the one detail worth checking: CI applications solve the same problem by clearing their ten review columns on an information request while their history event carries no payload, so that round's analyst assessment is genuinely unrecoverable. Keeping the payload is what makes the trail worth having.

**Guards, and why each exists.** Accepting and recommending require every requirement satisfactory — that is what the wireframe's greyed-out Accept button means. Returning, rejecting and requesting information each require a reason, since an empty return tells the next person nothing. A recommendation cannot exceed the action's allocation, and **zero is a real recommendation** rather than a missing value, following the model's own note on that column.

**Accepting the evidence does not change hands.** It records the analyst's conclusion and unlocks recommending. The wireframe shows Accept and Recommend to manager as separate buttons, and inventing an "evidence accepted" status to sit between them seemed worse than recording the milestone in history. Flagging it as an interpretation.

### Testing

17 backend tests covering each transition, both directions of the evidence gate, the reason requirements, the allocation bound, zero as a recommendation, role refusals (an analyst cannot approve, a manager cannot approve their own recommendation), status-skipping, unknown actions, proponent refusal, the derived action list, and the history endpoint. 10 frontend tests on the action bar. 132 backend and 80 frontend tests pass across the module; type-check unchanged.

### Still outstanding across this module

WCAG 2.2 and keyboard-navigation validation appears on every Initiative Agreements ticket's checklist and has not been done on any of them, including this one. Worth its own pass rather than a claim.

Refs #4898
