### PR TITLE
Fix: FSE Records Missing from Report 3172 After Re-validation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: lcfs-repo-context
+description: Use this skill when working in the LCFS repository to understand the monorepo layout, local development commands, coding conventions, feature boundaries, tests, migrations, and documentation sources before making changes.
+---
+
+# LCFS Repo Context
+
+## What this repo is
+
+LCFS is the BC Low Carbon Fuel Standard web application. It is a monorepo with:
+
+- `backend/`: Python 3.9 FastAPI service using SQLAlchemy async ORM, Alembic, Redis, MinIO/S3, Keycloak auth, Poetry, pytest, Black, Isort, Flake8, and MyPy.
+- `frontend/`: React 18 + Vite app using MUI 6, React Query, React Hook Form, Yup, Zustand, AG Grid, Vitest, Testing Library, Cypress, ESLint, and Prettier.
+- `etl/`: Apache NiFi, Groovy scripts, PostgreSQL migration/import tooling, anonymization scripts, and a Python migration subsystem.
+- `openshift/`: deployment templates and maintenance/cleanup resources.
+- `mcp-server/`: TypeScript MCP server for local LCFS development and testing workflows.
+- `wiki/`: project documentation. Prefer these docs for deeper context instead of guessing.
+
+## First orientation steps
+
+1. Check `git status --short` before editing. The worktree may contain user changes; do not overwrite or revert them unless explicitly asked.
+2. Use `rg` and `rg --files` first for code search.
+3. Read the nearest implementation and test files for the feature area before editing. Most backend and frontend features are organized by domain.
+4. Load detailed docs only when relevant:
+   - Setup: `wiki/Development-Environment-Setup.md`
+   - Coding style: `wiki/Coding-Standards-and-Conventions.md`
+   - Testing: `wiki/Testing-Procedures.md`
+   - API map: `wiki/API-Endpoint-Reference.md`
+   - Schema overview: `wiki/Database-Schema-Overview.md`
+   - Compliance report states: `wiki/Compliance-Report-State-Matrix.md`
+   - Migration work: `wiki/Data-Migration-TFRS-to-LCFS.md`, `etl/python_migration/MIGRATION_CONTEXT.md`
+   - Deployment: `wiki/Deployment-Procedures.md`, `wiki/Deployment-Architecture.md`, `wiki/CI-CD-Pipeline.md`
+
+## Backend conventions
+
+- App package: `backend/lcfs`.
+- API feature slices usually live under `backend/lcfs/web/api/<feature>/` with `views.py`, `services.py`, `repo.py`, `schema.py`, and sometimes `validation.py`, `export.py`, or `importer.py`.
+- Routes are wired in `backend/lcfs/web/api/router.py`.
+- Models live under `backend/lcfs/db/models/<domain>/`.
+- Alembic migrations live in `backend/lcfs/db/migrations/versions/`; there are many existing migrations, so inspect recent patterns before adding one.
+- Tests live under `backend/lcfs/tests/<feature>/` and usually mirror backend feature names.
+- Configuration uses `backend/lcfs/settings.py`; environment variables use the `LCFS_` prefix, with `APP_ENVIRONMENT` mapped to `environment`.
+- Prefer existing decorators and dependency patterns from nearby routes. Public endpoints commonly use `public_view_handler`; authenticated routes commonly use `view_handler`.
+- Keep business logic in service classes, persistence in repos, request/response contracts in Pydantic schemas, and thin FastAPI route handlers.
+
+Backend commands:
+
+```bash
+cd backend
+poetry install
+poetry run python -m lcfs
+poetry run pytest lcfs/tests/<feature>
+poetry run black lcfs
+poetry run isort lcfs
+poetry run flake8 --count .
+poetry run mypy lcfs
+./migrate.sh -g "description"
+./migrate.sh -u
+```
+
+Backend tests require PostgreSQL. The root `docker-compose.yml` provides `db`, `redis`, `minio`, `backend`, and `frontend`; `docker-compose-db-only.yml` is available when only the database is needed.
+
+## Frontend conventions
+
+- App source: `frontend/src`.
+- Use the `@/` alias for imports from `frontend/src`.
+- Reusable UI belongs in `frontend/src/components`; page/domain features belong in `frontend/src/views/<Feature>`.
+- API hooks live in `frontend/src/hooks`, and HTTP plumbing is in `frontend/src/services/useApiService.ts`.
+- Route config lives in `frontend/src/routes/routeConfig`.
+- Shared auth context lives in `frontend/src/contexts/AuthorizationContext.tsx`.
+- Tests sit near code in `__tests__` directories and use Vitest/Testing Library.
+- Prefer existing BC-prefixed components (`BCButton`, `BCDataGrid`, `BCForm`, `BCAlert`, `BCTypography`, etc.) and existing MUI theme patterns before adding new styling conventions.
+- Use React Query for server state, React Hook Form + Yup for form state/validation, and Zustand only for global client state.
+
+Frontend commands:
+
+```bash
+cd frontend
+npm install
+npm run dev
+npm run test:run -- <path-or-pattern>
+npm run type-check
+npm run lint
+npm run prettier
+npm run build
+npm run cypress:run
+```
+
+## ETL and migration context
+
+- NiFi/Groovy scripts are in `etl/nifi_scripts`.
+- NiFi templates are in `etl/templates`.
+- Local ETL compose file is `etl/docker-compose.yml`.
+- Python migration work is under `etl/python_migration`, with its own `README.md`, `Makefile`, `requirements.txt`, `migrations/`, `validation/`, and `setup/`.
+- Data transfer scripts may require OpenShift CLI access and should not be run casually against shared environments.
+- Anonymization for non-production data is documented in `etl/ANONYMIZER.md`.
+
+## Local service map
+
+The root compose stack exposes:
+
+- Frontend: `http://localhost:3000`
+- Backend API: `http://localhost:8000`
+- Backend docs: `http://localhost:8000/docs`
+- PostgreSQL: `localhost:5432`
+- Redis: `localhost:6379`
+- MinIO API: `http://localhost:9000`
+- MinIO console: `http://localhost:9001`
+
+ETL compose exposes:
+
+- NiFi: `http://localhost:8091/nifi/`
+- NiFi Registry: `http://localhost:18080`
+
+## Validation guidance
+
+- For backend-only changes, run the closest `poetry run pytest lcfs/tests/<feature>` target. Add or update tests when service, repo, validation, permissions, state-transition, calculation, import/export, or migration behavior changes.
+- For frontend changes, run the closest `npm run test:run -- <test-file-or-folder>` target. Add or update tests for visible behavior, hooks, routes, forms, permissions, and API interactions.
+- Run `npm run type-check` after TypeScript changes.
+- Run formatting/linting commands for the touched area when practical.
+- If a command cannot run because dependencies, containers, credentials, or services are missing, state that clearly and include the exact command attempted.
+
+## Agent behavior in this repo
+
+- Keep edits narrowly scoped to the requested feature or bug.
+- Preserve user changes in the working tree.
+- Prefer established domain patterns over new abstractions.
+- Do not edit generated, cache, binary, or data-dump files unless the task specifically requires it.
+- Do not commit local config or secrets such as `frontend/cypress.env.json`, `.env`, database dumps, or OpenShift tokens.
+- For compliance calculations, report states, credit ledger behavior, and migrations, inspect existing tests and wiki docs before changing logic; these areas have high business risk.
+- When touching a backend API and frontend consumer together, update route/schema/service/hook/view/test contracts consistently.

--- a/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
+++ b/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
@@ -6,124 +6,24 @@ Create Date: 2026-03-24 12:00:00.000000
 """
 
 
-from alembic import op
-
-from lcfs.db.dependencies import (
-    create_role_if_not_exists,
-    execute_sql_sections,
-    find_and_read_sql_file,
-    parse_sql_sections,
-)
-
 # revision identifiers, used by Alembic.
 revision = "098cf79762b9"
 down_revision = "c7e4d9a1b2f6"
 branch_labels = None
 depends_on = None
 
-FSE_MATERIALIZED_VIEW_SECTIONS = [
-    "FSE Reporting Base View",
-    "FSE Reporting Base Preferred View",
-    "FSE Base View YoY Optimised",
-]
-
-FSE_REFRESH_TRIGGER_TABLES = {
-    "compliance_report": "refresh_fse_mv_after_cr",
-    "compliance_report_status": "refresh_fse_mv_after_crs",
-    "compliance_report_charging_equipment": "refresh_fse_mv_after_crce",
-    "charging_equipment": "refresh_fse_mv_after_ce",
-    "charging_site": "refresh_fse_mv_after_cs",
-    "level_of_equipment": "refresh_fse_mv_after_loe",
-    "charging_equipment_status": "refresh_fse_mv_after_ces",
-    "charging_equipment_intended_use_association": "refresh_fse_mv_after_ceiu",
-    "charging_equipment_intended_user_association": "refresh_fse_mv_after_ceiur",
-    "end_use_type": "refresh_fse_mv_after_eut",
-    "end_user_type": "refresh_fse_mv_after_eurt",
-    "charging_power_output": "refresh_fse_mv_after_cpo",
-    "organization": "refresh_fse_mv_after_org",
-    "compliance_period": "refresh_fse_mv_after_cp",
-}
-
-
-def _drop_relation(name: str) -> None:
-    op.execute(
-        f"""
-        DO $$
-        BEGIN
-            IF to_regclass('public.{name}') IS NOT NULL THEN
-                IF (
-                    SELECT relkind
-                    FROM pg_class
-                    WHERE oid = 'public.{name}'::regclass
-                ) = 'm' THEN
-                    DROP MATERIALIZED VIEW public.{name} CASCADE;
-                ELSE
-                    DROP VIEW public.{name} CASCADE;
-                END IF;
-            END IF;
-        END $$;
-        """
-    )
-
-
-def _drop_refresh_triggers() -> None:
-    for table_name, trigger_name in FSE_REFRESH_TRIGGER_TABLES.items():
-        op.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON {table_name};")
-
-
-def _create_refresh_triggers() -> None:
-    op.execute(
-        """
-        CREATE OR REPLACE FUNCTION refresh_fse_materialized_views()
-        RETURNS TRIGGER AS $$
-        BEGIN
-            IF to_regclass('public.v_fse_reporting_base_pref') IS NOT NULL THEN
-                REFRESH MATERIALIZED VIEW v_fse_reporting_base_pref;
-            END IF;
-
-            IF to_regclass('public.vw_fse_base') IS NOT NULL THEN
-                REFRESH MATERIALIZED VIEW vw_fse_base;
-            END IF;
-
-            RETURN NULL;
-        END;
-        $$ LANGUAGE plpgsql;
-        """
-    )
-
-    for table_name, trigger_name in FSE_REFRESH_TRIGGER_TABLES.items():
-        op.execute(
-            f"""
-            CREATE TRIGGER {trigger_name}
-            AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON {table_name}
-            FOR EACH STATEMENT
-            EXECUTE FUNCTION refresh_fse_materialized_views();
-            """
-        )
-
 
 def upgrade() -> None:
     """
-    Recreate FSE reporting objects as materialized views.
+    Recreate v_fse_reporting_base_pref to match compliance records by
+    compliance_report_group_uuid instead of compliance_report_id.
 
     This fixes supplemental reports not showing kWh data that was uploaded
-    against the original report in the same compliance report group, and keeps
-    assessed historical report rows visible even when later equipment
-    validation changes the current/latest FSE row used by the editing view.
+    against the original report in the same compliance report group.
     """
-    create_role_if_not_exists()
-    _drop_refresh_triggers()
-    _drop_relation("vw_fse_base")
-    _drop_relation("v_fse_reporting_base_pref")
-    content = find_and_read_sql_file(sqlFile="metabase.sql")
-    sections = parse_sql_sections(content)
-    execute_sql_sections(sections, FSE_MATERIALIZED_VIEW_SECTIONS)
-    _create_refresh_triggers()
+    pass
 
 
 def downgrade() -> None:
-    """Remove FSE materialized views and refresh automation."""
-    _drop_refresh_triggers()
-    op.execute("DROP FUNCTION IF EXISTS refresh_fse_materialized_views();")
-    _drop_relation("vw_fse_base")
-    _drop_relation("v_fse_reporting_base_pref")
+    """Drop and recreate with original logic."""
+    pass

--- a/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
+++ b/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
@@ -6,24 +6,116 @@ Create Date: 2026-03-24 12:00:00.000000
 """
 
 
+from alembic import op
+
+from lcfs.db.dependencies import (
+    create_role_if_not_exists,
+    execute_sql_sections,
+    find_and_read_sql_file,
+    parse_sql_sections,
+)
+
 # revision identifiers, used by Alembic.
 revision = "098cf79762b9"
 down_revision = "c7e4d9a1b2f6"
 branch_labels = None
 depends_on = None
 
+FSE_MATERIALIZED_VIEW_SECTIONS = [
+    "FSE Reporting Base Preferred View",
+    "FSE Base View YoY Optimised",
+]
+
+FSE_REFRESH_TRIGGER_TABLES = {
+    "compliance_report": "refresh_fse_mv_after_cr",
+    "compliance_report_charging_equipment": "refresh_fse_mv_after_crce",
+    "charging_equipment": "refresh_fse_mv_after_ce",
+    "charging_site": "refresh_fse_mv_after_cs",
+    "charging_equipment_intended_use_association": "refresh_fse_mv_after_ceiu",
+    "charging_equipment_intended_user_association": "refresh_fse_mv_after_ceiur",
+    "organization": "refresh_fse_mv_after_org",
+}
+
+
+def _drop_relation(name: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF to_regclass('public.{name}') IS NOT NULL THEN
+                IF (
+                    SELECT relkind
+                    FROM pg_class
+                    WHERE oid = 'public.{name}'::regclass
+                ) = 'm' THEN
+                    DROP MATERIALIZED VIEW public.{name} CASCADE;
+                ELSE
+                    DROP VIEW public.{name} CASCADE;
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _drop_refresh_triggers() -> None:
+    for table_name, trigger_name in FSE_REFRESH_TRIGGER_TABLES.items():
+        op.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON {table_name};")
+
+
+def _create_refresh_triggers() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION refresh_fse_materialized_views()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF to_regclass('public.v_fse_reporting_base_pref') IS NOT NULL THEN
+                REFRESH MATERIALIZED VIEW v_fse_reporting_base_pref;
+            END IF;
+
+            IF to_regclass('public.vw_fse_base') IS NOT NULL THEN
+                REFRESH MATERIALIZED VIEW vw_fse_base;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    for table_name, trigger_name in FSE_REFRESH_TRIGGER_TABLES.items():
+        op.execute(
+            f"""
+            CREATE TRIGGER {trigger_name}
+            AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON {table_name}
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION refresh_fse_materialized_views();
+            """
+        )
+
 
 def upgrade() -> None:
     """
-    Recreate v_fse_reporting_base_pref to match compliance records by
-    compliance_report_group_uuid instead of compliance_report_id.
+    Recreate FSE reporting objects as materialized views.
 
     This fixes supplemental reports not showing kWh data that was uploaded
-    against the original report in the same compliance report group.
+    against the original report in the same compliance report group, and keeps
+    assessed historical report rows visible even when later equipment
+    validation changes the current/latest FSE row used by the editing view.
     """
-    pass
+    create_role_if_not_exists()
+    _drop_refresh_triggers()
+    _drop_relation("vw_fse_base")
+    _drop_relation("v_fse_reporting_base_pref")
+    content = find_and_read_sql_file(sqlFile="metabase.sql")
+    sections = parse_sql_sections(content)
+    execute_sql_sections(sections, FSE_MATERIALIZED_VIEW_SECTIONS)
+    _create_refresh_triggers()
 
 
 def downgrade() -> None:
-    """Drop and recreate with original logic."""
-    pass
+    """Remove FSE materialized views and refresh automation."""
+    _drop_refresh_triggers()
+    op.execute("DROP FUNCTION IF EXISTS refresh_fse_materialized_views();")
+    _drop_relation("vw_fse_base")
+    _drop_relation("v_fse_reporting_base_pref")

--- a/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
+++ b/backend/lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py
@@ -22,18 +22,26 @@ branch_labels = None
 depends_on = None
 
 FSE_MATERIALIZED_VIEW_SECTIONS = [
+    "FSE Reporting Base View",
     "FSE Reporting Base Preferred View",
     "FSE Base View YoY Optimised",
 ]
 
 FSE_REFRESH_TRIGGER_TABLES = {
     "compliance_report": "refresh_fse_mv_after_cr",
+    "compliance_report_status": "refresh_fse_mv_after_crs",
     "compliance_report_charging_equipment": "refresh_fse_mv_after_crce",
     "charging_equipment": "refresh_fse_mv_after_ce",
     "charging_site": "refresh_fse_mv_after_cs",
+    "level_of_equipment": "refresh_fse_mv_after_loe",
+    "charging_equipment_status": "refresh_fse_mv_after_ces",
     "charging_equipment_intended_use_association": "refresh_fse_mv_after_ceiu",
     "charging_equipment_intended_user_association": "refresh_fse_mv_after_ceiur",
+    "end_use_type": "refresh_fse_mv_after_eut",
+    "end_user_type": "refresh_fse_mv_after_eurt",
+    "charging_power_output": "refresh_fse_mv_after_cpo",
     "organization": "refresh_fse_mv_after_org",
+    "compliance_period": "refresh_fse_mv_after_cp",
 }
 
 

--- a/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
@@ -1,12 +1,14 @@
-"""Convert FSE reporting base views to materialized views.
+"""Create FSE reporting base view and preferred materialized view.
 
 Revision ID: c8d9e0f1a2b3
 Revises: a1c2d3e4f5b6
 Create Date: 2026-08-27 10:00:00.000000
 """
 
-from alembic import op
 from pathlib import Path
+
+from alembic import op
+import sqlalchemy as sa
 
 
 revision = "c8d9e0f1a2b3"
@@ -31,9 +33,26 @@ FSE_REFRESH_TRIGGERS = [
 
 OLD_BASE_VIEW_NAME = "v_fse_reporting_base"
 OLD_PREF_VIEW_NAME = "v_fse_reporting_base_pref"
-NEW_BASE_VIEW_NAME = "mv_fse_reporting_base"
+OLD_BASE_MATERIALIZED_VIEW_NAME = "mv_fse_reporting_base"
+NEW_BASE_VIEW_NAME = "v_fse_reporting_base"
 NEW_PREF_VIEW_NAME = "mv_fse_reporting_base_pref"
 FSE_SQL_SECTIONS = ("FSE Reporting Base View", "FSE Reporting Base Preferred View")
+VW_FSE_BASE_NAME = "vw_fse_base"
+VW_FSE_BASE_START_MARKER = f"DROP VIEW IF EXISTS {VW_FSE_BASE_NAME} CASCADE;"
+VW_FSE_BASE_END_MARKER = "-- Electricity Allocation FSE Match Query"
+
+ASSOCIATION_TABLES = (
+    (
+        "charging_equipment_intended_use_association",
+        "end_use_type_id",
+        "ix_ce_intended_use_equipment_version",
+    ),
+    (
+        "charging_equipment_intended_user_association",
+        "end_user_type_id",
+        "ix_ce_intended_user_equipment_version",
+    ),
+)
 
 
 def _parse_sql_sections(content: str) -> dict[str, str]:
@@ -89,18 +108,49 @@ def _fse_section_statements() -> list[str]:
     return statements
 
 
+def _vw_fse_base_statements() -> list[str]:
+    metabase_path = Path(__file__).resolve().parents[2] / "sql/views/metabase.sql"
+    content = metabase_path.read_text()
+    start = content.index(VW_FSE_BASE_START_MARKER)
+    end = content.index(VW_FSE_BASE_END_MARKER, start)
+    section = content[start:end]
+    return [stmt.strip() for stmt in section.split(";") if stmt.strip()]
+
+
 def _definition_with_old_names(definition: str) -> str:
     return definition.replace(NEW_PREF_VIEW_NAME, OLD_PREF_VIEW_NAME).replace(
         NEW_BASE_VIEW_NAME, OLD_BASE_VIEW_NAME
     )
 
 
+def _legacy_definition_without_association_version(definition: str) -> str:
+    replacements = {
+        "        ceiu.charging_equipment_version,\n": "",
+        "        ceiu2.charging_equipment_version,\n": "",
+        "    GROUP BY ceiu.charging_equipment_id, ceiu.charging_equipment_version": (
+            "    GROUP BY ceiu.charging_equipment_id"
+        ),
+        "    GROUP BY ceiu2.charging_equipment_id, ceiu2.charging_equipment_version": (
+            "    GROUP BY ceiu2.charging_equipment_id"
+        ),
+        "\n   AND ce.version = eu.charging_equipment_version": "",
+        "\n       AND ce.version = eu.charging_equipment_version": "",
+        "\n   AND ce.version = eus.charging_equipment_version": "",
+        "\n       AND ce.version = eus.charging_equipment_version": "",
+    }
+    for old, new in replacements.items():
+        definition = definition.replace(old, new)
+    return definition
+
+
 def _drop_current_fse_relations() -> None:
     for relation_name in (
         NEW_PREF_VIEW_NAME,
         OLD_PREF_VIEW_NAME,
+        OLD_BASE_MATERIALIZED_VIEW_NAME,
         NEW_BASE_VIEW_NAME,
         OLD_BASE_VIEW_NAME,
+        VW_FSE_BASE_NAME,
     ):
         op.execute(
             f"""
@@ -132,14 +182,137 @@ def _create_current_materialized_views_from_sql() -> None:
         op.execute(statement)
 
 
+def _create_vw_fse_base_from_sql() -> None:
+    for statement in _vw_fse_base_statements():
+        if statement.upper().startswith("GRANT "):
+            continue
+        op.execute(statement)
+
+
 def _create_legacy_views_from_sql() -> None:
     for statement in _fse_section_statements():
-        if not statement.upper().startswith("CREATE MATERIALIZED VIEW "):
+        statement_upper = statement.upper()
+        if not (
+            statement_upper.startswith("CREATE MATERIALIZED VIEW ")
+            or statement_upper.startswith("CREATE OR REPLACE VIEW ")
+        ):
             continue
-        legacy_statement = _definition_with_old_names(statement).replace(
-            "CREATE MATERIALIZED VIEW", "CREATE VIEW", 1
+        legacy_statement = _legacy_definition_without_association_version(
+            _definition_with_old_names(statement)
         )
+        if statement_upper.startswith("CREATE MATERIALIZED VIEW "):
+            legacy_statement = legacy_statement.replace(
+                "CREATE MATERIALIZED VIEW", "CREATE VIEW", 1
+            )
         op.execute(legacy_statement)
+
+
+def _drop_primary_key(table_name: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            pk_name text;
+        BEGIN
+            SELECT conname
+            INTO pk_name
+            FROM pg_constraint
+            WHERE conrelid = '{table_name}'::regclass
+              AND contype = 'p';
+
+            IF pk_name IS NOT NULL THEN
+                EXECUTE format(
+                    'ALTER TABLE %I DROP CONSTRAINT %I',
+                    '{table_name}',
+                    pk_name
+                );
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _add_version_to_association(
+    table_name: str, type_column: str, index_name: str
+) -> None:
+    op.add_column(
+        table_name,
+        sa.Column(
+            "charging_equipment_version",
+            sa.Integer(),
+            nullable=True,
+            comment="Version of the referenced charging equipment",
+        ),
+    )
+
+    staged_table_name = f"{table_name}_version_backfill"
+    op.execute(
+        f"""
+        CREATE TEMPORARY TABLE {staged_table_name} ON COMMIT DROP AS
+        SELECT DISTINCT
+            versioned_equipment.charging_equipment_id,
+            versioned_equipment.version AS charging_equipment_version,
+            association.{type_column}
+        FROM {table_name} association
+        JOIN charging_equipment source_equipment
+            ON source_equipment.charging_equipment_id = association.charging_equipment_id
+        JOIN charging_equipment versioned_equipment
+            ON versioned_equipment.group_uuid = source_equipment.group_uuid
+        """
+    )
+
+    op.execute(f"DELETE FROM {table_name}")
+
+    op.execute(
+        f"""
+        INSERT INTO {table_name} (
+            charging_equipment_id,
+            charging_equipment_version,
+            {type_column}
+        )
+        SELECT
+            charging_equipment_id,
+            charging_equipment_version,
+            {type_column}
+        FROM {staged_table_name}
+        """
+    )
+
+    op.alter_column(
+        table_name,
+        "charging_equipment_version",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+    _drop_primary_key(table_name)
+    op.create_primary_key(
+        op.f(f"pk_{table_name}"),
+        table_name,
+        ["charging_equipment_id", "charging_equipment_version", type_column],
+    )
+    op.create_index(
+        index_name,
+        table_name,
+        ["charging_equipment_id", "charging_equipment_version"],
+    )
+
+
+def _add_association_versions() -> None:
+    for table_name, type_column, index_name in ASSOCIATION_TABLES:
+        _add_version_to_association(table_name, type_column, index_name)
+
+
+def _drop_association_versions() -> None:
+    for table_name, type_column, index_name in reversed(ASSOCIATION_TABLES):
+        op.drop_index(index_name, table_name=table_name)
+        _drop_primary_key(table_name)
+        op.create_primary_key(
+            op.f(f"pk_{table_name}"),
+            table_name,
+            ["charging_equipment_id", type_column],
+        )
+        op.drop_column(table_name, "charging_equipment_version")
 
 
 def _create_source_indexes() -> None:
@@ -155,14 +328,49 @@ def _create_source_indexes() -> None:
     )
 
 
+def _create_refresh_state_table() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fse_reporting_mv_refresh_state (
+            id integer PRIMARY KEY DEFAULT 1,
+            dirty_generation bigint NOT NULL DEFAULT 0,
+            refreshed_generation bigint NOT NULL DEFAULT 0,
+            create_date timestamp with time zone NOT NULL DEFAULT now(),
+            update_date timestamp with time zone NOT NULL DEFAULT now(),
+            CONSTRAINT ck_fse_reporting_mv_refresh_state_singleton CHECK (id = 1)
+        );
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO fse_reporting_mv_refresh_state (
+            id,
+            dirty_generation,
+            refreshed_generation
+        )
+        VALUES (1, 0, 0)
+        ON CONFLICT (id) DO NOTHING;
+        """
+    )
+
+
 def _create_refresh_function() -> None:
     op.execute(
         """
         CREATE OR REPLACE FUNCTION refresh_fse_reporting_base_views()
         RETURNS TRIGGER AS $$
         BEGIN
-            REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base;
-            REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base_pref;
+            INSERT INTO fse_reporting_mv_refresh_state (
+                id,
+                dirty_generation,
+                refreshed_generation,
+                update_date
+            )
+            VALUES (1, 1, 0, now())
+            ON CONFLICT (id) DO UPDATE
+                SET dirty_generation =
+                        fse_reporting_mv_refresh_state.dirty_generation + 1,
+                    update_date = now();
             RETURN NULL;
         END;
         $$ LANGUAGE plpgsql;
@@ -207,9 +415,21 @@ def _drop_refresh_triggers() -> None:
 
 def upgrade() -> None:
     _create_source_indexes()
+    _create_refresh_state_table()
     _drop_current_fse_relations()
+    _add_association_versions()
     _create_current_materialized_views_from_sql()
+    _create_vw_fse_base_from_sql()
+    op.execute(
+        """
+        UPDATE fse_reporting_mv_refresh_state
+        SET refreshed_generation = dirty_generation,
+            update_date = now()
+        WHERE id = 1;
+        """
+    )
     _grant_select_if_role_exists(NEW_PREF_VIEW_NAME)
+    _grant_select_if_role_exists(VW_FSE_BASE_NAME)
     _create_refresh_function()
     _create_refresh_triggers()
 
@@ -219,5 +439,7 @@ def downgrade() -> None:
     op.execute("DROP FUNCTION IF EXISTS refresh_fse_reporting_base_views();")
     _drop_current_fse_relations()
     op.execute("DROP INDEX IF EXISTS ix_charging_site_group_uuid_version_id;")
+    op.execute("DROP TABLE IF EXISTS fse_reporting_mv_refresh_state;")
+    _drop_association_versions()
     _create_legacy_views_from_sql()
     _grant_select_if_role_exists(OLD_PREF_VIEW_NAME)

--- a/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
@@ -401,7 +401,7 @@ def _create_refresh_triggers() -> None:
         op.execute(
             f"""
             CREATE TRIGGER {trigger_name}
-            AFTER INSERT OR UPDATE ON {table_name}
+            AFTER INSERT OR UPDATE OR DELETE ON {table_name}
             FOR EACH STATEMENT
             EXECUTE FUNCTION refresh_fse_reporting_base_views();
             """

--- a/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-27-10-00_c8d9e0f1a2b3.py
@@ -1,0 +1,223 @@
+"""Convert FSE reporting base views to materialized views.
+
+Revision ID: c8d9e0f1a2b3
+Revises: a1c2d3e4f5b6
+Create Date: 2026-08-27 10:00:00.000000
+"""
+
+from alembic import op
+from pathlib import Path
+
+
+revision = "c8d9e0f1a2b3"
+down_revision = "a1c2d3e4f5b6"
+branch_labels = None
+depends_on = None
+
+
+FSE_REFRESH_TRIGGERS = [
+    ("charging_equipment", "refresh_fse_reporting_mvs_after_ce"),
+    (
+        "charging_equipment_intended_use_association",
+        "refresh_fse_reporting_mvs_after_ceiu",
+    ),
+    (
+        "charging_equipment_intended_user_association",
+        "refresh_fse_reporting_mvs_after_ceuser",
+    ),
+    ("charging_site", "refresh_fse_reporting_mvs_after_cs"),
+    ("compliance_report_charging_equipment", "refresh_fse_reporting_mvs_after_crce"),
+]
+
+OLD_BASE_VIEW_NAME = "v_fse_reporting_base"
+OLD_PREF_VIEW_NAME = "v_fse_reporting_base_pref"
+NEW_BASE_VIEW_NAME = "mv_fse_reporting_base"
+NEW_PREF_VIEW_NAME = "mv_fse_reporting_base_pref"
+FSE_SQL_SECTIONS = ("FSE Reporting Base View", "FSE Reporting Base Preferred View")
+
+
+def _parse_sql_sections(content: str) -> dict[str, str]:
+    sections = {}
+    current_section = None
+    current_sql = []
+
+    lines = content.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if (
+            line.startswith("--")
+            and "=" in line
+            and len(line) > 20
+            and i + 1 < len(lines)
+        ):
+            next_line = lines[i + 1].strip()
+            if (
+                next_line.startswith("--")
+                and "=" not in next_line
+                and next_line.replace("--", "").strip()
+            ):
+                if current_section and current_sql:
+                    sql_content = "\n".join(current_sql).strip()
+                    if sql_content:
+                        sections[current_section] = sql_content
+                current_section = next_line.replace("--", "").strip()
+                current_sql = []
+                i += 2
+                continue
+        elif current_section:
+            current_sql.append(lines[i])
+        i += 1
+
+    if current_section and current_sql:
+        sql_content = "\n".join(current_sql).strip()
+        if sql_content:
+            sections[current_section] = sql_content
+
+    return sections
+
+
+def _fse_section_statements() -> list[str]:
+    metabase_path = Path(__file__).resolve().parents[2] / "sql/views/metabase.sql"
+    sections = _parse_sql_sections(metabase_path.read_text())
+    statements = []
+    for section_name in FSE_SQL_SECTIONS:
+        section_sql = sections[section_name]
+        statements.extend(
+            stmt.strip() for stmt in section_sql.split(";") if stmt.strip()
+        )
+    return statements
+
+
+def _definition_with_old_names(definition: str) -> str:
+    return definition.replace(NEW_PREF_VIEW_NAME, OLD_PREF_VIEW_NAME).replace(
+        NEW_BASE_VIEW_NAME, OLD_BASE_VIEW_NAME
+    )
+
+
+def _drop_current_fse_relations() -> None:
+    for relation_name in (
+        NEW_PREF_VIEW_NAME,
+        OLD_PREF_VIEW_NAME,
+        NEW_BASE_VIEW_NAME,
+        OLD_BASE_VIEW_NAME,
+    ):
+        op.execute(
+            f"""
+            DO $$
+            DECLARE
+                relation_kind "char";
+            BEGIN
+                SELECT c.relkind
+                INTO relation_kind
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relname = '{relation_name}'
+                  AND n.nspname = current_schema();
+
+                IF relation_kind = 'm' THEN
+                    EXECUTE 'DROP MATERIALIZED VIEW IF EXISTS {relation_name} CASCADE';
+                ELSIF relation_kind = 'v' THEN
+                    EXECUTE 'DROP VIEW IF EXISTS {relation_name} CASCADE';
+                END IF;
+            END $$;
+            """
+        )
+
+
+def _create_current_materialized_views_from_sql() -> None:
+    for statement in _fse_section_statements():
+        if statement.upper().startswith("GRANT "):
+            continue
+        op.execute(statement)
+
+
+def _create_legacy_views_from_sql() -> None:
+    for statement in _fse_section_statements():
+        if not statement.upper().startswith("CREATE MATERIALIZED VIEW "):
+            continue
+        legacy_statement = _definition_with_old_names(statement).replace(
+            "CREATE MATERIALIZED VIEW", "CREATE VIEW", 1
+        )
+        op.execute(legacy_statement)
+
+
+def _create_source_indexes() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_charging_site_group_uuid_version_id
+            ON charging_site (
+                group_uuid,
+                version DESC,
+                charging_site_id DESC
+            );
+        """
+    )
+
+
+def _create_refresh_function() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION refresh_fse_reporting_base_views()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base;
+            REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base_pref;
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def _grant_select_if_role_exists(relation_name: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'basic_lcfs_reporting_role'
+            ) THEN
+                GRANT SELECT
+                    ON {relation_name}
+                    TO basic_lcfs_reporting_role;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _create_refresh_triggers() -> None:
+    for table_name, trigger_name in FSE_REFRESH_TRIGGERS:
+        op.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON {table_name};")
+        op.execute(
+            f"""
+            CREATE TRIGGER {trigger_name}
+            AFTER INSERT OR UPDATE ON {table_name}
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION refresh_fse_reporting_base_views();
+            """
+        )
+
+
+def _drop_refresh_triggers() -> None:
+    for table_name, trigger_name in FSE_REFRESH_TRIGGERS:
+        op.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON {table_name};")
+
+
+def upgrade() -> None:
+    _create_source_indexes()
+    _drop_current_fse_relations()
+    _create_current_materialized_views_from_sql()
+    _grant_select_if_role_exists(NEW_PREF_VIEW_NAME)
+    _create_refresh_function()
+    _create_refresh_triggers()
+
+
+def downgrade() -> None:
+    _drop_refresh_triggers()
+    op.execute("DROP FUNCTION IF EXISTS refresh_fse_reporting_base_views();")
+    _drop_current_fse_relations()
+    op.execute("DROP INDEX IF EXISTS ix_charging_site_group_uuid_version_id;")
+    _create_legacy_views_from_sql()
+    _grant_select_if_role_exists(OLD_PREF_VIEW_NAME)

--- a/backend/lcfs/db/models/compliance/ChargingEquipment.py
+++ b/backend/lcfs/db/models/compliance/ChargingEquipment.py
@@ -1,5 +1,6 @@
 from lcfs.db.base import BaseModel, Auditable, Versioning
 from sqlalchemy import (
+    and_,
     Column,
     Double,
     Integer,
@@ -11,7 +12,7 @@ from sqlalchemy import (
     select,
     event,
 )
-from sqlalchemy.orm import relationship, Session
+from sqlalchemy.orm import foreign, relationship, Session
 import enum
 
 
@@ -30,6 +31,12 @@ charging_equipment_intended_use_association = Table(
         primary_key=True,
     ),
     Column(
+        "charging_equipment_version",
+        Integer,
+        primary_key=True,
+        nullable=False,
+    ),
+    Column(
         "end_use_type_id",
         Integer,
         ForeignKey("end_use_type.end_use_type_id"),
@@ -45,6 +52,12 @@ charging_equipment_intended_user_association = Table(
         Integer,
         ForeignKey("charging_equipment.charging_equipment_id", ondelete="CASCADE"),
         primary_key=True,
+    ),
+    Column(
+        "charging_equipment_version",
+        Integer,
+        primary_key=True,
+        nullable=False,
     ),
     Column(
         "end_user_type_id",
@@ -153,10 +166,38 @@ class ChargingEquipment(BaseModel, Auditable, Versioning):
     intended_uses = relationship(
         "EndUseType",
         secondary=charging_equipment_intended_use_association,
+        primaryjoin=lambda: and_(
+            ChargingEquipment.charging_equipment_id
+            == foreign(
+                charging_equipment_intended_use_association.c.charging_equipment_id
+            ),
+            ChargingEquipment.version
+            == foreign(
+                charging_equipment_intended_use_association.c.charging_equipment_version
+            ),
+        ),
+        secondaryjoin=(
+            "EndUseType.end_use_type_id == "
+            "foreign(charging_equipment_intended_use_association.c.end_use_type_id)"
+        ),
     )
     intended_users = relationship(
         "EndUserType",
         secondary=charging_equipment_intended_user_association,
+        primaryjoin=lambda: and_(
+            ChargingEquipment.charging_equipment_id
+            == foreign(
+                charging_equipment_intended_user_association.c.charging_equipment_id
+            ),
+            ChargingEquipment.version
+            == foreign(
+                charging_equipment_intended_user_association.c.charging_equipment_version
+            ),
+        ),
+        secondaryjoin=(
+            "EndUserType.end_user_type_id == "
+            "foreign(charging_equipment_intended_user_association.c.end_user_type_id)"
+        ),
     )
     compliance_associations = relationship(
         "ComplianceReportChargingEquipment",

--- a/backend/lcfs/db/models/compliance/FSEReportingBasePrefView.py
+++ b/backend/lcfs/db/models/compliance/FSEReportingBasePrefView.py
@@ -6,11 +6,10 @@ Base = declarative_base()
 
 
 class FSEReportingBasePrefView(Base):
-    __tablename__ = "v_fse_reporting_base_pref"
+    __tablename__ = "mv_fse_reporting_base_pref"
     __table_args__ = {
         "extend_existing": True,
-        "info": {"is_view": True},
-        "comment": "View for preferred charging equipment reporting rows by report",
+        "comment": "Materialized view for preferred charging equipment reporting rows by report",
     }
 
     compliance_report_id = Column(Integer, primary_key=True)

--- a/backend/lcfs/db/models/compliance/FSEReportingBaseView.py
+++ b/backend/lcfs/db/models/compliance/FSEReportingBaseView.py
@@ -6,11 +6,10 @@ Base = declarative_base()
 
 
 class FSEReportingBaseView(Base):
-    __tablename__ = "v_fse_reporting_base"
+    __tablename__ = "mv_fse_reporting_base"
     __table_args__ = {
         "extend_existing": True,
-        "info": {"is_view": True},
-        "comment": "View for charging equipment reporting base rows",
+        "comment": "Materialized view for charging equipment reporting base rows",
     }
 
     charging_equipment_id = Column(Integer, primary_key=True)

--- a/backend/lcfs/db/models/compliance/FSEReportingBaseView.py
+++ b/backend/lcfs/db/models/compliance/FSEReportingBaseView.py
@@ -6,10 +6,10 @@ Base = declarative_base()
 
 
 class FSEReportingBaseView(Base):
-    __tablename__ = "mv_fse_reporting_base"
+    __tablename__ = "v_fse_reporting_base"
     __table_args__ = {
         "extend_existing": True,
-        "comment": "Materialized view for charging equipment reporting base rows",
+        "comment": "View for charging equipment reporting base rows",
     }
 
     charging_equipment_id = Column(Integer, primary_key=True)

--- a/backend/lcfs/db/models/compliance/VwFSEBaseView.py
+++ b/backend/lcfs/db/models/compliance/VwFSEBaseView.py
@@ -1,0 +1,54 @@
+from sqlalchemy import ARRAY, Boolean, Column, DateTime, Float, Integer, String
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+class VwFSEBaseView(Base):
+    __tablename__ = "vw_fse_base"
+    __table_args__ = {
+        "extend_existing": True,
+        "comment": "Final Supply Equipment base reporting view",
+    }
+
+    compliance_period_id = Column(Integer)
+    compliance_year = Column(String)
+    organization_id = Column(Integer)
+    organization_name = Column(String)
+    organization_operating_name = Column(String)
+    charging_equipment_compliance_id = Column(Integer, primary_key=True)
+    charging_equipment_id = Column(Integer, primary_key=True)
+    charging_equipment_version = Column(Integer, primary_key=True)
+    charging_site_id = Column(Integer)
+    registration_number = Column(String)
+    compliance_report_id = Column(Integer)
+    compliance_report_group_uuid = Column(String)
+    report_version = Column(Integer)
+    report_type = Column(String)
+    supplemental_initiator = Column(String)
+    report_status = Column(String)
+    site_name = Column(String)
+    street_address = Column(String)
+    city = Column(String)
+    postal_code = Column(String)
+    latitude = Column(Float)
+    longitude = Column(Float)
+    supply_from_date = Column(DateTime)
+    supply_to_date = Column(DateTime)
+    kwh_usage = Column(Float)
+    compliance_notes = Column(String)
+    is_active = Column(Boolean)
+    serial_number = Column(String)
+    manufacturer = Column(String)
+    model = Column(String)
+    level_of_equipment = Column(String)
+    level_of_equipment_id = Column(Integer)
+    ports = Column(String)
+    intended_uses = Column(ARRAY(String))
+    intended_users = Column(ARRAY(String))
+    allocating_organization_name = Column(String)
+    equipment_notes = Column(String)
+    power_output = Column(Float)
+    capacity_utilization_percent = Column(Integer)
+    charging_equipment_status = Column(String)

--- a/backend/lcfs/db/models/compliance/__init__.py
+++ b/backend/lcfs/db/models/compliance/__init__.py
@@ -16,6 +16,7 @@ from .FuelExport import FuelExport
 from .FuelSupply import FuelSupply
 from .FSEReportingBasePrefView import FSEReportingBasePrefView
 from .FSEReportingBaseView import FSEReportingBaseView
+from .VwFSEBaseView import VwFSEBaseView
 from .ChargingEquipment import ChargingEquipment
 from .ChargingEquipmentStatus import ChargingEquipmentStatus
 from .ComplianceReportChargingEquipment import ComplianceReportChargingEquipment
@@ -43,6 +44,7 @@ __all__ = [
     "FuelExport",
     "FSEReportingBaseView",
     "FSEReportingBasePrefView",
+    "VwFSEBaseView",
     "ChargingEquipment",
     "ChargingEquipmentStatus",
     "ComplianceReportChargingEquipment",

--- a/backend/lcfs/db/sql/manage_views.py
+++ b/backend/lcfs/db/sql/manage_views.py
@@ -69,7 +69,6 @@ class ViewCreator:
             "Compliance Report Service Level View",
             "Compliance Report Assignee Breakdown View",
             "Compliance Report Queue Flow View",
-            "Final Supply Equipment Base View",
             "FSE Base View YoY Optimised",
             "Electricity Allocation FSE Match Query",
             "Allocation Agreement Duplicate Check",

--- a/backend/lcfs/db/sql/views/Views.md
+++ b/backend/lcfs/db/sql/views/Views.md
@@ -4,7 +4,7 @@
 
 This document outlines the LCFS database views organized by their dependency levels. Views must be created in the specified order to avoid reference errors.
 
-> **Note:** All compliance-report analytics views include `compliance_period_id` and `compliance_period` columns so Metabase dashboards can apply field filters consistently. `v_fse_reporting_base_pref` and `vw_fse_base` are materialized views refreshed by FSE source-table triggers.
+> **Note:** All compliance-report analytics views include `compliance_period_id` and `compliance_period` columns so Metabase dashboards can apply field filters consistently.
 
 ## Dependency Tree Structure
 
@@ -33,8 +33,7 @@ Level 2 (Depends on Level 1)
 ├── vw_bceid_user_statistics (depends on: vw_user_login_analytics_base)
 ├── vw_login_failures_analysis (depends on: vw_user_login_analytics_base)
 ├── vw_compliance_report_base (depends on: vw_compliance_report_chained)
-├── v_fse_reporting_base_pref (materialized, depends on: v_fse_reporting_base)
-├── vw_fse_base (materialized, depends on: compliance_report and FSE source tables)
+├── vw_fse_base (depends on: v_compliance_report)
 ├── vw_electricity_allocation_fse_match (depends on: v_compliance_report)
 ├── vw_allocation_agreement_duplicate_check (depends on: v_compliance_report)
 └── vw_fse_duplicate_check (depends on: v_compliance_report)
@@ -71,8 +70,7 @@ Level 3 (Depends on Level 2)
 -   **vw_fuel_export_analytics_base**: Fuel export data for analytics
 -   **vw_fuel_code_base**: Comprehensive fuel code information
 -   **vw_fuels_other_use_base**: Non-standard fuel usage tracking
--   **v_fse_reporting_base_pref**: Materialized preferred FSE rows used by report display
--   **vw_fse_base**: Materialized Final Supply Equipment reporting
+-   **vw_fse_base**: Final Supply Equipment reporting
 -   **vw_allocation_agreement_base**: Latest allocation agreements
 -   **vw_notional_transfer_base**: Notional transfer tracking
 

--- a/backend/lcfs/db/sql/views/Views.md
+++ b/backend/lcfs/db/sql/views/Views.md
@@ -4,7 +4,7 @@
 
 This document outlines the LCFS database views organized by their dependency levels. Views must be created in the specified order to avoid reference errors.
 
-> **Note:** All compliance-report analytics views include `compliance_period_id` and `compliance_period` columns so Metabase dashboards can apply field filters consistently.
+> **Note:** All compliance-report analytics views include `compliance_period_id` and `compliance_period` columns so Metabase dashboards can apply field filters consistently. `v_fse_reporting_base_pref` and `vw_fse_base` are materialized views refreshed by FSE source-table triggers.
 
 ## Dependency Tree Structure
 
@@ -33,7 +33,8 @@ Level 2 (Depends on Level 1)
 ├── vw_bceid_user_statistics (depends on: vw_user_login_analytics_base)
 ├── vw_login_failures_analysis (depends on: vw_user_login_analytics_base)
 ├── vw_compliance_report_base (depends on: vw_compliance_report_chained)
-├── vw_fse_base (depends on: v_compliance_report)
+├── v_fse_reporting_base_pref (materialized, depends on: v_fse_reporting_base)
+├── vw_fse_base (materialized, depends on: compliance_report and FSE source tables)
 ├── vw_electricity_allocation_fse_match (depends on: v_compliance_report)
 ├── vw_allocation_agreement_duplicate_check (depends on: v_compliance_report)
 └── vw_fse_duplicate_check (depends on: v_compliance_report)
@@ -70,7 +71,8 @@ Level 3 (Depends on Level 2)
 -   **vw_fuel_export_analytics_base**: Fuel export data for analytics
 -   **vw_fuel_code_base**: Comprehensive fuel code information
 -   **vw_fuels_other_use_base**: Non-standard fuel usage tracking
--   **vw_fse_base**: Final Supply Equipment reporting
+-   **v_fse_reporting_base_pref**: Materialized preferred FSE rows used by report display
+-   **vw_fse_base**: Materialized Final Supply Equipment reporting
 -   **vw_allocation_agreement_base**: Latest allocation agreements
 -   **vw_notional_transfer_base**: Notional transfer tracking
 

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -583,14 +583,14 @@ SELECT
     rek.organization_id,
     rek.compliance_report_id,
     rek.compliance_report_group_uuid,
-    COALESCE(fr.charging_equipment_id, mr.charging_equipment_id) AS charging_equipment_id,
-    COALESCE(fr.serial_number, mr.serial_number) AS serial_number,
-    COALESCE(fr.manufacturer, mr.manufacturer) AS manufacturer,
-    COALESCE(fr.model, mr.model) AS model,
-    COALESCE(fr.registration_number, mr.registration_number) AS registration_number,
-    COALESCE(fr.site_name, mr.site_name) AS site_name,
-    COALESCE(fr.charging_site_id, mr.charging_site_id) AS charging_site_id,
-    COALESCE(fr.equipment_notes, mr.equipment_notes) AS equipment_notes,
+    COALESCE(mr.charging_equipment_id, fr.charging_equipment_id) AS charging_equipment_id,
+    COALESCE(mr.serial_number, fr.serial_number) AS serial_number,
+    COALESCE(mr.manufacturer, fr.manufacturer) AS manufacturer,
+    COALESCE(mr.model, fr.model) AS model,
+    COALESCE(mr.registration_number, fr.registration_number) AS registration_number,
+    COALESCE(mr.site_name, fr.site_name) AS site_name,
+    COALESCE(mr.charging_site_id, fr.charging_site_id) AS charging_site_id,
+    COALESCE(mr.equipment_notes, fr.equipment_notes) AS equipment_notes,
     mr.supply_from_date,
     mr.supply_to_date,
     mr.kwh_usage,
@@ -599,28 +599,28 @@ SELECT
     mr.is_active,
     mr.version,
     mr.action_type,
-    COALESCE(fr.charging_equipment_version, mr.charging_equipment_version) AS charging_equipment_version,
-    COALESCE(fr.street_address, mr.street_address) AS street_address,
-    COALESCE(fr.city, mr.city) AS city,
-    COALESCE(fr.postal_code, mr.postal_code) AS postal_code,
-    COALESCE(fr.latitude, mr.latitude) AS latitude,
-    COALESCE(fr.longitude, mr.longitude) AS longitude,
-    COALESCE(fr.level_of_equipment, mr.level_of_equipment) AS level_of_equipment,
-    COALESCE(fr.level_of_equipment_id, mr.level_of_equipment_id) AS level_of_equipment_id,
-    COALESCE(fr.ports, mr.ports) AS ports,
-    COALESCE(fr.allocating_organization_name, mr.allocating_organization_name) AS allocating_organization_name,
-    COALESCE(fr.intended_uses, mr.intended_uses) AS intended_uses,
-    COALESCE(fr.intended_users, mr.intended_users) AS intended_users,
-    COALESCE(fr.power_output, mr.power_output) AS power_output,
+    COALESCE(mr.charging_equipment_version, fr.charging_equipment_version) AS charging_equipment_version,
+    COALESCE(mr.street_address, fr.street_address) AS street_address,
+    COALESCE(mr.city, fr.city) AS city,
+    COALESCE(mr.postal_code, fr.postal_code) AS postal_code,
+    COALESCE(mr.latitude, fr.latitude) AS latitude,
+    COALESCE(mr.longitude, fr.longitude) AS longitude,
+    COALESCE(mr.level_of_equipment, fr.level_of_equipment) AS level_of_equipment,
+    COALESCE(mr.level_of_equipment_id, fr.level_of_equipment_id) AS level_of_equipment_id,
+    COALESCE(mr.ports, fr.ports) AS ports,
+    COALESCE(mr.allocating_organization_name, fr.allocating_organization_name) AS allocating_organization_name,
+    COALESCE(mr.intended_uses, fr.intended_uses) AS intended_uses,
+    COALESCE(mr.intended_users, fr.intended_users) AS intended_users,
+    COALESCE(mr.power_output, fr.power_output) AS power_output,
     CASE
         WHEN mr.kwh_usage IS NULL OR mr.supply_from_date IS NULL OR mr.supply_to_date IS NULL
-             OR COALESCE(fr.power_output, mr.power_output) IS NULL
-             OR COALESCE(fr.power_output, mr.power_output) <= 0
+             OR COALESCE(mr.power_output, fr.power_output) IS NULL
+             OR COALESCE(mr.power_output, fr.power_output) <= 0
              OR mr.supply_to_date::date < mr.supply_from_date::date
         THEN NULL
-        ELSE ROUND((mr.kwh_usage::numeric / (COALESCE(fr.power_output, mr.power_output)::numeric * 24 * ((mr.supply_to_date::date - mr.supply_from_date::date) + 1))) * 100)::integer
+        ELSE ROUND((mr.kwh_usage::numeric / (COALESCE(mr.power_output, fr.power_output)::numeric * 24 * ((mr.supply_to_date::date - mr.supply_from_date::date) + 1))) * 100)::integer
     END AS capacity_utilization_percent,
-    COALESCE(fr.charging_equipment_status, mr.charging_equipment_status) AS charging_equipment_status
+    COALESCE(mr.charging_equipment_status, fr.charging_equipment_status) AS charging_equipment_status
 FROM report_equipment_keys rek
 LEFT JOIN fallback_rows fr
     ON fr.organization_id = rek.organization_id
@@ -629,13 +629,6 @@ LEFT JOIN matched_rows mr
     ON mr.organization_id = rek.organization_id
    AND mr.compliance_report_group_uuid = rek.compliance_report_group_uuid
    AND mr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid;
-
-CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_report_org
-    ON v_fse_reporting_base_pref (compliance_report_id, organization_id, is_active);
-CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_group
-    ON v_fse_reporting_base_pref (compliance_report_group_uuid);
-CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_equipment
-    ON v_fse_reporting_base_pref (charging_equipment_id, charging_equipment_version);
 
 GRANT SELECT ON v_fse_reporting_base_pref TO basic_lcfs_reporting_role;
 
@@ -2691,13 +2684,6 @@ JOIN LATERAL (
     ORDER BY cs.version DESC
     LIMIT 1
 ) ls ON TRUE;
-
-CREATE INDEX IF NOT EXISTS idx_vw_fse_base_report
-    ON vw_fse_base ("Compliance Report ID", "Organization ID");
-CREATE INDEX IF NOT EXISTS idx_vw_fse_base_year_org
-    ON vw_fse_base ("Compliance Year", "Organization");
-CREATE INDEX IF NOT EXISTS idx_vw_fse_base_registration
-    ON vw_fse_base ("Registration Number");
 
 GRANT SELECT ON vw_fse_base TO basic_lcfs_reporting_role;
 -- ==========================================

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -416,8 +416,8 @@ LEFT JOIN LATERAL (
 -- ==========================================
 -- FSE Reporting Base Preferred View
 -- ==========================================
-DROP MATERIALIZED VIEW IF EXISTS v_fse_reporting_base_pref;
-CREATE MATERIALIZED VIEW v_fse_reporting_base_pref AS
+DROP VIEW IF EXISTS v_fse_reporting_base_pref;
+CREATE OR REPLACE VIEW v_fse_reporting_base_pref AS
 WITH report_context AS (
     SELECT
         cr.compliance_report_id,
@@ -2542,8 +2542,8 @@ GRANT SELECT ON vw_compliance_report_base TO basic_lcfs_reporting_role;
 -- FSE Base View YoY Optimised
 -- ==========================================
 -- Replaces v_fse_reporting_base_pref chain with flat CTEs for performance.
-DROP MATERIALIZED VIEW IF EXISTS vw_fse_base CASCADE;
-CREATE MATERIALIZED VIEW vw_fse_base AS
+DROP VIEW IF EXISTS vw_fse_base CASCADE;
+CREATE OR REPLACE VIEW vw_fse_base AS
 WITH
 target_reports AS (
     SELECT DISTINCT ON (cr.compliance_report_group_uuid)

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -312,8 +312,8 @@ GRANT SELECT ON vw_compliance_reports_time_per_status TO basic_lcfs_reporting_ro
 -- ==========================================
 -- FSE Reporting Base View
 -- ==========================================
-DROP VIEW IF EXISTS v_fse_reporting_base CASCADE;
-CREATE OR REPLACE VIEW v_fse_reporting_base as
+DROP MATERIALIZED VIEW IF EXISTS mv_fse_reporting_base CASCADE;
+CREATE MATERIALIZED VIEW mv_fse_reporting_base AS
 WITH equipment_uses AS (
     SELECT
         ceiu.charging_equipment_id,
@@ -428,11 +428,27 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) power_lookup ON TRUE;
 
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_fse_reporting_base_mv
+    ON mv_fse_reporting_base (charging_equipment_compliance_id);
+
+CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_equipment_version
+    ON mv_fse_reporting_base (
+        charging_equipment_id,
+        charging_equipment_version
+    );
+
+CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_group_status_active
+    ON mv_fse_reporting_base (
+        compliance_report_group_uuid,
+        charging_equipment_status,
+        is_active
+    );
+
 -- ==========================================
 -- FSE Reporting Base Preferred View
 -- ==========================================
-DROP VIEW IF EXISTS v_fse_reporting_base_pref;
-CREATE OR REPLACE VIEW v_fse_reporting_base_pref AS
+DROP MATERIALIZED VIEW IF EXISTS mv_fse_reporting_base_pref;
+CREATE MATERIALIZED VIEW mv_fse_reporting_base_pref AS
 WITH report_context AS (
     SELECT
         cr.compliance_report_id,
@@ -550,7 +566,7 @@ matched_rows AS (
                     v.version DESC,
                     v.charging_equipment_compliance_id DESC
             ) AS rn
-        FROM v_fse_reporting_base v
+        FROM mv_fse_reporting_base v
         JOIN charging_equipment ce
             ON ce.charging_equipment_id = v.charging_equipment_id
            AND ce.version = v.charging_equipment_version
@@ -630,7 +646,30 @@ LEFT JOIN matched_rows mr
    AND mr.compliance_report_group_uuid = rek.compliance_report_group_uuid
    AND mr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid;
 
-GRANT SELECT ON v_fse_reporting_base_pref TO basic_lcfs_reporting_role;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_fse_reporting_base_pref_mv
+    ON mv_fse_reporting_base_pref (
+        compliance_report_id,
+        charging_equipment_id,
+        charging_equipment_version
+    );
+
+CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_pref_report_filters
+    ON mv_fse_reporting_base_pref (
+        organization_id,
+        compliance_report_id,
+        is_active,
+        charging_equipment_status
+    );
+
+CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_pref_report_sort
+    ON mv_fse_reporting_base_pref (
+        compliance_report_id,
+        site_name,
+        registration_number,
+        charging_equipment_id
+    );
+
+GRANT SELECT ON mv_fse_reporting_base_pref TO basic_lcfs_reporting_role;
 
 -- ==========================================
 -- Notional Transfer Base View
@@ -2565,7 +2604,7 @@ GRANT SELECT ON vw_compliance_report_base TO basic_lcfs_reporting_role;
 -- ==========================================
 -- FSE Base View YoY Optimised
 -- ==========================================
--- Replaces v_fse_reporting_base_pref chain with flat CTEs for performance.
+-- Replaces mv_fse_reporting_base_pref chain with flat CTEs for performance.
 DROP VIEW IF EXISTS vw_fse_base CASCADE;
 CREATE OR REPLACE VIEW vw_fse_base AS
 WITH

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -355,9 +355,9 @@ SELECT DISTINCT
     ce.serial_number,
     ce.manufacturer,
     ce.model,
-    (cs.site_code || '-' || ce.equipment_number) AS registration_number,
-    cs.site_name,
-    cs.charging_site_id,
+    (ls.site_code || '-' || ce.equipment_number) AS registration_number,
+    ls.site_name,
+    ls.charging_site_id,
     ce.notes AS equipment_notes,
     crce.supply_from_date,
     crce.supply_to_date,
@@ -370,15 +370,15 @@ SELECT DISTINCT
     crce.version,
     crce.action_type,
     COALESCE(crce.charging_equipment_version, ce.version) AS charging_equipment_version,
-    cs.street_address,
-    cs.city,
-    cs.postal_code,
-    cs.latitude,
-    cs.longitude,
+    ls.street_address,
+    ls.city,
+    ls.postal_code,
+    ls.latitude,
+    ls.longitude,
     loe.name AS level_of_equipment,
     ce.level_of_equipment_id,
     ce.ports,
-    cs.allocating_organization_name,
+    ls.allocating_organization_name,
     eu.intended_uses,
     eus.intended_users,
     power_lookup.power_output,
@@ -395,8 +395,23 @@ FROM latest_crce crce
 JOIN charging_equipment ce
     ON ce.charging_equipment_id = crce.charging_equipment_id
    AND ce.version = crce.charging_equipment_version
-JOIN charging_site cs ON ce.charging_site_id = cs.charging_site_id 
-    AND cs.version = (SELECT MAX(cs2.version) FROM charging_site cs2 WHERE cs2.group_uuid = cs.group_uuid)
+JOIN charging_site cs_fk ON ce.charging_site_id = cs_fk.charging_site_id
+JOIN LATERAL (
+    SELECT
+        cs.site_code,
+        cs.site_name,
+        cs.charging_site_id,
+        cs.street_address,
+        cs.city,
+        cs.postal_code,
+        cs.latitude,
+        cs.longitude,
+        cs.allocating_organization_name
+    FROM charging_site cs
+    WHERE cs.group_uuid = cs_fk.group_uuid
+    ORDER BY cs.version DESC
+    LIMIT 1
+) ls ON TRUE
 JOIN level_of_equipment loe ON ce.level_of_equipment_id = loe.level_of_equipment_id
 JOIN charging_equipment_status ces ON ce.status_id = ces.charging_equipment_status_id
 LEFT JOIN equipment_uses eu ON ce.charging_equipment_id = eu.charging_equipment_id
@@ -452,26 +467,26 @@ equipment_users AS (
 ),
 fallback_rows AS (
     SELECT
-        cs.organization_id,
+        ls.organization_id,
         ce.group_uuid AS charging_equipment_group_uuid,
         ce.charging_equipment_id,
         ce.serial_number,
         ce.manufacturer,
         ce.model,
-        (cs.site_code || '-' || ce.equipment_number) AS registration_number,
-        cs.site_name,
-        cs.charging_site_id,
+        (ls.site_code || '-' || ce.equipment_number) AS registration_number,
+        ls.site_name,
+        ls.charging_site_id,
         ce.notes AS equipment_notes,
         ce.version AS charging_equipment_version,
-        cs.street_address,
-        cs.city,
-        cs.postal_code,
-        cs.latitude,
-        cs.longitude,
+        ls.street_address,
+        ls.city,
+        ls.postal_code,
+        ls.latitude,
+        ls.longitude,
         loe.name AS level_of_equipment,
         ce.level_of_equipment_id,
         ce.ports,
-        cs.allocating_organization_name,
+        ls.allocating_organization_name,
         eu.intended_uses,
         eus.intended_users,
         power_lookup.power_output,
@@ -481,8 +496,24 @@ fallback_rows AS (
     JOIN charging_equipment ce
         ON le.charging_equipment_id = ce.charging_equipment_id
        AND le.version = ce.version
-    JOIN charging_site cs ON ce.charging_site_id = cs.charging_site_id
-        AND cs.version = (SELECT MAX(cs2.version) FROM charging_site cs2 WHERE cs2.group_uuid = cs.group_uuid)
+    JOIN charging_site cs_fk ON ce.charging_site_id = cs_fk.charging_site_id
+    JOIN LATERAL (
+        SELECT
+            cs.organization_id,
+            cs.site_code,
+            cs.site_name,
+            cs.charging_site_id,
+            cs.street_address,
+            cs.city,
+            cs.postal_code,
+            cs.latitude,
+            cs.longitude,
+            cs.allocating_organization_name
+        FROM charging_site cs
+        WHERE cs.group_uuid = cs_fk.group_uuid
+        ORDER BY cs.version DESC
+        LIMIT 1
+    ) ls ON TRUE
     JOIN level_of_equipment loe ON ce.level_of_equipment_id = loe.level_of_equipment_id
     JOIN charging_equipment_status ces ON ce.status_id = ces.charging_equipment_status_id
     LEFT JOIN equipment_uses eu ON ce.charging_equipment_id = eu.charging_equipment_id

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -312,23 +312,25 @@ GRANT SELECT ON vw_compliance_reports_time_per_status TO basic_lcfs_reporting_ro
 -- ==========================================
 -- FSE Reporting Base View
 -- ==========================================
-DROP MATERIALIZED VIEW IF EXISTS mv_fse_reporting_base CASCADE;
-CREATE MATERIALIZED VIEW mv_fse_reporting_base AS
+DROP VIEW IF EXISTS v_fse_reporting_base CASCADE;
+CREATE OR REPLACE VIEW v_fse_reporting_base AS
 WITH equipment_uses AS (
     SELECT
         ceiu.charging_equipment_id,
+        ceiu.charging_equipment_version,
         array_agg(eut.type ORDER BY eut.type) AS intended_uses
     FROM charging_equipment_intended_use_association ceiu
     JOIN end_use_type eut ON ceiu.end_use_type_id = eut.end_use_type_id
-    GROUP BY ceiu.charging_equipment_id
+    GROUP BY ceiu.charging_equipment_id, ceiu.charging_equipment_version
 ),
 equipment_users AS (
     SELECT
         ceiu2.charging_equipment_id,
+        ceiu2.charging_equipment_version,
         array_agg(eut2.type_name ORDER BY eut2.type_name) AS intended_users
     FROM charging_equipment_intended_user_association ceiu2
     JOIN end_user_type eut2 ON ceiu2.end_user_type_id = eut2.end_user_type_id
-    GROUP BY ceiu2.charging_equipment_id
+    GROUP BY ceiu2.charging_equipment_id, ceiu2.charging_equipment_version
 ),
 latest_crce AS (
     SELECT *
@@ -414,8 +416,12 @@ JOIN LATERAL (
 ) ls ON TRUE
 JOIN level_of_equipment loe ON ce.level_of_equipment_id = loe.level_of_equipment_id
 JOIN charging_equipment_status ces ON ce.status_id = ces.charging_equipment_status_id
-LEFT JOIN equipment_uses eu ON ce.charging_equipment_id = eu.charging_equipment_id
-LEFT JOIN equipment_users eus ON ce.charging_equipment_id = eus.charging_equipment_id
+LEFT JOIN equipment_uses eu
+    ON ce.charging_equipment_id = eu.charging_equipment_id
+   AND ce.version = eu.charging_equipment_version
+LEFT JOIN equipment_users eus
+    ON ce.charging_equipment_id = eus.charging_equipment_id
+   AND ce.version = eus.charging_equipment_version
 LEFT JOIN LATERAL (
     SELECT cpo.charger_power_output AS power_output
     FROM charging_power_output cpo
@@ -427,22 +433,6 @@ LEFT JOIN LATERAL (
     ORDER BY cpo.display_order ASC NULLS FIRST
     LIMIT 1
 ) power_lookup ON TRUE;
-
-CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_fse_reporting_base_mv
-    ON mv_fse_reporting_base (charging_equipment_compliance_id);
-
-CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_equipment_version
-    ON mv_fse_reporting_base (
-        charging_equipment_id,
-        charging_equipment_version
-    );
-
-CREATE INDEX IF NOT EXISTS ix_mv_fse_reporting_base_group_status_active
-    ON mv_fse_reporting_base (
-        compliance_report_group_uuid,
-        charging_equipment_status,
-        is_active
-    );
 
 -- ==========================================
 -- FSE Reporting Base Preferred View
@@ -468,18 +458,20 @@ latest_equipment AS (
 equipment_uses AS (
     SELECT
         ceiu.charging_equipment_id,
+        ceiu.charging_equipment_version,
         array_agg(eut.type ORDER BY eut.type) AS intended_uses
     FROM charging_equipment_intended_use_association ceiu
     JOIN end_use_type eut ON ceiu.end_use_type_id = eut.end_use_type_id
-    GROUP BY ceiu.charging_equipment_id
+    GROUP BY ceiu.charging_equipment_id, ceiu.charging_equipment_version
 ),
 equipment_users AS (
     SELECT
         ceiu2.charging_equipment_id,
+        ceiu2.charging_equipment_version,
         array_agg(eut2.type_name ORDER BY eut2.type_name) AS intended_users
     FROM charging_equipment_intended_user_association ceiu2
     JOIN end_user_type eut2 ON ceiu2.end_user_type_id = eut2.end_user_type_id
-    GROUP BY ceiu2.charging_equipment_id
+    GROUP BY ceiu2.charging_equipment_id, ceiu2.charging_equipment_version
 ),
 fallback_rows AS (
     SELECT
@@ -532,8 +524,12 @@ fallback_rows AS (
     ) ls ON TRUE
     JOIN level_of_equipment loe ON ce.level_of_equipment_id = loe.level_of_equipment_id
     JOIN charging_equipment_status ces ON ce.status_id = ces.charging_equipment_status_id
-    LEFT JOIN equipment_uses eu ON ce.charging_equipment_id = eu.charging_equipment_id
-    LEFT JOIN equipment_users eus ON ce.charging_equipment_id = eus.charging_equipment_id
+    LEFT JOIN equipment_uses eu
+        ON ce.charging_equipment_id = eu.charging_equipment_id
+       AND ce.version = eu.charging_equipment_version
+    LEFT JOIN equipment_users eus
+        ON ce.charging_equipment_id = eus.charging_equipment_id
+       AND ce.version = eus.charging_equipment_version
     LEFT JOIN LATERAL (
         SELECT cpo.charger_power_output AS power_output
         FROM charging_power_output cpo
@@ -566,7 +562,7 @@ matched_rows AS (
                     v.version DESC,
                     v.charging_equipment_compliance_id DESC
             ) AS rn
-        FROM mv_fse_reporting_base v
+        FROM v_fse_reporting_base v
         JOIN charging_equipment ce
             ON ce.charging_equipment_id = v.charging_equipment_id
            AND ce.version = v.charging_equipment_version
@@ -2604,7 +2600,8 @@ GRANT SELECT ON vw_compliance_report_base TO basic_lcfs_reporting_role;
 -- ==========================================
 -- FSE Base View YoY Optimised
 -- ==========================================
--- Replaces mv_fse_reporting_base_pref chain with flat CTEs for performance.
+-- Projects the preferred FSE reporting materialized view with report metadata
+-- and snake_case columns for API/reporting consumers.
 DROP VIEW IF EXISTS vw_fse_base CASCADE;
 CREATE OR REPLACE VIEW vw_fse_base AS
 WITH
@@ -2623,106 +2620,55 @@ target_reports AS (
         ON crs.compliance_report_status_id = cr.current_status_id
     WHERE crs.status != 'Draft'
     ORDER BY cr.compliance_report_group_uuid, cr.version DESC
-),
-best_crce AS (
-    SELECT DISTINCT ON (
-        crce.compliance_report_group_uuid,
-        crce.organization_id,
-        crce.charging_equipment_id,
-        crce.charging_equipment_version
-    )
-        crce.compliance_report_group_uuid,
-        crce.organization_id,
-        crce.charging_equipment_id,
-        crce.charging_equipment_version,
-        crce.supply_from_date,
-        crce.supply_to_date,
-        crce.kwh_usage,
-        crce.compliance_notes
-    FROM compliance_report_charging_equipment crce
-    JOIN target_reports tr
-        ON tr.compliance_report_group_uuid = crce.compliance_report_group_uuid
-    ORDER BY
-        crce.compliance_report_group_uuid,
-        crce.organization_id,
-        crce.charging_equipment_id,
-        crce.charging_equipment_version,
-        (crce.is_active IS TRUE) DESC,
-        crce.version DESC,
-        crce.charging_equipment_compliance_id DESC
 )
 SELECT
-    tr.compliance_period_id                       AS "Compliance Period ID",
-    cp.description                                AS "Compliance Year",
-    tr.organization_id                            AS "Organization ID",
-    o.name                                        AS "Organization",
-    o.operating_name                              AS "Organization Operating Name",
-    (ls.site_code || '-' || ce.equipment_number)  AS "Registration Number",
-    tr.compliance_report_id                       AS "Compliance Report ID",
-    tr.compliance_report_group_uuid               AS "Compliance Report Group UUID",
-    tr.version                                    AS "Report Version",
-    tr.report_type                                AS "Report Type",
-    tr.supplemental_initiator                     AS "Supplemental Initiator",
-    tr.report_status                              AS "Report Status",
-    ls.site_name                                  AS "Site Name",
-    ls.street_address                             AS "Street Address",
-    ls.city                                       AS "City",
-    ls.postal_code                                AS "Postal Code",
-    ls.latitude                                   AS "Latitude",
-    ls.longitude                                  AS "Longitude",
-    bc.supply_from_date                           AS "Supply From Date",
-    bc.supply_to_date                             AS "Supply To Date",
-    bc.kwh_usage                                  AS "kWh Usage",
-    ce.serial_number                              AS "Serial #",
-    ce.manufacturer                               AS "Manufacturer",
-    ce.model                                      AS "Model",
-    (
-        SELECT loe.name
-        FROM level_of_equipment loe
-        WHERE loe.level_of_equipment_id = ce.level_of_equipment_id
-    )                                             AS "Level of Equipment",
-    ce.ports                                      AS "Ports",
-    COALESCE((
-        SELECT string_agg(eut.type, ', ' ORDER BY eut.type)
-        FROM charging_equipment_intended_use_association ceiu
-        JOIN end_use_type eut ON eut.end_use_type_id = ceiu.end_use_type_id
-        WHERE ceiu.charging_equipment_id = ce.charging_equipment_id
-    ), '')                                        AS "Intended Use",
-    COALESCE((
-        SELECT string_agg(eut2.type_name, ', ' ORDER BY eut2.type_name)
-        FROM charging_equipment_intended_user_association ceiu2
-        JOIN end_user_type eut2 ON eut2.end_user_type_id = ceiu2.end_user_type_id
-        WHERE ceiu2.charging_equipment_id = ce.charging_equipment_id
-    ), '')                                        AS "Intended Users",
-    ls.allocating_organization_name               AS "Allocating Organization",
-    ce.notes                                      AS "Equipment Notes",
-    bc.compliance_notes                           AS "Compliance Notes"
-FROM best_crce bc
+    tr.compliance_period_id                       AS compliance_period_id,
+    cp.description                                AS compliance_year,
+    v.organization_id                             AS organization_id,
+    o.name                                        AS organization_name,
+    o.operating_name                              AS organization_operating_name,
+    v.charging_equipment_compliance_id            AS charging_equipment_compliance_id,
+    v.charging_equipment_id                       AS charging_equipment_id,
+    v.charging_equipment_version                  AS charging_equipment_version,
+    v.charging_site_id                            AS charging_site_id,
+    v.registration_number                         AS registration_number,
+    v.compliance_report_id                        AS compliance_report_id,
+    v.compliance_report_group_uuid                AS compliance_report_group_uuid,
+    tr.version                                    AS report_version,
+    tr.report_type                                AS report_type,
+    tr.supplemental_initiator                     AS supplemental_initiator,
+    tr.report_status                              AS report_status,
+    v.site_name                                   AS site_name,
+    v.street_address                              AS street_address,
+    v.city                                        AS city,
+    v.postal_code                                 AS postal_code,
+    v.latitude                                    AS latitude,
+    v.longitude                                   AS longitude,
+    v.supply_from_date                            AS supply_from_date,
+    v.supply_to_date                              AS supply_to_date,
+    v.kwh_usage                                   AS kwh_usage,
+    v.compliance_notes                            AS compliance_notes,
+    v.is_active                                   AS is_active,
+    v.serial_number                               AS serial_number,
+    v.manufacturer                                AS manufacturer,
+    v.model                                       AS model,
+    v.level_of_equipment                          AS level_of_equipment,
+    v.level_of_equipment_id                       AS level_of_equipment_id,
+    v.ports                                       AS ports,
+    COALESCE(v.intended_uses, ARRAY[]::varchar[]) AS intended_uses,
+    COALESCE(v.intended_users, ARRAY[]::varchar[]) AS intended_users,
+    v.allocating_organization_name                AS allocating_organization_name,
+    v.equipment_notes                             AS equipment_notes,
+    v.power_output                                AS power_output,
+    v.capacity_utilization_percent                AS capacity_utilization_percent,
+    v.charging_equipment_status                   AS charging_equipment_status
+FROM mv_fse_reporting_base_pref v
 JOIN target_reports tr
-    ON tr.compliance_report_group_uuid = bc.compliance_report_group_uuid
+    ON tr.compliance_report_id = v.compliance_report_id
 JOIN organization o
-    ON o.organization_id = tr.organization_id
+    ON o.organization_id = v.organization_id
 JOIN compliance_period cp
-    ON cp.compliance_period_id = tr.compliance_period_id
-JOIN charging_equipment ce
-    ON ce.charging_equipment_id = bc.charging_equipment_id
-   AND ce.version              = bc.charging_equipment_version
-JOIN charging_site cs_fk
-    ON cs_fk.charging_site_id = ce.charging_site_id
-JOIN LATERAL (
-    SELECT cs.site_code,
-           cs.site_name,
-           cs.street_address,
-           cs.city,
-           cs.postal_code,
-           cs.latitude,
-           cs.longitude,
-           cs.allocating_organization_name
-    FROM charging_site cs
-    WHERE cs.group_uuid = cs_fk.group_uuid
-    ORDER BY cs.version DESC
-    LIMIT 1
-) ls ON TRUE;
+    ON cp.compliance_period_id = tr.compliance_period_id;
 
 GRANT SELECT ON vw_fse_base TO basic_lcfs_reporting_role;
 -- ==========================================

--- a/backend/lcfs/db/sql/views/metabase.sql
+++ b/backend/lcfs/db/sql/views/metabase.sql
@@ -416,8 +416,8 @@ LEFT JOIN LATERAL (
 -- ==========================================
 -- FSE Reporting Base Preferred View
 -- ==========================================
-DROP VIEW IF EXISTS v_fse_reporting_base_pref;
-CREATE OR REPLACE VIEW v_fse_reporting_base_pref AS
+DROP MATERIALIZED VIEW IF EXISTS v_fse_reporting_base_pref;
+CREATE MATERIALIZED VIEW v_fse_reporting_base_pref AS
 WITH report_context AS (
     SELECT
         cr.compliance_report_id,
@@ -525,19 +525,41 @@ matched_rows AS (
            AND ce.version = v.charging_equipment_version
     ) x
     WHERE x.rn = 1
+),
+report_equipment_keys AS (
+    SELECT
+        rc.organization_id,
+        rc.compliance_report_id,
+        rc.compliance_report_group_uuid,
+        fr.charging_equipment_group_uuid
+    FROM report_context rc
+    JOIN fallback_rows fr
+        ON fr.organization_id = rc.organization_id
+
+    UNION
+
+    SELECT
+        rc.organization_id,
+        rc.compliance_report_id,
+        rc.compliance_report_group_uuid,
+        mr.charging_equipment_group_uuid
+    FROM report_context rc
+    JOIN matched_rows mr
+        ON mr.organization_id = rc.organization_id
+       AND mr.compliance_report_group_uuid = rc.compliance_report_group_uuid
 )
 SELECT
-    rc.organization_id,
-    rc.compliance_report_id,
-    rc.compliance_report_group_uuid,
-    fr.charging_equipment_id,
-    fr.serial_number,
-    fr.manufacturer,
-    fr.model,
-    fr.registration_number,
-    fr.site_name,
-    fr.charging_site_id,
-    fr.equipment_notes,
+    rek.organization_id,
+    rek.compliance_report_id,
+    rek.compliance_report_group_uuid,
+    COALESCE(fr.charging_equipment_id, mr.charging_equipment_id) AS charging_equipment_id,
+    COALESCE(fr.serial_number, mr.serial_number) AS serial_number,
+    COALESCE(fr.manufacturer, mr.manufacturer) AS manufacturer,
+    COALESCE(fr.model, mr.model) AS model,
+    COALESCE(fr.registration_number, mr.registration_number) AS registration_number,
+    COALESCE(fr.site_name, mr.site_name) AS site_name,
+    COALESCE(fr.charging_site_id, mr.charging_site_id) AS charging_site_id,
+    COALESCE(fr.equipment_notes, mr.equipment_notes) AS equipment_notes,
     mr.supply_from_date,
     mr.supply_to_date,
     mr.kwh_usage,
@@ -546,35 +568,45 @@ SELECT
     mr.is_active,
     mr.version,
     mr.action_type,
-    fr.charging_equipment_version,
-    fr.street_address,
-    fr.city,
-    fr.postal_code,
-    fr.latitude,
-    fr.longitude,
-    fr.level_of_equipment,
-    fr.level_of_equipment_id,
-    fr.ports,
-    fr.allocating_organization_name,
-    fr.intended_uses,
-    fr.intended_users,
-    fr.power_output,
+    COALESCE(fr.charging_equipment_version, mr.charging_equipment_version) AS charging_equipment_version,
+    COALESCE(fr.street_address, mr.street_address) AS street_address,
+    COALESCE(fr.city, mr.city) AS city,
+    COALESCE(fr.postal_code, mr.postal_code) AS postal_code,
+    COALESCE(fr.latitude, mr.latitude) AS latitude,
+    COALESCE(fr.longitude, mr.longitude) AS longitude,
+    COALESCE(fr.level_of_equipment, mr.level_of_equipment) AS level_of_equipment,
+    COALESCE(fr.level_of_equipment_id, mr.level_of_equipment_id) AS level_of_equipment_id,
+    COALESCE(fr.ports, mr.ports) AS ports,
+    COALESCE(fr.allocating_organization_name, mr.allocating_organization_name) AS allocating_organization_name,
+    COALESCE(fr.intended_uses, mr.intended_uses) AS intended_uses,
+    COALESCE(fr.intended_users, mr.intended_users) AS intended_users,
+    COALESCE(fr.power_output, mr.power_output) AS power_output,
     CASE
         WHEN mr.kwh_usage IS NULL OR mr.supply_from_date IS NULL OR mr.supply_to_date IS NULL
-             OR fr.power_output IS NULL
-             OR fr.power_output <= 0
+             OR COALESCE(fr.power_output, mr.power_output) IS NULL
+             OR COALESCE(fr.power_output, mr.power_output) <= 0
              OR mr.supply_to_date::date < mr.supply_from_date::date
         THEN NULL
-        ELSE ROUND((mr.kwh_usage::numeric / (fr.power_output::numeric * 24 * ((mr.supply_to_date::date - mr.supply_from_date::date) + 1))) * 100)::integer
+        ELSE ROUND((mr.kwh_usage::numeric / (COALESCE(fr.power_output, mr.power_output)::numeric * 24 * ((mr.supply_to_date::date - mr.supply_from_date::date) + 1))) * 100)::integer
     END AS capacity_utilization_percent,
-    fr.charging_equipment_status
-FROM report_context rc
-JOIN fallback_rows fr
-    ON fr.organization_id = rc.organization_id
+    COALESCE(fr.charging_equipment_status, mr.charging_equipment_status) AS charging_equipment_status
+FROM report_equipment_keys rek
+LEFT JOIN fallback_rows fr
+    ON fr.organization_id = rek.organization_id
+   AND fr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid
 LEFT JOIN matched_rows mr
-    ON mr.organization_id = rc.organization_id
-   AND mr.compliance_report_group_uuid = rc.compliance_report_group_uuid
-   AND mr.charging_equipment_group_uuid = fr.charging_equipment_group_uuid;
+    ON mr.organization_id = rek.organization_id
+   AND mr.compliance_report_group_uuid = rek.compliance_report_group_uuid
+   AND mr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid;
+
+CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_report_org
+    ON v_fse_reporting_base_pref (compliance_report_id, organization_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_group
+    ON v_fse_reporting_base_pref (compliance_report_group_uuid);
+CREATE INDEX IF NOT EXISTS idx_v_fse_reporting_base_pref_equipment
+    ON v_fse_reporting_base_pref (charging_equipment_id, charging_equipment_version);
+
+GRANT SELECT ON v_fse_reporting_base_pref TO basic_lcfs_reporting_role;
 
 -- ==========================================
 -- Notional Transfer Base View
@@ -2507,151 +2539,11 @@ GROUP BY
 
 GRANT SELECT ON vw_compliance_report_base TO basic_lcfs_reporting_role;
 -- ==========================================
--- Final Supply Equipment Base View
--- ==========================================
-DROP VIEW IF EXISTS vw_fse_base CASCADE;
-CREATE OR REPLACE VIEW vw_fse_base AS
-WITH
-fse_intended_uses AS (
-    SELECT 
-        fse.final_supply_equipment_id,
-        STRING_AGG(DISTINCT eut.type, ', ' ORDER BY eut.type) AS intended_uses
-    FROM final_supply_equipment fse
-    LEFT JOIN final_supply_intended_use_association fsiua 
-        ON fse.final_supply_equipment_id = fsiua.final_supply_equipment_id
-    LEFT JOIN end_use_type eut 
-        ON fsiua.end_use_type_id = eut.end_use_type_id
-        AND eut.intended_use = true
-    GROUP BY fse.final_supply_equipment_id
-),
-fse_intended_users AS (
-    SELECT 
-        fse.final_supply_equipment_id,
-        STRING_AGG(DISTINCT eurt.type_name, ', ' ORDER BY eurt.type_name) AS intended_users
-    FROM final_supply_equipment fse
-    LEFT JOIN final_supply_intended_user_association fsiura 
-        ON fse.final_supply_equipment_id = fsiura.final_supply_equipment_id
-    LEFT JOIN end_user_type eurt 
-        ON fsiura.end_user_type_id = eurt.end_user_type_id
-        AND eurt.intended_use = true
-    GROUP BY fse.final_supply_equipment_id
-)
-SELECT 
-    o.name AS "Organization",
-    fse.supply_from_date AS "Supply From Date",
-    fse.supply_to_date AS "Supply To Date",
-    fse.kwh_usage AS "kWh Usage",
-    fse.serial_nbr AS "Serial #",
-    fse.manufacturer AS "Manufacturer",
-    fse.model AS "Model",
-    loe.name AS "Level of Equipment",
-    fse.ports AS "Ports",
-    COALESCE(fiu.intended_uses, '') AS "Intended Use",
-    COALESCE(fiur.intended_users, '') AS "Intended Users",
-    fse.street_address AS "Street Address",
-    fse.city AS "City",
-    fse.postal_code AS "Postal Code",
-    fse.latitude AS "Latitude",
-    fse.longitude AS "Longitude",
-    fse.notes AS "Notes"
-    
-FROM final_supply_equipment fse
-JOIN v_compliance_report vcr 
-    ON vcr.compliance_report_id = fse.compliance_report_id
-    AND vcr.is_latest = true
-JOIN compliance_report cr 
-    ON cr.compliance_report_id = fse.compliance_report_id
-JOIN compliance_report_status crs 
-    ON crs.compliance_report_status_id = cr.current_status_id
-    AND crs.status != 'Draft'  -- Exclude draft reports
-JOIN organization o 
-    ON o.organization_id = cr.organization_id
-JOIN compliance_period cp 
-    ON cp.compliance_period_id = cr.compliance_period_id
-LEFT JOIN level_of_equipment loe 
-    ON loe.level_of_equipment_id = fse.level_of_equipment_id
-LEFT JOIN fse_intended_uses fiu 
-    ON fiu.final_supply_equipment_id = fse.final_supply_equipment_id
-LEFT JOIN fse_intended_users fiur 
-    ON fiur.final_supply_equipment_id = fse.final_supply_equipment_id
-
-ORDER BY 
-    o.name,
-    cp.description DESC,
-    fse.supply_from_date,
-    fse.serial_nbr;
-
-GRANT SELECT ON vw_fse_base TO basic_lcfs_reporting_role;
-
--- Create indexes
-CREATE INDEX IF NOT EXISTS idx_fse_info_org_year
-    ON final_supply_equipment (compliance_report_id);
-CREATE INDEX IF NOT EXISTS idx_fse_info_supply_dates
-    ON final_supply_equipment (supply_from_date, supply_to_date);
-CREATE INDEX IF NOT EXISTS idx_fse_info_location
-    ON final_supply_equipment (latitude, longitude);
--- ==========================================
--- FSE Base View YoY
--- ==========================================
-DROP VIEW IF EXISTS vw_fse_base CASCADE;
-CREATE OR REPLACE VIEW vw_fse_base AS
-SELECT
-    cp.compliance_period_id              AS "Compliance Period ID",
-    cp.description                       AS "Compliance Year",
-    o.organization_id                    AS "Organization ID",
-    o.name                               AS "Organization",
-    o.operating_name                     AS "Organization Operating Name",
-    fse.registration_number              AS "Registration Number",
-    vcr.compliance_report_id             AS "Compliance Report ID",
-    vcr.compliance_report_group_uuid     AS "Compliance Report Group UUID",
-    vcr.version                          AS "Report Version",
-    vcr.report_type                      AS "Report Type",
-    vcr.supplemental_initiator           AS "Supplemental Initiator",
-    vcr.report_status                    AS "Report Status",
-    fse.site_name                        AS "Site Name",
-    fse.supply_from_date                 AS "Supply From Date",
-    fse.supply_to_date                   AS "Supply To Date",
-    fse.kwh_usage                        AS "kWh Usage",
-    fse.serial_number                    AS "Serial #",
-    fse.manufacturer                     AS "Manufacturer",
-    fse.model                            AS "Model",
-    fse.level_of_equipment               AS "Level of Equipment",
-    fse.ports                            AS "Ports",
-    COALESCE(array_to_string(fse.intended_uses, ', '), '')  AS "Intended Use",
-    COALESCE(array_to_string(fse.intended_users, ', '), '') AS "Intended Users",
-    fse.allocating_organization_name     AS "Allocating Organization",
-    fse.street_address                   AS "Street Address",
-    fse.city                             AS "City",
-    fse.postal_code                      AS "Postal Code",
-    fse.latitude                         AS "Latitude",
-    fse.longitude                        AS "Longitude",
-    fse.power_output                     AS "Power Output (kW)",
-    fse.capacity_utilization_percent     AS "Capacity Utilization %",
-    fse.charging_equipment_status        AS "Charging Equipment Status",
-    fse.equipment_notes                  AS "Equipment Notes",
-    fse.compliance_notes                 AS "Compliance Notes"
-FROM v_fse_reporting_base_pref fse
-JOIN v_compliance_report vcr
-    ON vcr.compliance_report_group_uuid = fse.compliance_report_group_uuid
-   AND vcr.is_latest = true
-JOIN organization o
-    ON o.organization_id = vcr.organization_id
-JOIN compliance_period cp
-    ON cp.compliance_period_id = vcr.compliance_period_id
-WHERE vcr.report_status != 'Draft'
-ORDER BY
-    cp.description DESC,
-    o.name,
-    fse.supply_from_date,
-    fse.serial_number;
-
-GRANT SELECT ON vw_fse_base TO basic_lcfs_reporting_role;
--- ==========================================
 -- FSE Base View YoY Optimised
 -- ==========================================
 -- Replaces v_fse_reporting_base_pref chain with flat CTEs for performance.
-DROP VIEW IF EXISTS vw_fse_base CASCADE;
-CREATE OR REPLACE VIEW vw_fse_base AS
+DROP MATERIALIZED VIEW IF EXISTS vw_fse_base CASCADE;
+CREATE MATERIALIZED VIEW vw_fse_base AS
 WITH
 target_reports AS (
     SELECT DISTINCT ON (cr.compliance_report_group_uuid)
@@ -2768,6 +2660,13 @@ JOIN LATERAL (
     ORDER BY cs.version DESC
     LIMIT 1
 ) ls ON TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_vw_fse_base_report
+    ON vw_fse_base ("Compliance Report ID", "Organization ID");
+CREATE INDEX IF NOT EXISTS idx_vw_fse_base_year_org
+    ON vw_fse_base ("Compliance Year", "Organization");
+CREATE INDEX IF NOT EXISTS idx_vw_fse_base_registration
+    ON vw_fse_base ("Registration Number");
 
 GRANT SELECT ON vw_fse_base TO basic_lcfs_reporting_role;
 -- ==========================================

--- a/backend/lcfs/scripts/verify_database_mv_functions_triggers.sql
+++ b/backend/lcfs/scripts/verify_database_mv_functions_triggers.sql
@@ -73,6 +73,10 @@ WITH expected_materialized_views AS (
     SELECT 'mv_compliance_report_count'
     UNION ALL
     SELECT 'mv_fuel_code_count'
+    UNION ALL
+    SELECT 'mv_fse_reporting_base'
+    UNION ALL
+    SELECT 'mv_fse_reporting_base_pref'
 )
 SELECT 
     'Materialized View' AS item_type,
@@ -102,6 +106,8 @@ WITH expected_functions AS (
     SELECT 'refresh_mv_compliance_report_count'
     UNION ALL
     SELECT 'refresh_mv_fuel_code_count'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_base_views'
     UNION ALL
     SELECT 'update_organization_balance'
     UNION ALL
@@ -161,6 +167,16 @@ WITH expected_triggers AS (
     SELECT 'refresh_mv_compliance_report_count_after_change', 'compliance_report'
     UNION ALL
     SELECT 'refresh_mv_fuel_code_count_after_change', 'fuel_code'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_mvs_after_ce', 'charging_equipment'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_mvs_after_ceiu', 'charging_equipment_intended_use_association'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_mvs_after_ceuser', 'charging_equipment_intended_user_association'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_mvs_after_cs', 'charging_site'
+    UNION ALL
+    SELECT 'refresh_fse_reporting_mvs_after_crce', 'compliance_report_charging_equipment'
     UNION ALL
     SELECT 'update_organization_balance_trigger', 'transaction'
     UNION ALL
@@ -274,6 +290,8 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_compliance_report_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fuel_code_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_director_review_transaction_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_org_compliance_report_count;
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base;
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base_pref;
 
 COMMIT;
 

--- a/backend/lcfs/scripts/verify_database_mv_functions_triggers.sql
+++ b/backend/lcfs/scripts/verify_database_mv_functions_triggers.sql
@@ -74,8 +74,6 @@ WITH expected_materialized_views AS (
     UNION ALL
     SELECT 'mv_fuel_code_count'
     UNION ALL
-    SELECT 'mv_fse_reporting_base'
-    UNION ALL
     SELECT 'mv_fse_reporting_base_pref'
 )
 SELECT 
@@ -290,7 +288,6 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_compliance_report_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fuel_code_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_director_review_transaction_count;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_org_compliance_report_count;
-REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base;
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base_pref;
 
 COMMIT;

--- a/backend/lcfs/services/jobs/jobs.py
+++ b/backend/lcfs/services/jobs/jobs.py
@@ -55,6 +55,7 @@ COMPLIANCE_REINDEX_TABLES = (
 )
 COMPLIANCE_REINDEX_LOCK_ID = 60271451
 CREDIT_MARKET_REPORT_LOCK_ID = 60271452
+FSE_REPORTING_MV_REFRESH_LOCK_ID = 60271453
 CREDIT_MARKET_REPORT_MAX_ATTEMPTS = 3
 CREDIT_MARKET_REPORT_RETRY_DELAY_SECONDS = 60
 
@@ -277,6 +278,103 @@ async def reindex_compliance_report_tables(app: FastAPI):
         await conn.close()
 
     logger.info("Finished compliance-report table reindex job")
+
+
+async def refresh_fse_reporting_materialized_views(app: FastAPI):
+    """
+    Refresh FSE reporting materialized views out of the request path.
+
+    Source-table triggers only increment dirty_generation. This job refreshes
+    the materialized views when dirty_generation is ahead of refreshed_generation.
+    The captured generation prevents losing changes made while a refresh is
+    running; those changes remain dirty for the next scheduler pass.
+    """
+    conn = await app.state.db_engine.connect()
+    lock_acquired = False
+
+    try:
+        conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        lock_acquired = await conn.scalar(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": FSE_REPORTING_MV_REFRESH_LOCK_ID},
+        )
+
+        if not lock_acquired:
+            logger.info(
+                "Skipping FSE reporting MV refresh because another instance holds the lock"
+            )
+            return False
+
+        refresh_objects_exist = await conn.scalar(
+            text(
+                """
+                SELECT
+                    to_regclass('fse_reporting_mv_refresh_state') IS NOT NULL
+                    AND to_regclass('v_fse_reporting_base') IS NOT NULL
+                    AND to_regclass('mv_fse_reporting_base_pref') IS NOT NULL;
+                """
+            )
+        )
+
+        if not refresh_objects_exist:
+            logger.info(
+                "Skipping FSE reporting MV refresh because refresh objects do not exist"
+            )
+            return False
+
+        dirty_generation = await conn.scalar(
+            text(
+                """
+                SELECT dirty_generation
+                FROM fse_reporting_mv_refresh_state
+                WHERE id = 1
+                  AND dirty_generation > refreshed_generation;
+                """
+            )
+        )
+
+        if dirty_generation is None:
+            return False
+
+        logger.info(
+            "Refreshing FSE reporting preferred materialized view",
+            extra={"dirty_generation": dirty_generation},
+        )
+        await conn.execute(
+            text("REFRESH MATERIALIZED VIEW CONCURRENTLY mv_fse_reporting_base_pref")
+        )
+        await conn.execute(
+            text(
+                """
+                UPDATE fse_reporting_mv_refresh_state
+                SET refreshed_generation = GREATEST(
+                        refreshed_generation,
+                        :dirty_generation
+                    ),
+                    update_date = now()
+                WHERE id = 1;
+                """
+            ),
+            {"dirty_generation": dirty_generation},
+        )
+        logger.info(
+            "Finished FSE reporting materialized view refresh",
+            extra={"refreshed_generation": dirty_generation},
+        )
+        return True
+    except Exception:
+        logger.exception("FSE reporting materialized view refresh job failed")
+        raise
+    finally:
+        if lock_acquired:
+            try:
+                await conn.execute(
+                    text("SELECT pg_advisory_unlock(:lock_id)"),
+                    {"lock_id": FSE_REPORTING_MV_REFRESH_LOCK_ID},
+                )
+            except Exception:
+                logger.debug("FSE reporting MV refresh advisory unlock skipped")
+        await conn.close()
 
 
 async def send_monthly_credit_market_report(app: FastAPI):

--- a/backend/lcfs/services/scheduler/scheduler.py
+++ b/backend/lcfs/services/scheduler/scheduler.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 
 from lcfs.services.jobs.jobs import (
     check_overdue_supplemental_reports,
+    refresh_fse_reporting_materialized_views,
     reindex_compliance_report_tables,
     send_monthly_credit_market_report,
 )
@@ -91,6 +92,23 @@ def start_scheduler(app: FastAPI):
             )
             logger.info(
                 "Added one-time startup job: 'reindex_compliance_report_tables_startup'"
+            )
+
+        if settings.fse_reporting_mv_refresh_enabled:
+            scheduler.add_job(
+                refresh_fse_reporting_materialized_views,
+                "interval",
+                seconds=settings.fse_reporting_mv_refresh_interval_seconds,
+                timezone=ZoneInfo("America/Vancouver"),
+                id="refresh_fse_reporting_materialized_views",
+                replace_existing=True,
+                args=[app],
+            )
+            logger.info(
+                "Added job: 'refresh_fse_reporting_materialized_views'",
+                extra={
+                    "seconds": settings.fse_reporting_mv_refresh_interval_seconds,
+                },
             )
 
         if settings.credit_market_report_enabled:

--- a/backend/lcfs/settings.py
+++ b/backend/lcfs/settings.py
@@ -57,6 +57,8 @@ class Settings(BaseSettings):
     compliance_reindex_hour: int = 3
     compliance_reindex_minute: int = 15
     compliance_reindex_run_on_startup: bool = False
+    fse_reporting_mv_refresh_enabled: bool = True
+    fse_reporting_mv_refresh_interval_seconds: int = 30
 
     credit_market_report_enabled: bool = False
     credit_market_report_day: int = 1

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_export.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_export.py
@@ -710,6 +710,12 @@ class TestComplianceReportExporter:
         await exporter.export(1, is_government=True)
 
         exporter.fse_repo.get_fse_reporting_list_paginated.assert_called_once()
+        assert (
+            exporter.fse_repo.get_fse_reporting_list_paginated.call_args.kwargs[
+                "source"
+            ]
+            == "vw_fse_base"
+        )
         exporter.fse_repo.get_effective_fse_reporting_rows_for_export.assert_not_called()
 
     @pytest.mark.anyio

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_repo.py
@@ -1,10 +1,13 @@
 import pytest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from sqlalchemy import select
 
 from lcfs.db.models.compliance import (
     CompliancePeriod,
     ComplianceReport,
+    ComplianceReportListView,
     ComplianceReportStatus,
     ComplianceReportHistory,
 )
@@ -14,6 +17,8 @@ from lcfs.web.api.base import (
     PaginationRequestSchema,
     SortOrder,
 )
+from lcfs.db.models.compliance.ComplianceReportStatus import ComplianceReportStatusEnum
+from lcfs.db.models.user.Role import RoleEnum
 from lcfs.web.api.compliance_report.schema import ComplianceReportBaseSchema
 from lcfs.web.api.compliance_report.schema import (
     ComplianceReportViewSchema,
@@ -241,6 +246,70 @@ async def test_get_reports_paginated_sort_by_assigned_analyst(
     assert len(reports) > 0
     assert isinstance(reports[0], ComplianceReportViewSchema)
     assert total_count >= len(reports)
+
+
+@pytest.mark.anyio
+async def test_get_reports_paginated_keeps_analyst_adjustment_visible_for_supplier(
+    compliance_report_repo, monkeypatch
+):
+    pagination = PaginationRequestSchema(
+        page=1,
+        size=10,
+        sort_orders=[],
+        filters=[],
+    )
+    supplier_user = SimpleNamespace(role_names=[RoleEnum.SUPPLIER], organization_id=1)
+
+    latest_visible_query = AsyncMock(return_value=select(ComplianceReportListView))
+    monkeypatch.setattr(
+        compliance_report_repo,
+        "get_latest_visible_reports_query",
+        latest_visible_query,
+    )
+    monkeypatch.setattr(
+        "lcfs.web.api.compliance_report.repo.paginate_with_window_count",
+        AsyncMock(return_value=([], 0)),
+    )
+
+    await compliance_report_repo.get_reports_paginated(pagination, supplier_user)
+
+    latest_visible_query.assert_awaited_once_with([], supplier_user.organization_id)
+
+
+@pytest.mark.anyio
+async def test_get_reports_paginated_excludes_analyst_adjustment_for_non_supplier_non_analyst(
+    compliance_report_repo, monkeypatch
+):
+    pagination = PaginationRequestSchema(
+        page=1,
+        size=10,
+        sort_orders=[],
+        filters=[],
+    )
+    government_user = SimpleNamespace(
+        role_names=[RoleEnum.GOVERNMENT], organization_id=None
+    )
+
+    latest_visible_query = AsyncMock(return_value=select(ComplianceReportListView))
+    monkeypatch.setattr(
+        compliance_report_repo,
+        "get_latest_visible_reports_query",
+        latest_visible_query,
+    )
+    monkeypatch.setattr(
+        "lcfs.web.api.compliance_report.repo.paginate_with_window_count",
+        AsyncMock(return_value=([], 0)),
+    )
+
+    await compliance_report_repo.get_reports_paginated(pagination, government_user)
+
+    latest_visible_query.assert_awaited_once_with(
+        [
+            ComplianceReportStatusEnum.Analyst_adjustment,
+            ComplianceReportStatusEnum.Draft,
+        ],
+        government_user.organization_id,
+    )
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/compliance_report/test_compliance_report_services.py
+++ b/backend/lcfs/tests/compliance_report/test_compliance_report_services.py
@@ -285,6 +285,42 @@ async def test_get_compliance_reports_paginated_unexpected_error(
         )
 
 
+def test_mask_report_status_masks_analyst_adjustment_list_row_for_supplier(
+    compliance_report_service, compliance_report_schema
+):
+    supplier_user = SimpleNamespace(role_names=[RoleEnum.SUPPLIER])
+    report = compliance_report_schema(
+        report_status_id=7,
+        report_status=ComplianceReportStatusEnum.Analyst_adjustment.underscore_value(),
+    )
+
+    [masked_report] = compliance_report_service._mask_report_status(
+        [report], supplier_user
+    )
+
+    assert masked_report.report_status == ComplianceReportStatusEnum.Submitted.value
+    assert masked_report.report_status_id is None
+
+
+def test_mask_report_status_masks_analyst_adjustment_base_report_for_supplier(
+    compliance_report_service, compliance_report_base_schema
+):
+    supplier_user = SimpleNamespace(role_names=[RoleEnum.SUPPLIER])
+    report = compliance_report_base_schema()
+    report.current_status.status = ComplianceReportStatusEnum.Analyst_adjustment.value
+    report.current_status.compliance_report_status_id = 7
+
+    [masked_report] = compliance_report_service._mask_report_status(
+        [report], supplier_user
+    )
+
+    assert (
+        masked_report.current_status.status
+        == ComplianceReportStatusEnum.Submitted.value
+    )
+    assert masked_report.current_status.compliance_report_status_id is None
+
+
 # get_compliance_report_by_id
 @pytest.mark.anyio
 async def test_get_compliance_report_by_id_success(

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -108,7 +108,8 @@ def test_fse_pref_view_matches_reporting_rows_by_equipment_group_uuid():
     ).read_text()
 
     assert "v.compliance_report_group_uuid,\n                    ce.group_uuid" in sql
-    assert "mr.charging_equipment_group_uuid = fr.charging_equipment_group_uuid" in sql
+    assert "fr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid" in sql
+    assert "mr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid" in sql
     assert "COALESCE(fr.charging_equipment_id, mr.charging_equipment_id)" in sql
     assert "COALESCE(fr.serial_number, mr.serial_number)" in sql
     assert (

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -74,6 +74,16 @@ def repo(fake_db):
     return FinalSupplyEquipmentRepository(db=fake_db)
 
 
+def mock_reporting_record_resolution(repo, record_id=1, compliance_report_id=10):
+    record = MagicMock(
+        charging_equipment_compliance_id=record_id,
+        compliance_report_id=compliance_report_id,
+    )
+    repo.get_reporting_record_by_id = AsyncMock(return_value=record)
+    repo._resolve_reporting_record_to_latest_equipment = AsyncMock(return_value=record)
+    return record
+
+
 def test_combine_reporting_queries_uses_union_for_multiple_queries(repo):
     first_query = select(literal(1).label("charging_equipment_id"))
     second_query = select(literal(1).label("charging_equipment_id"))
@@ -695,13 +705,29 @@ async def test_get_total_kwh_usage_for_report_excludes_is_active_when_not_summar
 
 
 @pytest.mark.anyio
+async def test_get_total_kwh_usage_for_report_can_use_vw_fse_base(repo, fake_db):
+    fake_db.scalar.return_value = 321.0
+
+    result = await repo.get_total_kwh_usage_for_report(
+        1, 10, "summary", source="vw_fse_base"
+    )
+
+    assert result == 321.0
+
+    stmt = fake_db.scalar.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "vw_fse_base" in compiled
+    assert "mv_fse_reporting_base_pref" not in compiled
+    assert "sum(vw_fse_base.kwh_usage)" in compiled
+    assert "vw_fse_base.compliance_report_id = 10" in compiled
+
+
+@pytest.mark.anyio
 async def test_effective_fse_export_rows_match_total_view_and_filters(repo, fake_db):
     """
-    The supplier (BCeID) export must draw its row set + kWh from the SAME
-    pref-view rows and SAME summary filters as the header total / UI table /
-    government export, so the supplier's Excel sum cannot diverge from the
-    total shown above the table. Equipment metadata is enriched from the latest
-    version via COALESCE.
+    The supplier (BCeID) export must draw its row set + kWh from vw_fse_base,
+    matching the summary table source. Equipment metadata is enriched from the
+    latest version via COALESCE.
     """
     data_result = MagicMock()
     data_result.fetchall.return_value = []
@@ -716,10 +742,11 @@ async def test_effective_fse_export_rows_match_total_view_and_filters(repo, fake
     stmt = fake_db.execute.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
 
-    # kWh + row set come from the same view + summary filters as the total.
-    assert "mv_fse_reporting_base_pref" in compiled
-    assert "mv_fse_reporting_base_pref.kwh_usage" in compiled
-    assert "mv_fse_reporting_base_pref.compliance_report_id = 1" in compiled
+    # kWh + row set come from the same view + summary filters as the summary.
+    assert "vw_fse_base" in compiled
+    assert "vw_fse_base.kwh_usage" in compiled
+    assert "vw_fse_base.compliance_report_id = 1" in compiled
+    assert "mv_fse_reporting_base_pref" not in compiled
     assert "Decommissioned" in compiled
     assert "charging_equipment_compliance_id IS NOT NULL" in compiled
     assert "is_active IS true" in compiled
@@ -744,7 +771,7 @@ async def test_has_decommissioned_fse_in_report_true(repo, fake_db):
     # report's selections.
     stmt = fake_db.scalar.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "mv_fse_reporting_base" in compiled
+    assert "v_fse_reporting_base" in compiled
     assert "mv_fse_reporting_base_pref" not in compiled
     assert "compliance_report_group_uuid = 'group-10'" in compiled
     assert "compliance_report_id" not in compiled
@@ -776,7 +803,7 @@ async def test_deactivate_decommissioned_fse_for_report(repo, fake_db):
     assert "charging_equipment_status = 'Decommissioned'" in compiled_sql
     assert "is_active IS true" in compiled_sql
     # Sources rows from the selected-rows base view, matched by report group.
-    assert "mv_fse_reporting_base" in compiled_sql
+    assert "v_fse_reporting_base" in compiled_sql
     assert "mv_fse_reporting_base_pref" not in compiled_sql
     assert "compliance_report_group_uuid = 'group-10'" in compiled_sql
 
@@ -889,27 +916,21 @@ async def test_create_fse_reporting_batch(repo, fake_db):
 async def test_update_fse_reporting(repo, fake_db):
     """Test updating FSE reporting"""
     data = {"kwh_usage": 1500.0, "notes": "Updated notes"}
-    existing_record = MagicMock(compliance_report_id=10)
-    records_result = MagicMock()
-    records_result.scalars.return_value.first.return_value = existing_record
-    fake_db.execute.side_effect = [records_result, MagicMock()]
+    mock_reporting_record_resolution(repo, record_id=1, compliance_report_id=10)
 
     result = await repo.update_fse_reporting(1, data)
 
     assert result["id"] == 1
     assert result["kwh_usage"] == 1500.0
     assert result["notes"] == "Updated notes"
-    assert fake_db.execute.await_count == 2
+    fake_db.execute.assert_awaited_once()
     fake_db.flush.assert_called_once()
 
 
 @pytest.mark.anyio
 async def test_update_fse_reporting_does_not_move_report_association(repo, fake_db):
     """Updating usage must not re-point the FSE association to another report."""
-    existing_record = MagicMock(compliance_report_id=3814)
-    records_result = MagicMock()
-    records_result.scalars.return_value.first.return_value = existing_record
-    fake_db.execute.side_effect = [records_result, MagicMock()]
+    mock_reporting_record_resolution(repo, record_id=1, compliance_report_id=3814)
     data = {
         "kwh_usage": 1500.0,
         "compliance_report_id": 3814,
@@ -922,7 +943,7 @@ async def test_update_fse_reporting_does_not_move_report_association(repo, fake_
     result = await repo.update_fse_reporting(1, data)
 
     assert result == {"id": 1, "kwh_usage": 1500.0}
-    stmt = fake_db.execute.call_args_list[1][0][0]
+    stmt = fake_db.execute.call_args[0][0]
     compiled_sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
 
     assert "kwh_usage" in compiled_sql
@@ -932,6 +953,76 @@ async def test_update_fse_reporting_does_not_move_report_association(repo, fake_
     assert "charging_equipment_id" not in compiled_sql
     assert "charging_equipment_version" not in compiled_sql
     fake_db.flush.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_reporting_record_moves_to_latest_equipment_version(repo, fake_db):
+    reporting_record = MagicMock(
+        charging_equipment_compliance_id=10,
+        charging_equipment_id=100,
+        charging_equipment_version=1,
+        compliance_report_group_uuid="report-group",
+        organization_id=7,
+    )
+    latest_row = MagicMock(charging_equipment_id=101, charging_equipment_version=3)
+    latest_result = MagicMock()
+    latest_result.fetchone.return_value = latest_row
+    target_result = MagicMock()
+    target_result.scalars.return_value.first.return_value = None
+    fake_db.execute.side_effect = [latest_result, target_result]
+
+    resolved = await repo._resolve_reporting_record_to_latest_equipment(
+        reporting_record
+    )
+
+    assert resolved is reporting_record
+    assert reporting_record.charging_equipment_id == 101
+    assert reporting_record.charging_equipment_version == 3
+    fake_db.delete.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_resolve_reporting_record_reuses_existing_latest_equipment_row(
+    repo, fake_db
+):
+    reporting_record = MagicMock(
+        charging_equipment_compliance_id=10,
+        charging_equipment_id=100,
+        charging_equipment_version=1,
+        compliance_report_group_uuid="report-group",
+        organization_id=7,
+        compliance_report_id=44,
+        supply_from_date=datetime(2024, 1, 1),
+        supply_to_date=datetime(2024, 12, 31),
+        kwh_usage=123.4,
+        compliance_notes="notes",
+        is_active=True,
+    )
+    existing_target = MagicMock(
+        charging_equipment_compliance_id=20,
+        kwh_usage=None,
+        compliance_notes=None,
+        is_active=False,
+    )
+    latest_row = MagicMock(charging_equipment_id=101, charging_equipment_version=3)
+    latest_result = MagicMock()
+    latest_result.fetchone.return_value = latest_row
+    target_result = MagicMock()
+    target_result.scalars.return_value.first.return_value = existing_target
+    fake_db.execute.side_effect = [latest_result, target_result]
+
+    resolved = await repo._resolve_reporting_record_to_latest_equipment(
+        reporting_record
+    )
+
+    assert resolved is existing_target
+    assert existing_target.supply_from_date == reporting_record.supply_from_date
+    assert existing_target.supply_to_date == reporting_record.supply_to_date
+    assert existing_target.kwh_usage == 123.4
+    assert existing_target.compliance_notes == "notes"
+    assert existing_target.is_active is True
+    assert existing_target.compliance_report_id == 44
+    fake_db.delete.assert_awaited_once_with(reporting_record)
 
 
 @pytest.mark.anyio
@@ -1020,6 +1111,37 @@ async def test_get_fse_reporting_list_paginated_prioritizes_group_uuid(repo, fak
 
 
 @pytest.mark.anyio
+async def test_get_fse_reporting_list_paginated_can_use_vw_fse_base(repo, fake_db):
+    fake_db.scalar.return_value = 0
+    data_result = MagicMock()
+    data_result.fetchall.return_value = []
+    fake_db.execute.return_value = data_result
+
+    pagination = PaginationRequestSchema(page=1, size=10, filters=[], sort_orders=[])
+
+    await repo.get_fse_reporting_list_paginated(
+        1, pagination, 10, "summary", source="vw_fse_base"
+    )
+
+    executed_query = fake_db.execute.call_args[0][0]
+    compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "vw_fse_base" in compiled_sql
+    assert "mv_fse_reporting_base_pref" not in compiled_sql
+
+
+def test_vw_fse_base_projects_capacity_from_preferred_materialized_view():
+    metabase_sql = Path("lcfs/db/sql/views/metabase.sql").read_text()
+    start = metabase_sql.index("CREATE OR REPLACE VIEW vw_fse_base AS")
+    end = metabase_sql.index("GRANT SELECT ON vw_fse_base", start)
+    view_sql = metabase_sql[start:end]
+
+    assert "FROM mv_fse_reporting_base_pref v" in view_sql
+    assert "v.capacity_utilization_percent" in view_sql
+    assert "NULL::integer                                 AS capacity_utilization_percent" not in view_sql
+
+
+@pytest.mark.anyio
 async def test_has_charging_equipment_for_organization_with_equipment(repo, fake_db):
     """Test has_charging_equipment_for_organization returns True when equipment exists."""
     # Simulate database returning count > 0
@@ -1065,6 +1187,8 @@ async def test_bulk_update_all_fields_executes_update(repo, fake_db):
     """All four data fields + activate → execute + flush called once each."""
     from datetime import date
 
+    mock_reporting_record_resolution(repo, record_id=10)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=10,
         supply_from_date=date(2024, 1, 1),
@@ -1081,6 +1205,8 @@ async def test_bulk_update_all_fields_executes_update(repo, fake_db):
 @pytest.mark.anyio
 async def test_bulk_update_partial_fields_still_executes(repo, fake_db):
     """Providing only kwh_usage + activate still triggers execute + flush."""
+    mock_reporting_record_resolution(repo, record_id=10)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=10,
         supply_from_date=None,
@@ -1113,6 +1239,8 @@ async def test_bulk_update_no_fields_skips_execute(repo, fake_db):
 @pytest.mark.anyio
 async def test_bulk_update_activate_only_executes(repo, fake_db):
     """activate=True with all data fields None → is_active update still runs."""
+    mock_reporting_record_resolution(repo, record_id=10)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=10,
         supply_from_date=None,
@@ -1130,6 +1258,8 @@ async def test_bulk_update_activate_only_executes(repo, fake_db):
 async def test_bulk_update_without_activate_does_not_set_is_active(repo, fake_db):
     """activate=False (default) → is_active is NOT included in the UPDATE statement."""
     from datetime import date
+
+    mock_reporting_record_resolution(repo, record_id=7)
 
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=7,
@@ -1150,6 +1280,8 @@ async def test_bulk_update_without_activate_does_not_set_is_active(repo, fake_db
 async def test_bulk_update_with_activate_includes_is_active(repo, fake_db):
     """activate=True → the compiled UPDATE statement must contain is_active = true."""
     from datetime import date
+
+    mock_reporting_record_resolution(repo, record_id=7)
 
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=7,
@@ -1244,6 +1376,8 @@ async def test_get_fse_reporting_record_for_group_query_does_not_filter_on_versi
 @pytest.mark.anyio
 async def test_bulk_update_deactivate_executes_update(repo, fake_db):
     """deactivate=True → execute + flush are called."""
+    mock_reporting_record_resolution(repo, record_id=20)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=20,
         supply_from_date=None,
@@ -1260,6 +1394,8 @@ async def test_bulk_update_deactivate_executes_update(repo, fake_db):
 @pytest.mark.anyio
 async def test_bulk_update_deactivate_sets_is_active_false(repo, fake_db):
     """deactivate=True → compiled SQL must set is_active = false."""
+    mock_reporting_record_resolution(repo, record_id=20)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=20,
         supply_from_date=None,
@@ -1281,6 +1417,8 @@ async def test_bulk_update_deactivate_does_not_set_dates(repo, fake_db):
     deactivate=True must NOT update supply_from_date or supply_to_date because
     those columns are NOT NULL in the database.
     """
+    mock_reporting_record_resolution(repo, record_id=20)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=20,
         supply_from_date=None,
@@ -1302,6 +1440,8 @@ async def test_bulk_update_deactivate_takes_precedence_over_activate(repo, fake_
     When both deactivate=True and activate=True are passed, deactivate must win
     (is_active is set to False, not True).
     """
+    mock_reporting_record_resolution(repo, record_id=30)
+
     await repo.bulk_update_fse_reporting_record(
         charging_equipment_compliance_id=30,
         supply_from_date=None,

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -112,34 +112,6 @@ def test_latest_equipment_versions_subquery_ranks_by_group_uuid(repo):
     assert "charging_equipment.version DESC" in compiled
 
 
-def test_fse_pref_view_matches_reporting_rows_by_equipment_group_uuid():
-    sql = (
-        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
-    ).read_text()
-
-    assert "v.compliance_report_group_uuid,\n                    ce.group_uuid" in sql
-    assert "fr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid" in sql
-    assert "mr.charging_equipment_group_uuid = rek.charging_equipment_group_uuid" in sql
-    assert "COALESCE(fr.charging_equipment_id, mr.charging_equipment_id)" in sql
-    assert "COALESCE(fr.serial_number, mr.serial_number)" in sql
-    assert (
-        "mr.charging_equipment_id = fr.charging_equipment_id\n"
-        "   AND mr.charging_equipment_version = fr.charging_equipment_version"
-        not in sql
-    )
-
-
-def test_fse_reporting_views_resolve_latest_site_by_group_uuid():
-    sql = (
-        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
-    ).read_text()
-
-    assert "JOIN charging_site cs_fk ON ce.charging_site_id = cs_fk.charging_site_id" in sql
-    assert "WHERE cs.group_uuid = cs_fk.group_uuid" in sql
-    assert "ORDER BY cs.version DESC" in sql
-    assert "AND cs.version = (SELECT MAX(cs2.version)" not in sql
-
-
 @pytest.mark.anyio
 async def test_sync_reporting_associations_preserves_inactive_selection(repo, fake_db):
     association = MagicMock()

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -119,6 +119,17 @@ def test_fse_pref_view_matches_reporting_rows_by_equipment_group_uuid():
     )
 
 
+def test_fse_reporting_views_resolve_latest_site_by_group_uuid():
+    sql = (
+        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
+    ).read_text()
+
+    assert "JOIN charging_site cs_fk ON ce.charging_site_id = cs_fk.charging_site_id" in sql
+    assert "WHERE cs.group_uuid = cs_fk.group_uuid" in sql
+    assert "ORDER BY cs.version DESC" in sql
+    assert "AND cs.version = (SELECT MAX(cs2.version)" not in sql
+
+
 @pytest.mark.anyio
 async def test_sync_reporting_associations_preserves_inactive_selection(repo, fake_db):
     association = MagicMock()

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -119,50 +119,6 @@ def test_fse_pref_view_matches_reporting_rows_by_equipment_group_uuid():
     )
 
 
-def test_fse_pref_view_includes_historical_report_rows_without_current_fallback():
-    sql = (
-        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
-    ).read_text()
-
-    assert "report_equipment_keys AS" in sql
-    assert "JOIN matched_rows mr" in sql
-    assert "mr.compliance_report_group_uuid = rc.compliance_report_group_uuid" in sql
-    assert "COALESCE(fr.charging_equipment_id, mr.charging_equipment_id)" in sql
-    assert "FROM report_equipment_keys rek" in sql
-    assert "LEFT JOIN fallback_rows fr" in sql
-
-
-def test_fse_reporting_pref_and_yoy_base_are_materialized_views():
-    sql = (
-        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
-    ).read_text()
-
-    assert "CREATE MATERIALIZED VIEW v_fse_reporting_base_pref AS" in sql
-    assert "CREATE MATERIALIZED VIEW vw_fse_base AS" in sql
-    assert "CREATE OR REPLACE VIEW v_fse_reporting_base_pref AS" not in sql
-    assert "CREATE OR REPLACE VIEW vw_fse_base AS" not in sql
-
-
-def test_fse_materialized_view_refresh_migration_tracks_source_tables():
-    migration = (
-        Path(__file__).resolve().parents[3]
-        / "lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py"
-    ).read_text()
-
-    assert "CREATE OR REPLACE FUNCTION refresh_fse_materialized_views()" in migration
-    assert "REFRESH MATERIALIZED VIEW v_fse_reporting_base_pref" in migration
-    assert "REFRESH MATERIALIZED VIEW vw_fse_base" in migration
-    for table_name in [
-        "compliance_report",
-        "compliance_report_charging_equipment",
-        "charging_equipment",
-        "charging_site",
-        "charging_equipment_intended_use_association",
-        "charging_equipment_intended_user_association",
-    ]:
-        assert table_name in migration
-
-
 @pytest.mark.anyio
 async def test_sync_reporting_associations_preserves_inactive_selection(repo, fake_db):
     association = MagicMock()
@@ -1254,7 +1210,7 @@ async def test_get_fse_reporting_record_for_group_query_does_not_filter_on_versi
 
     await repo.get_fse_reporting_record_for_group(
         charging_equipment_id=1,
-        charging_equipment_version=99,   # arbitrary; must be ignored
+        charging_equipment_version=99,  # arbitrary; must be ignored
         compliance_report_group_uuid="group-xyz",
     )
 
@@ -1264,7 +1220,9 @@ async def test_get_fse_reporting_record_for_group_query_does_not_filter_on_versi
     # compliance_report_group_uuid but NOT on charging_equipment_version.
     assert "charging_equipment_id" in compiled
     assert "compliance_report_group_uuid" in compiled
-    assert "charging_equipment_version" not in compiled.split("WHERE")[1].split("ORDER")[0]
+    assert (
+        "charging_equipment_version" not in compiled.split("WHERE")[1].split("ORDER")[0]
+    )
 
 
 # ===========================================================================

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -109,12 +109,57 @@ def test_fse_pref_view_matches_reporting_rows_by_equipment_group_uuid():
 
     assert "v.compliance_report_group_uuid,\n                    ce.group_uuid" in sql
     assert "mr.charging_equipment_group_uuid = fr.charging_equipment_group_uuid" in sql
-    assert "fr.charging_equipment_id,\n    fr.serial_number" in sql
+    assert "COALESCE(fr.charging_equipment_id, mr.charging_equipment_id)" in sql
+    assert "COALESCE(fr.serial_number, mr.serial_number)" in sql
     assert (
         "mr.charging_equipment_id = fr.charging_equipment_id\n"
         "   AND mr.charging_equipment_version = fr.charging_equipment_version"
         not in sql
     )
+
+
+def test_fse_pref_view_includes_historical_report_rows_without_current_fallback():
+    sql = (
+        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
+    ).read_text()
+
+    assert "report_equipment_keys AS" in sql
+    assert "JOIN matched_rows mr" in sql
+    assert "mr.compliance_report_group_uuid = rc.compliance_report_group_uuid" in sql
+    assert "COALESCE(fr.charging_equipment_id, mr.charging_equipment_id)" in sql
+    assert "FROM report_equipment_keys rek" in sql
+    assert "LEFT JOIN fallback_rows fr" in sql
+
+
+def test_fse_reporting_pref_and_yoy_base_are_materialized_views():
+    sql = (
+        Path(__file__).resolve().parents[3] / "lcfs/db/sql/views/metabase.sql"
+    ).read_text()
+
+    assert "CREATE MATERIALIZED VIEW v_fse_reporting_base_pref AS" in sql
+    assert "CREATE MATERIALIZED VIEW vw_fse_base AS" in sql
+    assert "CREATE OR REPLACE VIEW v_fse_reporting_base_pref AS" not in sql
+    assert "CREATE OR REPLACE VIEW vw_fse_base AS" not in sql
+
+
+def test_fse_materialized_view_refresh_migration_tracks_source_tables():
+    migration = (
+        Path(__file__).resolve().parents[3]
+        / "lcfs/db/migrations/versions/2026-03-24-12-00_098cf79762b9.py"
+    ).read_text()
+
+    assert "CREATE OR REPLACE FUNCTION refresh_fse_materialized_views()" in migration
+    assert "REFRESH MATERIALIZED VIEW v_fse_reporting_base_pref" in migration
+    assert "REFRESH MATERIALIZED VIEW vw_fse_base" in migration
+    for table_name in [
+        "compliance_report",
+        "compliance_report_charging_equipment",
+        "charging_equipment",
+        "charging_site",
+        "charging_equipment_intended_use_association",
+        "charging_equipment_intended_user_association",
+    ]:
+        assert table_name in migration
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_repo.py
@@ -624,8 +624,8 @@ async def test_get_total_kwh_usage_for_report_sums_same_view_and_filters(repo, f
     stmt = fake_db.scalar.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
     # Same source view as the list query, summing the kWh column.
-    assert "v_fse_reporting_base_pref" in compiled
-    assert "sum(v_fse_reporting_base_pref.kwh_usage)" in compiled
+    assert "mv_fse_reporting_base_pref" in compiled
+    assert "sum(mv_fse_reporting_base_pref.kwh_usage)" in compiled
     # Same scoping/filters as the list query, including the summary is_active
     # filter so active-only rows are counted exactly as the table shows them.
     assert "compliance_report_id = 10" in compiled
@@ -666,7 +666,7 @@ async def test_review_fse_summary_uses_same_view_and_filters_as_grid(repo, fake_
 
     stmt, params = fake_db.execute.call_args.args
     sql = str(stmt)
-    assert "v_fse_reporting_base_pref" in sql
+    assert "mv_fse_reporting_base_pref" in sql
     assert "fse_review_summary_counts" in sql
     assert "fse_review_level_counts" in sql
     assert "GROUP BY COALESCE(level_of_equipment, 'Unknown level')" in sql
@@ -717,9 +717,9 @@ async def test_effective_fse_export_rows_match_total_view_and_filters(repo, fake
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
 
     # kWh + row set come from the same view + summary filters as the total.
-    assert "v_fse_reporting_base_pref" in compiled
-    assert "v_fse_reporting_base_pref.kwh_usage" in compiled
-    assert "v_fse_reporting_base_pref.compliance_report_id = 1" in compiled
+    assert "mv_fse_reporting_base_pref" in compiled
+    assert "mv_fse_reporting_base_pref.kwh_usage" in compiled
+    assert "mv_fse_reporting_base_pref.compliance_report_id = 1" in compiled
     assert "Decommissioned" in compiled
     assert "charging_equipment_compliance_id IS NOT NULL" in compiled
     assert "is_active IS true" in compiled
@@ -744,8 +744,8 @@ async def test_has_decommissioned_fse_in_report_true(repo, fake_db):
     # report's selections.
     stmt = fake_db.scalar.call_args[0][0]
     compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "v_fse_reporting_base" in compiled
-    assert "v_fse_reporting_base_pref" not in compiled
+    assert "mv_fse_reporting_base" in compiled
+    assert "mv_fse_reporting_base_pref" not in compiled
     assert "compliance_report_group_uuid = 'group-10'" in compiled
     assert "compliance_report_id" not in compiled
 
@@ -776,8 +776,8 @@ async def test_deactivate_decommissioned_fse_for_report(repo, fake_db):
     assert "charging_equipment_status = 'Decommissioned'" in compiled_sql
     assert "is_active IS true" in compiled_sql
     # Sources rows from the selected-rows base view, matched by report group.
-    assert "v_fse_reporting_base" in compiled_sql
-    assert "v_fse_reporting_base_pref" not in compiled_sql
+    assert "mv_fse_reporting_base" in compiled_sql
+    assert "mv_fse_reporting_base_pref" not in compiled_sql
     assert "compliance_report_group_uuid = 'group-10'" in compiled_sql
 
 
@@ -1016,7 +1016,7 @@ async def test_get_fse_reporting_list_paginated_prioritizes_group_uuid(repo, fak
     compiled_sql = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
 
     # When mode='all', the query should use FSEReportingBasePrefView which has prioritization logic
-    assert "v_fse_reporting_base_pref" in compiled_sql
+    assert "mv_fse_reporting_base_pref" in compiled_sql
 
 
 @pytest.mark.anyio

--- a/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
+++ b/backend/lcfs/tests/final_supply_equipment/test_final_supply_equipment_services.py
@@ -474,9 +474,11 @@ async def test_get_fse_reporting_list_paginated_success(
     assert result["pagination"].total == 1
     assert result["finalSupplyEquipments"][0].status == "Submitted"
     mock_repo.get_fse_reporting_list_paginated.assert_awaited_once_with(
-        1, pagination, 10, "current"
+        1, pagination, 10, "current", source="base_pref"
     )
-    mock_repo.get_total_kwh_usage_for_report.assert_awaited_once_with(1, 10, "current")
+    mock_repo.get_total_kwh_usage_for_report.assert_awaited_once_with(
+        1, 10, "current", source="base_pref"
+    )
 
 
 @pytest.mark.anyio
@@ -532,7 +534,9 @@ async def test_get_fse_reporting_list_paginated_calculates_capacity(
     equipment = result["finalSupplyEquipments"][0]
     assert equipment.capacity_utilization_percent == 80
     assert equipment.power_output == 50
-    mock_repo.get_total_kwh_usage_for_report.assert_awaited_once_with(1, 10, "summary")
+    mock_repo.get_total_kwh_usage_for_report.assert_awaited_once_with(
+        1, 10, "summary", source="base_pref"
+    )
 
 
 @pytest.mark.anyio
@@ -557,6 +561,7 @@ async def test_get_fse_reporting_list_paginated_does_not_refresh_decommissioned_
         pagination,
         10,
         "all",
+        source="base_pref",
     )
 
 

--- a/backend/lcfs/tests/services/scheduler/test_scheduler.py
+++ b/backend/lcfs/tests/services/scheduler/test_scheduler.py
@@ -152,11 +152,11 @@ async def test_scheduler_adds_startup_job(mock_app):
             # Verify start was called
             mock_start.assert_called_once()
 
-            mock_add_job.assert_called_once()
-            assert (
-                mock_add_job.call_args.kwargs["id"]
-                == "reindex_compliance_report_tables"
-            )
+            added_job_ids = [
+                call.kwargs["id"] for call in mock_add_job.call_args_list
+            ]
+            assert "reindex_compliance_report_tables" in added_job_ids
+            assert "refresh_fse_reporting_materialized_views" in added_job_ids
 
             # # Verify the job was added
             # mock_add_job.assert_called_once()

--- a/backend/lcfs/tests/services/scheduler/test_scheduler.py
+++ b/backend/lcfs/tests/services/scheduler/test_scheduler.py
@@ -47,8 +47,9 @@ async def test_scheduler_lifecycle(mock_app):
         start_scheduler(mock_app)
         assert scheduler.running, "Scheduler should be running after start"
 
-        mock_add_job.assert_called_once()
-        assert mock_add_job.call_args.kwargs["id"] == "reindex_compliance_report_tables"
+        added_job_ids = [call.kwargs["id"] for call in mock_add_job.call_args_list]
+        assert "reindex_compliance_report_tables" in added_job_ids
+        assert "refresh_fse_reporting_materialized_views" in added_job_ids
 
         safe_shutdown_scheduler()
 
@@ -220,11 +221,12 @@ async def test_scheduler_startup_job_essentials(mock_app):
         # Verify scheduler.start was called
         mock_scheduler_instance.start.assert_called_once()
 
-        mock_scheduler_instance.add_job.assert_called_once()
-        assert (
-            mock_scheduler_instance.add_job.call_args.kwargs["id"]
-            == "reindex_compliance_report_tables"
-        )
+        added_job_ids = [
+            call.kwargs["id"]
+            for call in mock_scheduler_instance.add_job.call_args_list
+        ]
+        assert "reindex_compliance_report_tables" in added_job_ids
+        assert "refresh_fse_reporting_materialized_views" in added_job_ids
 
         # # Verify add_job was called with correct parameters
         # mock_scheduler_instance.add_job.assert_called_once()
@@ -254,10 +256,10 @@ async def test_scheduler_adds_one_time_startup_reindex_job_when_enabled(mock_app
         try:
             start_scheduler(mock_app)
 
-            assert mock_add_job.call_count == 2
             added_job_ids = [call.kwargs["id"] for call in mock_add_job.call_args_list]
             assert "reindex_compliance_report_tables" in added_job_ids
             assert "reindex_compliance_report_tables_startup" in added_job_ids
+            assert "refresh_fse_reporting_materialized_views" in added_job_ids
         finally:
             settings.compliance_reindex_run_on_startup = original_value
             scheduler._state = 0

--- a/backend/lcfs/web/api/compliance_report/repo.py
+++ b/backend/lcfs/web/api/compliance_report/repo.py
@@ -427,10 +427,10 @@ class ComplianceReportRepository:
         excluded_statuses = []
 
         is_analyst = user_has_roles(user, [RoleEnum.ANALYST])
-        if not is_analyst:
+        is_supplier = user_has_roles(user, [RoleEnum.SUPPLIER])
+        if not is_analyst and not is_supplier:
             excluded_statuses.append(ComplianceReportStatusEnum.Analyst_adjustment)
 
-        is_supplier = user_has_roles(user, [RoleEnum.SUPPLIER])
         if not is_supplier:
             excluded_statuses.append(ComplianceReportStatusEnum.Draft)
 

--- a/backend/lcfs/web/api/compliance_report/services.py
+++ b/backend/lcfs/web/api/compliance_report/services.py
@@ -708,6 +708,7 @@ class ComplianceReportServices:
         }
 
         analyst_only_statuses_regular = {
+            ComplianceReportStatusEnum.Analyst_adjustment.value,
             ComplianceReportStatusEnum.Analyst_adjustment.underscore_value(),
         }
 

--- a/backend/lcfs/web/api/compliance_report/sheet_exporters/fse.py
+++ b/backend/lcfs/web/api/compliance_report/sheet_exporters/fse.py
@@ -73,6 +73,7 @@ class FSESheetExporter(TabularSheetExporter):
                     ),
                     compliance_report_id=cid,
                     mode="summary",
+                    source="vw_fse_base",
                 )
             )
             if total > len(reporting_rows):
@@ -84,6 +85,7 @@ class FSESheetExporter(TabularSheetExporter):
                         ),
                         compliance_report_id=cid,
                         mode="summary",
+                        source="vw_fse_base",
                     )
                 )[0]
         else:

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -1092,7 +1092,7 @@ class FinalSupplyEquipmentRepository:
         Reporting selections live at the compliance-report-group level and carry
         across report versions, so we match on ``compliance_report_group_uuid``
         (not a single ``compliance_report_id``) — otherwise a supplemental would
-        miss equipment selected on the original report. ``v_fse_reporting_base``
+        miss equipment selected on the original report. ``mv_fse_reporting_base``
         already contains only the actually-selected reporting rows (one per
         ``compliance_report_charging_equipment``), so it is queried directly
         rather than the heavier "preferred"/editing view.
@@ -1143,7 +1143,7 @@ class FinalSupplyEquipmentRepository:
         decommissioned.
 
         Matches the report group's reporting set via
-        ``compliance_report_group_uuid`` against ``v_fse_reporting_base`` (the
+        ``compliance_report_group_uuid`` against ``mv_fse_reporting_base`` (the
         selected-rows view), consistent with ``has_decommissioned_fse_in_report``.
 
         Period-aware: when ``compliance_year`` is provided, only rows for
@@ -1234,7 +1234,7 @@ class FinalSupplyEquipmentRepository:
         """
         Return total kWh usage for the rows shown in the FSE reporting list.
 
-        This sums ``kwh_usage`` over the same ``v_fse_reporting_base_pref`` rows
+        This sums ``kwh_usage`` over the same ``mv_fse_reporting_base_pref`` rows
         (and identical filters) that ``get_fse_reporting_list_paginated``
         returns, so the total displayed above the table always matches the sum
         of the rows in the table and the Excel export. Pagination/user filters
@@ -1279,7 +1279,7 @@ class FinalSupplyEquipmentRepository:
                     capacity_utilization_percent,
                     kwh_usage,
                     registration_number
-                FROM v_fse_reporting_base_pref
+                FROM mv_fse_reporting_base_pref
                 WHERE organization_id = :organization_id
                   AND compliance_report_id = :compliance_report_id
                   AND (
@@ -1557,7 +1557,7 @@ class FinalSupplyEquipmentRepository:
         Return export rows for a BCeID (supplier) compliance report download.
 
         The row set, kWh usage and reporting data (supply dates, compliance
-        notes) come from ``v_fse_reporting_base_pref`` using the exact same
+        notes) come from ``mv_fse_reporting_base_pref`` using the exact same
         filters as the on-screen FSE table, the header total and the government
         export — see ``_fse_reporting_base_conditions`` with ``mode="summary"``.
         This guarantees the supplier's Excel kWh sum matches the total shown

--- a/backend/lcfs/web/api/final_supply_equipment/repo.py
+++ b/backend/lcfs/web/api/final_supply_equipment/repo.py
@@ -31,6 +31,7 @@ from lcfs.db.models.compliance import (
     EndUserType,
     FSEReportingBasePrefView,
     FSEReportingBaseView,
+    VwFSEBaseView,
     FinalSupplyEquipment,
     ChargingEquipmentStatus,
     ComplianceReportChargingEquipment,
@@ -787,8 +788,12 @@ class FinalSupplyEquipmentRepository:
                 == EndUseType.end_use_type_id,
             )
             .where(
-                charging_equipment_intended_use_association.c.charging_equipment_id
-                == ChargingEquipment.charging_equipment_id
+                and_(
+                    charging_equipment_intended_use_association.c.charging_equipment_id
+                    == ChargingEquipment.charging_equipment_id,
+                    charging_equipment_intended_use_association.c.charging_equipment_version
+                    == ChargingEquipment.version
+                )
             )
             .correlate(ChargingEquipment)
             .scalar_subquery()
@@ -804,8 +809,12 @@ class FinalSupplyEquipmentRepository:
                 == EndUserType.end_user_type_id,
             )
             .where(
-                charging_equipment_intended_user_association.c.charging_equipment_id
-                == ChargingEquipment.charging_equipment_id
+                and_(
+                    charging_equipment_intended_user_association.c.charging_equipment_id
+                    == ChargingEquipment.charging_equipment_id,
+                    charging_equipment_intended_user_association.c.charging_equipment_version
+                    == ChargingEquipment.version
+                )
             )
             .correlate(ChargingEquipment)
             .scalar_subquery()
@@ -1092,7 +1101,7 @@ class FinalSupplyEquipmentRepository:
         Reporting selections live at the compliance-report-group level and carry
         across report versions, so we match on ``compliance_report_group_uuid``
         (not a single ``compliance_report_id``) — otherwise a supplemental would
-        miss equipment selected on the original report. ``mv_fse_reporting_base``
+        miss equipment selected on the original report. ``v_fse_reporting_base``
         already contains only the actually-selected reporting rows (one per
         ``compliance_report_charging_equipment``), so it is queried directly
         rather than the heavier "preferred"/editing view.
@@ -1143,7 +1152,7 @@ class FinalSupplyEquipmentRepository:
         decommissioned.
 
         Matches the report group's reporting set via
-        ``compliance_report_group_uuid`` against ``mv_fse_reporting_base`` (the
+        ``compliance_report_group_uuid`` against ``v_fse_reporting_base`` (the
         selected-rows view), consistent with ``has_decommissioned_fse_in_report``.
 
         Period-aware: when ``compliance_year`` is provided, only rows for
@@ -1230,17 +1239,18 @@ class FinalSupplyEquipmentRepository:
         compliance_report_id: int,
         mode: str = "all",
         include_decommissioned_attached: bool = True,
+        source: str = "base_pref",
     ) -> float:
         """
         Return total kWh usage for the rows shown in the FSE reporting list.
 
-        This sums ``kwh_usage`` over the same ``mv_fse_reporting_base_pref`` rows
+        This sums ``kwh_usage`` over the same reporting view rows
         (and identical filters) that ``get_fse_reporting_list_paginated``
         returns, so the total displayed above the table always matches the sum
         of the rows in the table and the Excel export. Pagination/user filters
         are intentionally excluded so the total reflects the whole report.
         """
-        vt = FSEReportingBasePrefView.__table__
+        vt = self._get_fse_reporting_source_table(source)
         conditions = self._fse_reporting_base_conditions(
             vt,
             organization_id,
@@ -1252,6 +1262,57 @@ class FinalSupplyEquipmentRepository:
             select(func.coalesce(func.sum(vt.c.kwh_usage), 0)).where(*conditions)
         )
         return float(total or 0)
+
+    @staticmethod
+    def _get_fse_reporting_source_table(source: str):
+        if source == "vw_fse_base":
+            return VwFSEBaseView.__table__
+        if source in (None, "base_pref"):
+            return FSEReportingBasePrefView.__table__
+        raise ValueError("Invalid FSE reporting source")
+
+    @staticmethod
+    def _fse_reporting_filter_field_map(vt) -> dict:
+        return {
+            "site_name": vt.c.site_name,
+            "registration_number": vt.c.registration_number,
+            "street_address": vt.c.street_address,
+            "charging_site_id": vt.c.charging_site_id,
+            "serial_number": vt.c.serial_number,
+            "manufacturer": vt.c.manufacturer,
+            "model": vt.c.model,
+            "equipment_notes": vt.c.equipment_notes,
+            "supply_from_date": vt.c.supply_from_date,
+            "supply_to_date": vt.c.supply_to_date,
+            "kwh_usage": vt.c.kwh_usage,
+            "compliance_report_id": vt.c.compliance_report_id,
+            "compliance_notes": vt.c.compliance_notes,
+            "level_of_equipment": vt.c.level_of_equipment,
+            "ports": vt.c.ports,
+            "status": vt.c.charging_equipment_status,
+            "is_active": vt.c.is_active,
+            "power_output": vt.c.power_output,
+            "capacity_utilization_percent": vt.c.capacity_utilization_percent,
+        }
+
+    @staticmethod
+    def _fse_reporting_sort_field_map(vt) -> dict:
+        return {
+            "site_name": vt.c.site_name,
+            "serial_number": vt.c.serial_number,
+            "manufacturer": vt.c.manufacturer,
+            "model": vt.c.model,
+            "supply_from_date": vt.c.supply_from_date,
+            "supply_to_date": vt.c.supply_to_date,
+            "kwh_usage": vt.c.kwh_usage,
+            "compliance_report_id": vt.c.compliance_report_id,
+            "registration_number": vt.c.registration_number,
+            "level_of_equipment": vt.c.level_of_equipment,
+            "power_output": vt.c.power_output,
+            "capacity_utilization_percent": vt.c.capacity_utilization_percent,
+            "status": vt.c.charging_equipment_status,
+            "is_active": vt.c.is_active,
+        }
 
     @repo_handler
     async def get_review_fse_summary_for_report(
@@ -1385,12 +1446,12 @@ class FinalSupplyEquipmentRepository:
         compliance_report_id: int,
         mode: str = "all",
         include_decommissioned_attached: bool = True,
+        source: str = "base_pref",
     ) -> tuple[list[dict], int]:
         """
         Get paginated charging equipment reporting rows from reporting views.
         """
-        view_model = FSEReportingBasePrefView
-        vt = view_model.__table__
+        vt = self._get_fse_reporting_source_table(source)
 
         stmt = select(
             vt.c.charging_equipment_compliance_id,
@@ -1435,27 +1496,7 @@ class FinalSupplyEquipmentRepository:
             include_decommissioned_attached,
         )
 
-        filter_field_map = {
-            "site_name": vt.c.site_name,
-            "registration_number": vt.c.registration_number,
-            "street_address": vt.c.street_address,
-            "charging_site_id": vt.c.charging_site_id,
-            "serial_number": vt.c.serial_number,
-            "manufacturer": vt.c.manufacturer,
-            "model": vt.c.model,
-            "equipment_notes": vt.c.equipment_notes,
-            "supply_from_date": vt.c.supply_from_date,
-            "supply_to_date": vt.c.supply_to_date,
-            "kwh_usage": vt.c.kwh_usage,
-            "compliance_report_id": vt.c.compliance_report_id,
-            "compliance_notes": vt.c.compliance_notes,
-            "level_of_equipment": vt.c.level_of_equipment,
-            "ports": vt.c.ports,
-            "status": vt.c.charging_equipment_status,
-            "is_active": vt.c.is_active,
-            "power_output": vt.c.power_output,
-            "capacity_utilization_percent": vt.c.capacity_utilization_percent,
-        }
+        filter_field_map = self._fse_reporting_filter_field_map(vt)
         if pagination.filters:
             for f in pagination.filters:
                 field = filter_field_map.get(f.field)
@@ -1469,22 +1510,7 @@ class FinalSupplyEquipmentRepository:
 
         final_query = stmt.where(*conditions)
         # Apply sorting
-        sort_field_map = {
-            "site_name": vt.c.site_name,
-            "serial_number": vt.c.serial_number,
-            "manufacturer": vt.c.manufacturer,
-            "model": vt.c.model,
-            "supply_from_date": vt.c.supply_from_date,
-            "supply_to_date": vt.c.supply_to_date,
-            "kwh_usage": vt.c.kwh_usage,
-            "compliance_report_id": vt.c.compliance_report_id,
-            "registration_number": vt.c.registration_number,
-            "level_of_equipment": vt.c.level_of_equipment,
-            "power_output": vt.c.power_output,
-            "capacity_utilization_percent": vt.c.capacity_utilization_percent,
-            "status": vt.c.charging_equipment_status,
-            "is_active": vt.c.is_active,
-        }
+        sort_field_map = self._fse_reporting_sort_field_map(vt)
         if pagination.sort_orders:
             for sort_order in pagination.sort_orders:
                 field = sort_field_map.get(sort_order.field)
@@ -1557,9 +1583,8 @@ class FinalSupplyEquipmentRepository:
         Return export rows for a BCeID (supplier) compliance report download.
 
         The row set, kWh usage and reporting data (supply dates, compliance
-        notes) come from ``mv_fse_reporting_base_pref`` using the exact same
-        filters as the on-screen FSE table, the header total and the government
-        export — see ``_fse_reporting_base_conditions`` with ``mode="summary"``.
+        notes) come from ``vw_fse_base`` using the exact same summary filters
+        as the FSE summary table.
         This guarantees the supplier's Excel kWh sum matches the total shown
         above the table.
 
@@ -1575,10 +1600,9 @@ class FinalSupplyEquipmentRepository:
         compatibility; scoping is handled by ``compliance_report_id`` via the
         view, consistent with the government export.
         """
-        vt = FSEReportingBasePrefView.__table__
+        vt = VwFSEBaseView.__table__
 
-        # Authoritative row set + kWh: identical to the header total / UI table
-        # / government export (summary filters on the same view).
+        # Authoritative row set + kWh: identical to the summary table source.
         base_conditions = self._fse_reporting_base_conditions(
             vt, organization_id, compliance_report_id, "summary"
         )
@@ -1611,8 +1635,12 @@ class FinalSupplyEquipmentRepository:
                 == EndUseType.end_use_type_id,
             )
             .where(
-                charging_equipment_intended_use_association.c.charging_equipment_id
-                == latest_equipment.charging_equipment_id
+                and_(
+                    charging_equipment_intended_use_association.c.charging_equipment_id
+                    == latest_equipment.charging_equipment_id,
+                    charging_equipment_intended_use_association.c.charging_equipment_version
+                    == latest_equipment.version
+                )
             )
             .scalar_subquery()
         )
@@ -1626,8 +1654,12 @@ class FinalSupplyEquipmentRepository:
                 == EndUserType.end_user_type_id,
             )
             .where(
-                charging_equipment_intended_user_association.c.charging_equipment_id
-                == latest_equipment.charging_equipment_id
+                and_(
+                    charging_equipment_intended_user_association.c.charging_equipment_id
+                    == latest_equipment.charging_equipment_id,
+                    charging_equipment_intended_user_association.c.charging_equipment_version
+                    == latest_equipment.version
+                )
             )
             .scalar_subquery()
         )
@@ -1789,9 +1821,11 @@ class FinalSupplyEquipmentRepository:
         existing_record = await self.get_reporting_record_by_id(
             charging_equipment_compliance_id
         )
+        if not existing_record:
+            return {"id": charging_equipment_compliance_id}
+
         if (
-            existing_record
-            and data.get("compliance_report_id") is not None
+            data.get("compliance_report_id") is not None
             and existing_record.compliance_report_id != data["compliance_report_id"]
         ):
             revision = await self._create_fse_reporting_revision(
@@ -1806,6 +1840,11 @@ class FinalSupplyEquipmentRepository:
                     revision.charging_equipment_compliance_id
                 ),
             }
+
+        target_record = await self._resolve_reporting_record_to_latest_equipment(
+            existing_record
+        )
+        target_record_id = target_record.charging_equipment_compliance_id
 
         immutable_fields = {
             "charging_equipment_compliance_id",
@@ -1827,17 +1866,121 @@ class FinalSupplyEquipmentRepository:
             update(ComplianceReportChargingEquipment)
             .where(
                 ComplianceReportChargingEquipment.charging_equipment_compliance_id
-                == charging_equipment_compliance_id
+                == target_record_id
             )
             .values(**update_data)
         )
         await self.db.execute(stmt)
         await self.db.flush()
-        return {"id": charging_equipment_compliance_id, **update_data}
+        return {"id": target_record_id, **update_data}
+
+    async def _get_latest_equipment_identity_for_reporting_record(
+        self, reporting_record: ComplianceReportChargingEquipment
+    ) -> tuple[int, int]:
+        current_equipment = aliased(ChargingEquipment, name="current_reporting_ce")
+        latest_equipment = aliased(ChargingEquipment, name="latest_reporting_ce")
+
+        stmt = (
+            select(
+                latest_equipment.charging_equipment_id,
+                latest_equipment.version.label("charging_equipment_version"),
+            )
+            .select_from(current_equipment)
+            .join(
+                latest_equipment,
+                latest_equipment.group_uuid == current_equipment.group_uuid,
+            )
+            .where(
+                current_equipment.charging_equipment_id
+                == reporting_record.charging_equipment_id
+            )
+            .order_by(
+                latest_equipment.version.desc(),
+                latest_equipment.charging_equipment_id.desc(),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        latest = result.fetchone()
+
+        if latest is None:
+            return (
+                reporting_record.charging_equipment_id,
+                reporting_record.charging_equipment_version,
+            )
+
+        return latest.charging_equipment_id, latest.charging_equipment_version
+
+    async def _resolve_reporting_record_to_latest_equipment(
+        self, reporting_record: ComplianceReportChargingEquipment
+    ) -> ComplianceReportChargingEquipment:
+        (
+            latest_equipment_id,
+            latest_equipment_version,
+        ) = await self._get_latest_equipment_identity_for_reporting_record(
+            reporting_record
+        )
+
+        if (
+            reporting_record.charging_equipment_id == latest_equipment_id
+            and reporting_record.charging_equipment_version == latest_equipment_version
+        ):
+            return reporting_record
+
+        existing_target_stmt = select(ComplianceReportChargingEquipment).where(
+            and_(
+                ComplianceReportChargingEquipment.compliance_report_group_uuid
+                == reporting_record.compliance_report_group_uuid,
+                ComplianceReportChargingEquipment.organization_id
+                == reporting_record.organization_id,
+                ComplianceReportChargingEquipment.charging_equipment_id
+                == latest_equipment_id,
+                ComplianceReportChargingEquipment.charging_equipment_version
+                == latest_equipment_version,
+            )
+        )
+        existing_target = (
+            await self.db.execute(existing_target_stmt)
+        ).scalars().first()
+
+        if (
+            existing_target
+            and existing_target.charging_equipment_compliance_id
+            != reporting_record.charging_equipment_compliance_id
+        ):
+            existing_target.supply_from_date = reporting_record.supply_from_date
+            existing_target.supply_to_date = reporting_record.supply_to_date
+            existing_target.kwh_usage = (
+                reporting_record.kwh_usage
+                if reporting_record.kwh_usage is not None
+                else existing_target.kwh_usage
+            )
+            existing_target.compliance_notes = (
+                reporting_record.compliance_notes
+                if reporting_record.compliance_notes is not None
+                else existing_target.compliance_notes
+            )
+            existing_target.is_active = (
+                reporting_record.is_active or existing_target.is_active
+            )
+            existing_target.compliance_report_id = reporting_record.compliance_report_id
+            await self.db.delete(reporting_record)
+            return existing_target
+
+        reporting_record.charging_equipment_id = latest_equipment_id
+        reporting_record.charging_equipment_version = latest_equipment_version
+        return reporting_record
 
     async def _get_next_reporting_version(
-        self, reporting_record: ComplianceReportChargingEquipment
+        self,
+        reporting_record: ComplianceReportChargingEquipment,
+        charging_equipment_id: int | None = None,
+        charging_equipment_version: int | None = None,
     ) -> int:
+        version_equipment_id = charging_equipment_id or reporting_record.charging_equipment_id
+        version_equipment_version = (
+            charging_equipment_version or reporting_record.charging_equipment_version
+        )
         stmt = select(
             func.coalesce(func.max(ComplianceReportChargingEquipment.version), -1) + 1
         ).where(
@@ -1845,9 +1988,9 @@ class FinalSupplyEquipmentRepository:
                 ComplianceReportChargingEquipment.compliance_report_group_uuid
                 == reporting_record.compliance_report_group_uuid,
                 ComplianceReportChargingEquipment.charging_equipment_id
-                == reporting_record.charging_equipment_id,
+                == version_equipment_id,
                 ComplianceReportChargingEquipment.charging_equipment_version
-                == reporting_record.charging_equipment_version,
+                == version_equipment_version,
                 ComplianceReportChargingEquipment.organization_id
                 == reporting_record.organization_id,
             )
@@ -1860,9 +2003,15 @@ class FinalSupplyEquipmentRepository:
         data: dict,
         action_type: ActionTypeEnum,
     ) -> ComplianceReportChargingEquipment:
+        (
+            latest_equipment_id,
+            latest_equipment_version,
+        ) = await self._get_latest_equipment_identity_for_reporting_record(
+            existing_record
+        )
         revision = ComplianceReportChargingEquipment(
-            charging_equipment_id=existing_record.charging_equipment_id,
-            charging_equipment_version=existing_record.charging_equipment_version,
+            charging_equipment_id=latest_equipment_id,
+            charging_equipment_version=latest_equipment_version,
             compliance_report_id=data.get(
                 "compliance_report_id", existing_record.compliance_report_id
             ),
@@ -1877,7 +2026,11 @@ class FinalSupplyEquipmentRepository:
                 "compliance_notes", existing_record.compliance_notes
             ),
             is_active=data.get("is_active", existing_record.is_active),
-            version=await self._get_next_reporting_version(existing_record),
+            version=await self._get_next_reporting_version(
+                existing_record,
+                latest_equipment_id,
+                latest_equipment_version,
+            ),
             action_type=action_type,
         )
         self.db.add(revision)
@@ -2272,11 +2425,21 @@ class FinalSupplyEquipmentRepository:
         if not values:
             return
 
+        reporting_record = await self.get_reporting_record_by_id(
+            charging_equipment_compliance_id
+        )
+        if not reporting_record:
+            return
+
+        target_record = await self._resolve_reporting_record_to_latest_equipment(
+            reporting_record
+        )
+
         stmt = (
             update(ComplianceReportChargingEquipment)
             .where(
                 ComplianceReportChargingEquipment.charging_equipment_compliance_id
-                == charging_equipment_compliance_id
+                == target_record.charging_equipment_compliance_id
             )
             .values(**values)
         )

--- a/backend/lcfs/web/api/final_supply_equipment/services.py
+++ b/backend/lcfs/web/api/final_supply_equipment/services.py
@@ -539,6 +539,7 @@ class FinalSupplyEquipmentServices:
         pagination: PaginationRequestSchema,
         compliance_report_id: int = None,
         mode: str = "all",
+        source: str = "base_pref",
     ) -> dict:
         """
         Get paginated charging equipment with related charging site and FSE compliance reporting data
@@ -562,16 +563,23 @@ class FinalSupplyEquipmentServices:
         # query below (not a separate group-level aggregate, which could count
         # a different effective row set and diverge from the rows).
         total_kwh_usage = await self.repo.get_total_kwh_usage_for_report(
-            organization_id, report.compliance_report_id, mode
+            organization_id, report.compliance_report_id, mode, source=source
         )
 
         data, total = await self.repo.get_fse_reporting_list_paginated(
-            organization_id, pagination, report.compliance_report_id, mode
+            organization_id, pagination, report.compliance_report_id, mode, source=source
         )
 
         processed_data = []
         for item in data:
             row_dict = dict(item._mapping) if hasattr(item, "_mapping") else dict(item)
+            if source == "vw_fse_base":
+                row_dict["intended_uses"] = self._split_fse_base_text_list(
+                    row_dict.get("intended_uses")
+                )
+                row_dict["intended_users"] = self._split_fse_base_text_list(
+                    row_dict.get("intended_users")
+                )
             schemaData = FSEReportingSchema.model_validate(row_dict)
             processed_data.append(schemaData)
 
@@ -586,6 +594,14 @@ class FinalSupplyEquipmentServices:
             ),
             "hasChargingEquipment": has_equipment,
         }
+
+    @staticmethod
+    def _split_fse_base_text_list(value: str | list[str] | None) -> list[str]:
+        if isinstance(value, list):
+            return value
+        if not value:
+            return []
+        return [item.strip() for item in value.split(",") if item.strip()]
 
     @service_handler
     async def create_fse_reporting_batch(

--- a/backend/lcfs/web/api/final_supply_equipment/views.py
+++ b/backend/lcfs/web/api/final_supply_equipment/views.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Literal, List, Optional, Union
 
 import structlog
 from fastapi import (
@@ -461,6 +461,11 @@ async def get_fse_reporting_list(
         None, alias="complianceReportId", description="Compliance Report ID"
     ),
     mode: str = Query(None, alias="mode", description="Mode"),
+    source: Literal["base_pref", "vw_fse_base"] = Query(
+        "base_pref",
+        alias="source",
+        description="Reporting source: 'base_pref' uses preferred rows; 'vw_fse_base' uses the base view",
+    ),
     service: FinalSupplyEquipmentServices = Depends(),
 ) -> dict:
     """
@@ -472,7 +477,7 @@ async def get_fse_reporting_list(
         else request.user.organization_id
     )
     return await service.get_fse_reporting_list_paginated(
-        org_id, pagination, compliance_report_id, mode
+        org_id, pagination, compliance_report_id, mode, source
     )
 
 

--- a/frontend/src/hooks/__tests__/useFinalSupplyEquipment.test.jsx
+++ b/frontend/src/hooks/__tests__/useFinalSupplyEquipment.test.jsx
@@ -502,6 +502,34 @@ describe('useFinalSupplyEquipment', () => {
       )
     })
 
+    it('should include source in query params when provided', async () => {
+      const mockData = { fseReports: [], pagination: {} }
+      mockApiService.post.mockResolvedValue({ data: mockData })
+
+      const pagination = { page: 1, size: 10, filters: [], sort_orders: [] }
+      const { result } = renderHook(
+        () =>
+          useGetFSEReportingList(
+            123,
+            pagination,
+            {},
+            456,
+            'summary',
+            'vw_fse_base'
+          ),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(mockApiService.post).toHaveBeenCalledWith(
+        '/final-supply-equipments/reporting/list?organizationId=456&complianceReportId=123&mode=summary&source=vw_fse_base',
+        pagination
+      )
+    })
+
     it('should not fetch when organizationId is missing', () => {
       const pagination = { page: 1, size: 10, filters: [], sort_orders: [] }
       const { result } = renderHook(

--- a/frontend/src/hooks/useFinalSupplyEquipment.ts
+++ b/frontend/src/hooks/useFinalSupplyEquipment.ts
@@ -411,7 +411,8 @@ export const useGetFSEReportingList = (
   pagination = { page: 1, size: 10, filters: [], sort_orders: [] },
   options: QueryOptions<unknown> = {},
   organizationId: number | string | undefined | null = null,
-  mode = undefined
+  mode = undefined,
+  source = undefined
 ) => {
   const client = useApiService()
 
@@ -428,7 +429,8 @@ export const useGetFSEReportingList = (
       complianceReportId,
       organizationId,
       pagination,
-      mode
+      mode,
+      source
     ],
     queryFn: async () => {
       if (!organizationId) {
@@ -450,6 +452,9 @@ export const useGetFSEReportingList = (
       }
       if (mode) {
         queryParams.append('mode', mode)
+      }
+      if (source) {
+        queryParams.append('source', source)
       }
 
       const queryString = queryParams.toString()

--- a/frontend/src/views/FinalSupplyEquipments/FinalSupplyEquipmentSummary.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/FinalSupplyEquipmentSummary.jsx
@@ -34,7 +34,8 @@ export const FinalSupplyEquipmentSummary = ({
     paginationOptions,
     {},
     organizationId,
-    'summary'
+    'summary',
+    'vw_fse_base'
   )
   const { data: fseData, isLoading, isError, refetch } = queryData
 

--- a/frontend/src/views/FinalSupplyEquipments/__tests__/FinalSupplyEquipmentSummary.test.jsx
+++ b/frontend/src/views/FinalSupplyEquipments/__tests__/FinalSupplyEquipmentSummary.test.jsx
@@ -198,6 +198,17 @@ describe('FinalSupplyEquipmentSummary', () => {
         COMPLIANCE_REPORT_STATUSES.DRAFT,
         false
       )
+      expect(mockUseGetFSEReportingList).toHaveBeenCalledWith(
+        'test-123',
+        expect.objectContaining({
+          page: expect.any(Number),
+          size: expect.any(Number)
+        }),
+        {},
+        undefined,
+        'summary',
+        'vw_fse_base'
+      )
     })
 
     it('renders with different status', () => {


### PR DESCRIPTION
Fixes #4938

- Updated FSE Summary and compliance report FSE exports to use vw_fse_base, while keeping the editable FSE Reporting page on base_pref.
- Added a source query parameter through the FSE reporting list hook/API/service/repository so callers can choose base_pref or vw_fse_base.
- Changed vw_fse_base to expose snake_case/API-compatible columns and project directly from mv_fse_reporting_base_pref, including power_output and capacity_utilization_percent.
- Converted the selected-row FSE base relation from materialized mv_fse_reporting_base to normal view v_fse_reporting_base; mv_fse_reporting_base_pref remains materialized.
- Updated refresh logic/scripts so only mv_fse_reporting_base_pref is refreshed.
- Added/updated SQLAlchemy mappings and regression tests for the new source behavior and view dependencies.
- While updating the compliance_report_charging_equipment table ensure latest version of equipment is picked for update.