### PR TITLE
Fix: Standardize penalty dashboard value display - 4875, 4876

### DIFF
--- a/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/PenaltyComponents.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/PenaltyComponents.jsx
@@ -31,7 +31,7 @@ export const MetricCardsSection = ({ penaltyTotals, sparklineOptions }) => (
   <Stack spacing={1} sx={{ width: '100%' }}>
     <BCMetricCard
       title={i18n.t('org:penaltyLog.metrics.totalPenalties')}
-      value={currencyFormatter(penaltyTotals.total, false, 0)}
+      value={currencyFormatter(penaltyTotals.total)}
       subtitle={i18n.t('org:penaltyLog.metrics.yearToDate')}
       option={sparklineOptions.total}
       ariaLabel={i18n.t('org:penaltyLog.metrics.totalPenaltiesTrend')}
@@ -39,7 +39,7 @@ export const MetricCardsSection = ({ penaltyTotals, sparklineOptions }) => (
     />
     <BCMetricCard
       title={i18n.t('org:penaltyLog.metrics.totalAuto')}
-      value={currencyFormatter(penaltyTotals.totalAutomatic, false, 0)}
+      value={currencyFormatter(penaltyTotals.totalAutomatic)}
       subtitle={i18n.t('org:penaltyLog.metrics.totalSubtitle')}
       option={sparklineOptions.automatic}
       ariaLabel={i18n.t('org:penaltyLog.metrics.automaticPenaltiesTrend')}
@@ -47,7 +47,7 @@ export const MetricCardsSection = ({ penaltyTotals, sparklineOptions }) => (
     />
     <BCMetricCard
       title={i18n.t('org:penaltyLog.metrics.discretionary')}
-      value={currencyFormatter(penaltyTotals.discretionary, false, 0)}
+      value={currencyFormatter(penaltyTotals.discretionary)}
       subtitle={i18n.t('org:penaltyLog.metrics.discretionarySubtitle')}
       option={sparklineOptions.discretionary}
       ariaLabel={i18n.t('org:penaltyLog.metrics.discretionaryPenaltiesTrend')}
@@ -105,15 +105,9 @@ export const PenaltySummaryTable = ({
             {yearlyPenalties.map((row) => (
               <TableRow key={row.year} hover>
                 <TableCell>{row.year}</TableCell>
-                <TableCell>
-                  {currencyFormatter(row.autoRenewable, false, 0)}
-                </TableCell>
-                <TableCell>
-                  {currencyFormatter(row.autoLowCarbon, false, 0)}
-                </TableCell>
-                <TableCell>
-                  {currencyFormatter(row.totalAutomatic, false, 0)}
-                </TableCell>
+                <TableCell>{currencyFormatter(row.autoRenewable)}</TableCell>
+                <TableCell>{currencyFormatter(row.autoLowCarbon)}</TableCell>
+                <TableCell>{currencyFormatter(row.totalAutomatic)}</TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -129,7 +123,7 @@ export const PenaltySummaryTable = ({
                 {i18n.t('org:penaltyLog.metrics.autoRenewable')}
               </BCTypography>
               <BCTypography variant="subtitle1" fontWeight="medium">
-                {currencyFormatter(penaltyTotals.autoRenewable, false, 0)}
+                {currencyFormatter(penaltyTotals.autoRenewable)}
               </BCTypography>
             </Stack>
           </Grid>
@@ -139,7 +133,7 @@ export const PenaltySummaryTable = ({
                 {i18n.t('org:penaltyLog.metrics.autoLowCarbon')}
               </BCTypography>
               <BCTypography variant="subtitle1" fontWeight="medium">
-                {currencyFormatter(penaltyTotals.autoLowCarbon, false, 0)}
+                {currencyFormatter(penaltyTotals.autoLowCarbon)}
               </BCTypography>
             </Stack>
           </Grid>
@@ -151,9 +145,7 @@ export const PenaltySummaryTable = ({
                 {i18n.t('org:penaltyLog.metrics.discretionary')}
               </BCTypography>
               <BCTypography variant="subtitle1" fontWeight="medium">
-                {currencyFormatter(penaltyTotals.discretionary, {
-                  maximumFractionDigits: 0
-                })}
+                {currencyFormatter(penaltyTotals.discretionary)}
               </BCTypography>
             </Stack>
           </Grid>
@@ -163,9 +155,7 @@ export const PenaltySummaryTable = ({
                 {i18n.t('org:penaltyLog.metrics.totalAuto')}
               </BCTypography>
               <BCTypography variant="subtitle1" fontWeight="medium">
-                {currencyFormatter(penaltyTotals.totalAutomatic, {
-                  maximumFractionDigits: 0
-                })}
+                {currencyFormatter(penaltyTotals.totalAutomatic)}
               </BCTypography>
             </Stack>
           </Grid>

--- a/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/__tests__/PenaltyFormatting.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/__tests__/PenaltyFormatting.test.jsx
@@ -112,7 +112,7 @@ describe('organization dashboard penalty formatting', () => {
     )
   })
 
-  it('formats monetary chart labels and tooltips with two decimal places', () => {
+  it('formats monetary chart labels by magnitude and keeps exact tooltips', () => {
     const stackedBarOption = useStackedBarOption([], theme)
     const penaltyMixOption = usePenaltyMixOption(
       { autoRenewable: 123.45, autoLowCarbon: 200, discretionary: 50.1 },
@@ -120,7 +120,12 @@ describe('organization dashboard penalty formatting', () => {
     )
     const sparklineOption = useSparklineOption([], [], theme)
 
-    expect(stackedBarOption.yAxis.axisLabel.formatter(1000)).toBe('$1,000.00')
+    const formatAxisLabel = stackedBarOption.yAxis.axisLabel.formatter
+
+    expect(formatAxisLabel(999.5)).toBe('$999.50')
+    expect(formatAxisLabel(1000)).toBe('$1.00K')
+    expect(formatAxisLabel(24500)).toBe('$24.50K')
+    expect(formatAxisLabel(24000000)).toBe('$24.00M')
     expect(
       stackedBarOption.tooltip.formatter([
         {

--- a/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/__tests__/PenaltyFormatting.test.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/__tests__/PenaltyFormatting.test.jsx
@@ -1,0 +1,154 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MetricCardsSection, PenaltySummaryTable } from '../PenaltyComponents'
+import { penaltyLogColumnDefs, penaltyLogEditorColDefs } from '../_schema'
+import {
+  usePenaltyMixOption,
+  useSparklineOption,
+  useStackedBarOption
+} from '../../_charts'
+
+vi.mock('@/components/charts/BCMetricCard', () => ({
+  BCMetricCard: ({ value }) => <div>{value}</div>
+}))
+
+vi.mock('@/components/charts/BCResponsiveEchart', () => ({
+  BCResponsiveEChart: () => <div data-testid="penalty-chart" />
+}))
+
+vi.mock('@/components/BCDataGrid/columns', () => ({
+  actions: () => ({}),
+  validation: {}
+}))
+
+vi.mock('@/components/BCDataGrid/components', () => ({
+  AutocompleteCellEditor: () => null,
+  BCSelectFloatingFilter: () => null,
+  RequiredHeader: () => null
+}))
+
+vi.mock('@/utils/grid/eventHandlers', () => ({
+  suppressKeyboardEvent: () => false
+}))
+
+vi.mock('@/i18n', () => ({
+  default: { t: (key) => key }
+}))
+
+const theme = {
+  palette: {
+    primary: { main: '#123456' },
+    info: { main: '#234567' },
+    warning: { main: '#345678' },
+    background: { paper: '#ffffff' }
+  }
+}
+
+describe('organization dashboard penalty formatting', () => {
+  it('formats every metric card value with two decimal places', () => {
+    render(
+      <MetricCardsSection
+        penaltyTotals={{
+          total: 1234,
+          totalAutomatic: 1000.5,
+          discretionary: 233.56
+        }}
+        sparklineOptions={{ total: {}, automatic: {}, discretionary: {} }}
+      />
+    )
+
+    expect(screen.getByText('$1,234.00')).toBeInTheDocument()
+    expect(screen.getByText('$1,000.50')).toBeInTheDocument()
+    expect(screen.getByText('$233.56')).toBeInTheDocument()
+  })
+
+  it('preserves cents and adds trailing zeros throughout the summary', () => {
+    render(
+      <PenaltySummaryTable
+        yearlyPenalties={[
+          {
+            year: '2025',
+            autoRenewable: 123.45,
+            autoLowCarbon: 200,
+            totalAutomatic: 323.45
+          }
+        ]}
+        penaltyTotals={{
+          autoRenewable: 123.45,
+          autoLowCarbon: 200,
+          discretionary: 50.1,
+          totalAutomatic: 323.45
+        }}
+        penaltyMixOption={{}}
+      />
+    )
+
+    expect(screen.getAllByText('$123.45')).toHaveLength(2)
+    expect(screen.getAllByText('$200.00')).toHaveLength(2)
+    expect(screen.getAllByText('$323.45')).toHaveLength(2)
+    expect(screen.getByText('$50.10')).toBeInTheDocument()
+  })
+
+  it('formats history and editor penalty amounts with two decimal places', () => {
+    const historyAmountColumn = penaltyLogColumnDefs.find(
+      ({ field }) => field === 'penaltyAmount'
+    )
+    const editorAmountColumn = penaltyLogEditorColDefs(
+      new Map(),
+      [],
+      (_key, options) => options?.defaultValue ?? _key
+    ).find(({ field }) => field === 'penaltyAmount')
+
+    expect(historyAmountColumn.valueFormatter({ value: 1250 })).toBe(
+      '$1,250.00'
+    )
+    expect(historyAmountColumn.valueFormatter({ value: 1250.75 })).toBe(
+      '$1,250.75'
+    )
+    expect(editorAmountColumn.valueFormatter({ value: 1250 })).toBe('$1,250.00')
+    expect(editorAmountColumn.valueFormatter({ value: 1250.75 })).toBe(
+      '$1,250.75'
+    )
+  })
+
+  it('formats monetary chart labels and tooltips with two decimal places', () => {
+    const stackedBarOption = useStackedBarOption([], theme)
+    const penaltyMixOption = usePenaltyMixOption(
+      { autoRenewable: 123.45, autoLowCarbon: 200, discretionary: 50.1 },
+      theme
+    )
+    const sparklineOption = useSparklineOption([], [], theme)
+
+    expect(stackedBarOption.yAxis.axisLabel.formatter(1000)).toBe('$1,000.00')
+    expect(
+      stackedBarOption.tooltip.formatter([
+        {
+          axisValue: '2025',
+          marker: '',
+          seriesName: 'Auto renewable',
+          value: 123.45
+        },
+        {
+          axisValue: '2025',
+          marker: '',
+          seriesName: 'Auto low carbon',
+          value: 200
+        }
+      ])
+    ).toBe('2025<br/>Auto renewable: $123.45<br/>Auto low carbon: $200.00')
+    expect(
+      penaltyMixOption.tooltip.formatter({
+        marker: '',
+        name: 'Auto renewable',
+        value: 123.45,
+        percent: 33.3
+      })
+    ).toBe('Auto renewable: $123.45 (33.3%)')
+    expect(
+      sparklineOption.tooltip.formatter([
+        { marker: '', axisValue: '2025', data: 50.1 }
+      ])
+    ).toBe('2025: $50.10')
+  })
+})

--- a/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/_schema.tsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/PenaltyLog/_schema.tsx
@@ -100,9 +100,7 @@ export const penaltyLogColumnDefs = [
     headerName: i18n.t('org:penaltyLog.columns.penaltyAmount'),
     field: 'penaltyAmount',
     valueFormatter: ({ value }) =>
-      value === null || value === undefined
-        ? ''
-        : currencyFormatter(value, false, 0),
+      value === null || value === undefined ? '' : currencyFormatter(value),
     minWidth: 260
   }
 ]
@@ -182,13 +180,7 @@ export const penaltyLogEditorColDefs = (
     }),
     cellEditor: 'agNumberCellEditor',
     valueFormatter: ({ value }) =>
-      value === null || value === undefined
-        ? ''
-        : Number(value).toLocaleString('en-CA', {
-            style: 'currency',
-            currency: 'CAD',
-            maximumFractionDigits: 0
-          }),
+      value === null || value === undefined ? '' : currencyFormatter(value),
     minWidth: 240
   },
   {

--- a/frontend/src/views/Organizations/OrganizationView/components/_charts.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/_charts.jsx
@@ -1,5 +1,13 @@
 import { currencyFormatter } from '@/utils/formatters'
 
+const compactCurrencyFormatter = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  notation: 'compact',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
+
 const formatAxisTooltip = (params) => {
   if (!params?.length) return ''
 
@@ -28,7 +36,7 @@ export const useStackedBarOption = (data, theme) => {
     yAxis: {
       type: 'value',
       axisLabel: {
-        formatter: (value) => currencyFormatter(value)
+        formatter: (value) => compactCurrencyFormatter.format(value)
       }
     },
     series: [

--- a/frontend/src/views/Organizations/OrganizationView/components/_charts.jsx
+++ b/frontend/src/views/Organizations/OrganizationView/components/_charts.jsx
@@ -1,19 +1,34 @@
 import { currencyFormatter } from '@/utils/formatters'
 
+const formatAxisTooltip = (params) => {
+  if (!params?.length) return ''
+
+  const year = params[0].axisValueLabel ?? params[0].axisValue ?? ''
+  const values = params.map(
+    ({ marker = '', seriesName, value }) =>
+      `${marker}${seriesName}: ${currencyFormatter(value)}`
+  )
+
+  return [year, ...values].join('<br/>')
+}
+
+const formatItemTooltip = ({ marker = '', name, value, percent }) =>
+  `${marker}${name}: ${currencyFormatter(value)} (${percent}%)`
+
 export const useStackedBarOption = (data, theme) => {
   const primary = theme.palette.primary.main
   const info = theme.palette.info.main
 
   return {
     color: [primary, info],
-    tooltip: { trigger: 'axis' },
+    tooltip: { trigger: 'axis', formatter: formatAxisTooltip },
     legend: { top: 0 },
     grid: { left: 16, right: 24, bottom: 8, top: 40, containLabel: true },
     xAxis: { type: 'category', data: data.map((item) => item.year) },
     yAxis: {
       type: 'value',
       axisLabel: {
-        formatter: (val) => (val >= 1000 ? `${val / 1000}k` : val)
+        formatter: (value) => currencyFormatter(value)
       }
     },
     series: [
@@ -40,7 +55,7 @@ export const usePenaltyMixOption = (totals, theme) => {
 
   return {
     color: [palette.primary.main, palette.info.main, palette.warning.main],
-    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    tooltip: { trigger: 'item', formatter: formatItemTooltip },
     legend: { orient: 'horizontal', bottom: 0 },
     series: [
       {


### PR DESCRIPTION
This PR standardizes penalty value formatting on the organization dashboard.

- Format values using K, M, or full amounts
- Enforce two decimal places for penalties
- Preserve cent values for renewable penalties

Closes #4875
Closes #4876