### PR TITLE
Feat: Designated action activity panel - 4898

### DIFF
--- a/backend/lcfs/tests/initiative_agreement/test_designated_action_workflow.py
+++ b/backend/lcfs/tests/initiative_agreement/test_designated_action_workflow.py
@@ -443,3 +443,70 @@ async def test_the_history_endpoint_returns_the_trail_newest_first(
     assert response.status_code == status.HTTP_200_OK
     events = [entry["event"] for entry in response.json()]
     assert events == [EVENT_CREDITS_RECOMMENDED, EVENT_EVIDENCE_REVIEWED]
+
+
+@pytest.mark.anyio
+async def test_the_history_names_the_analyst_rather_than_an_id(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Assignment events store ids; a reader needs names."""
+    from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+        _seed_ia_analyst,
+    )
+
+    action = await _seed_da(dbsession, "IA-26WFI")
+    first = await _seed_ia_analyst(dbsession, "hfong", "Harriet", "Fong")
+    second = await _seed_ia_analyst(dbsession, "jwills", "Jo", "Willems")
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    assign_url = fastapi_app.url_path_for(
+        "assign_designated_action_analyst",
+        designated_action_id=action.designated_action_id,
+    )
+    await client.put(assign_url, json={"assignedAnalystId": first.user_profile_id})
+    await client.put(assign_url, json={"assignedAnalystId": second.user_profile_id})
+
+    response = await client.get(
+        fastapi_app.url_path_for(
+            "get_designated_action_history",
+            designated_action_id=action.designated_action_id,
+        )
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    reassignment = response.json()[0]
+    assert reassignment["snapshot"]["from_analyst"] == "Harriet Fong"
+    assert reassignment["snapshot"]["to_analyst"] == "Jo Willems"
+    # The stable ids are still there underneath.
+    assert reassignment["snapshot"]["from_analyst_id"] == first.user_profile_id
+
+
+@pytest.mark.anyio
+async def test_an_unassignment_names_only_who_was_removed(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    from lcfs.tests.initiative_agreement.test_designated_actions_api import (
+        _seed_ia_analyst,
+    )
+
+    action = await _seed_da(dbsession, "IA-26WFJ")
+    analyst = await _seed_ia_analyst(dbsession, "kpatel", "Kiran", "Patel")
+    set_mock_user(fastapi_app, IDIR_IA_MANAGER)
+
+    assign_url = fastapi_app.url_path_for(
+        "assign_designated_action_analyst",
+        designated_action_id=action.designated_action_id,
+    )
+    await client.put(assign_url, json={"assignedAnalystId": analyst.user_profile_id})
+    await client.put(assign_url, json={"assignedAnalystId": None})
+
+    response = await client.get(
+        fastapi_app.url_path_for(
+            "get_designated_action_history",
+            designated_action_id=action.designated_action_id,
+        )
+    )
+
+    unassignment = response.json()[0]
+    assert unassignment["snapshot"]["from_analyst"] == "Kiran Patel"
+    assert unassignment["snapshot"]["to_analyst"] is None

--- a/backend/lcfs/web/api/initiative_agreement/repo.py
+++ b/backend/lcfs/web/api/initiative_agreement/repo.py
@@ -761,6 +761,25 @@ class InitiativeAgreementRepository:
         return list(result.scalars().all())
 
     @repo_handler
+    async def get_user_display_names(self, user_profile_ids) -> Dict[int, str]:
+        """Names for a set of users, for rendering stored ids."""
+        ids = [i for i in set(user_profile_ids) if i is not None]
+        if not ids:
+            return {}
+        result = await self.db.execute(
+            select(
+                UserProfile.user_profile_id,
+                UserProfile.first_name,
+                UserProfile.last_name,
+            ).where(UserProfile.user_profile_id.in_(ids))
+        )
+        names = {}
+        for user_profile_id, first_name, last_name in result.all():
+            full = " ".join(p for p in (first_name, last_name) if p).strip()
+            names[user_profile_id] = full or None
+        return names
+
+    @repo_handler
     async def add_designated_action_history(
         self, history: DesignatedActionHistory
     ) -> DesignatedActionHistory:

--- a/backend/lcfs/web/api/initiative_agreement/schema.py
+++ b/backend/lcfs/web/api/initiative_agreement/schema.py
@@ -232,6 +232,9 @@ class DesignatedActionHistorySchema(BaseSchema):
     display_name: Optional[str] = None
     create_date: Optional[datetime] = None
     status: Optional[DesignatedActionStatusSchema] = None
+    # Free-form event payload. Its keys are data rather than schema fields,
+    # so they stay exactly as stored — snake_case — while the surrounding
+    # response is camelCase. Readers of the snapshot must expect that.
     snapshot: Optional[dict] = None
 
     class Config:

--- a/backend/lcfs/web/api/initiative_agreement/services.py
+++ b/backend/lcfs/web/api/initiative_agreement/services.py
@@ -488,10 +488,32 @@ class InitiativeAgreementServices:
     async def get_designated_action_history(
         self, designated_action_id: int
     ) -> List[DesignatedActionHistorySchema]:
-        """The audit trail behind the action, newest first."""
+        """The audit trail behind the action, newest first.
+
+        Assignment events store analyst ids, which say nothing to a reader,
+        so names are resolved here for display. The stored snapshot keeps
+        the ids — they are the stable reference.
+        """
         await self._get_action_or_404(designated_action_id)
         history = await self.repo.get_designated_action_history(designated_action_id)
-        return [DesignatedActionHistorySchema.model_validate(h) for h in history]
+
+        referenced_ids = []
+        for entry in history:
+            snapshot = entry.snapshot or {}
+            referenced_ids.append(snapshot.get("from_analyst_id"))
+            referenced_ids.append(snapshot.get("to_analyst_id"))
+        names = await self.repo.get_user_display_names(referenced_ids)
+
+        rows = []
+        for entry in history:
+            row = DesignatedActionHistorySchema.model_validate(entry)
+            snapshot = dict(row.snapshot or {})
+            if "from_analyst_id" in snapshot or "to_analyst_id" in snapshot:
+                snapshot["from_analyst"] = names.get(snapshot.get("from_analyst_id"))
+                snapshot["to_analyst"] = names.get(snapshot.get("to_analyst_id"))
+                row = row.model_copy(update={"snapshot": snapshot})
+            rows.append(row)
+        return rows
 
     @service_handler
     async def get_evidence_requirements(

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -145,5 +145,30 @@
       "return": "Return for further work",
       "reject": "Reject this designated action"
     }
+  },
+  "history": {
+    "title": "Activity",
+    "loading": "Loading activity...",
+    "empty": "Nothing has happened on this designated action yet.",
+    "notReviewed": "Not reviewed",
+    "nobody": "nobody",
+    "assignedTo": "Assigned to {{name}}",
+    "reassigned": "Reassigned from {{from}} to {{to}}",
+    "unassignedFrom": "Unassigned from {{name}}",
+    "recommendedCredits": "Recommended {{count}} compliance units",
+    "movedTo": "Moved to {{status}}",
+    "evidenceSummary": "Evidence at this point: {{count}} requirements, {{satisfactory}} satisfactory, {{outstanding}} outstanding",
+    "events": {
+      "statusChange": "Status changed",
+      "analystAssigned": "Analyst assigned",
+      "analystReassigned": "Analyst reassigned",
+      "analystUnassigned": "Analyst unassigned",
+      "creditsRecommended": "Recommended to manager",
+      "informationRequested": "Additional information requested",
+      "evidenceReviewed": "Evidence accepted",
+      "changeOrder": "Change order",
+      "creditsIssued": "Compliance units issued",
+      "unknown": "Activity"
+    }
   }
 }

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -37,6 +37,7 @@ import { InitiativeAgreementTabs } from './components/InitiativeAgreementTabs'
 import { DocumentTree } from './components/DocumentTree'
 import { EvidenceOfCompletion } from './components/EvidenceOfCompletion'
 import { DesignatedActionWorkflow } from './components/DesignatedActionWorkflow'
+import { DesignatedActionHistoryPanel } from './components/DesignatedActionHistoryPanel'
 
 // The shared document machinery keys on this string for designated actions.
 const PARENT_TYPE = 'designatedAction'
@@ -335,6 +336,11 @@ const DesignatedActionDetailBase = () => {
         parentType={PARENT_TYPE}
         parentID={designatedActionId}
       />
+
+      {/* The audit trail behind every workflow step (#4898). */}
+      <Role roles={[roles.ia_analyst, roles.ia_manager, roles.director]}>
+        <DesignatedActionHistoryPanel designatedActionId={designatedActionId} />
+      </Role>
 
       {/* Standard dual-mode thread (#4900); the page is IDIR-only until
           the BCeID story, matching the API. */}

--- a/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/DesignatedActionDetail.test.jsx
@@ -63,6 +63,12 @@ vi.mock('../components/EvidenceOfCompletion', () => ({
   EvidenceOfCompletion: () => <div data-test="evidence-of-completion" />
 }))
 
+vi.mock('../components/DesignatedActionHistoryPanel', () => ({
+  DesignatedActionHistoryPanel: () => (
+    <div data-test="designated-action-history" />
+  )
+}))
+
 const workflowProps = vi.fn()
 vi.mock('../components/DesignatedActionWorkflow', () => ({
   DesignatedActionWorkflow: (props) => {
@@ -179,6 +185,11 @@ describe('DesignatedActionDetail', () => {
         creditAllocation: 1850
       })
     )
+  })
+
+  it('renders the audit trail panel', () => {
+    render(<DesignatedActionDetail />, { wrapper })
+    expect(screen.getByTestId('designated-action-history')).toBeInTheDocument()
   })
 
   it('renders the comments thread', () => {

--- a/frontend/src/views/InitiativeAgreements/components/DesignatedActionHistoryPanel.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DesignatedActionHistoryPanel.jsx
@@ -1,0 +1,264 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, Collapse, IconButton, Paper } from '@mui/material'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import Loading from '@/components/Loading'
+import { useDesignatedActionHistory } from '@/hooks/useInitiativeAgreements'
+import { timezoneFormatter } from '@/utils/formatters'
+
+// The audit trail behind a designated action (#4898). Every workflow step
+// is recorded; this is where a reviewer reads back what happened and, for
+// the rounds that captured it, what the evidence looked like at the time.
+
+// Snapshot keys are stored as written — snake_case — while the rest of the
+// response is camelCase. See DesignatedActionHistorySchema.
+const OUTCOME_SATISFACTORY = 'Satisfactory'
+
+const EVENT_LABELS = {
+  STATUS_CHANGE: 'statusChange',
+  ANALYST_ASSIGNED: 'analystAssigned',
+  ANALYST_REASSIGNED: 'analystReassigned',
+  ANALYST_UNASSIGNED: 'analystUnassigned',
+  CREDITS_RECOMMENDED: 'creditsRecommended',
+  INFORMATION_REQUESTED: 'informationRequested',
+  EVIDENCE_REVIEWED: 'evidenceReviewed',
+  CHANGE_ORDER: 'changeOrder',
+  CREDITS_ISSUED: 'creditsIssued'
+}
+
+const railColour = (event) => {
+  if (event === 'INFORMATION_REQUESTED') return 'warning.main'
+  if (event === 'EVIDENCE_REVIEWED') return 'success.main'
+  if (event === 'CREDITS_ISSUED') return 'success.main'
+  return 'primary.main'
+}
+
+const EvidenceDetail = ({ requirements }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
+  const [open, setOpen] = useState(false)
+
+  const satisfactory = requirements.filter(
+    (r) => r.review_outcome === OUTCOME_SATISFACTORY
+  ).length
+  const outstanding = requirements.length - satisfactory
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <BCTypography
+        component="button"
+        variant="body4"
+        color="link"
+        data-test="history-evidence-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        sx={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 0,
+          textDecoration: 'underline'
+        }}
+      >
+        {t('initiativeAgreement:history.evidenceSummary', {
+          count: requirements.length,
+          satisfactory,
+          outstanding
+        })}
+      </BCTypography>
+      <Collapse in={open}>
+        <Box
+          data-test="history-evidence-detail"
+          sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}
+        >
+          {requirements.map((requirement) => (
+            <Box
+              key={requirement.evidence_requirement_id}
+              sx={{
+                borderLeft: 3,
+                borderColor:
+                  requirement.review_outcome === OUTCOME_SATISFACTORY
+                    ? 'success.main'
+                    : 'warning.main',
+                pl: 1.5
+              }}
+            >
+              <BCTypography variant="body4" sx={{ fontWeight: 600 }}>
+                {requirement.description}
+              </BCTypography>
+              <BCTypography
+                variant="body4"
+                component="p"
+                color="text.secondary"
+              >
+                {requirement.review_outcome ||
+                  t('initiativeAgreement:history.notReviewed')}
+              </BCTypography>
+              {requirement.analyst_review && (
+                <BCTypography variant="body4" component="p">
+                  {requirement.analyst_review}
+                </BCTypography>
+              )}
+            </Box>
+          ))}
+        </Box>
+      </Collapse>
+    </Box>
+  )
+}
+
+const EntryDetail = ({ entry }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
+  const snapshot = entry.snapshot || {}
+  const lines = []
+
+  if (entry.event === 'ANALYST_ASSIGNED' && snapshot.to_analyst) {
+    lines.push(
+      t('initiativeAgreement:history.assignedTo', { name: snapshot.to_analyst })
+    )
+  }
+  if (entry.event === 'ANALYST_REASSIGNED') {
+    lines.push(
+      t('initiativeAgreement:history.reassigned', {
+        from: snapshot.from_analyst || t('initiativeAgreement:history.nobody'),
+        to: snapshot.to_analyst || t('initiativeAgreement:history.nobody')
+      })
+    )
+  }
+  if (entry.event === 'ANALYST_UNASSIGNED' && snapshot.from_analyst) {
+    lines.push(
+      t('initiativeAgreement:history.unassignedFrom', {
+        name: snapshot.from_analyst
+      })
+    )
+  }
+  if (snapshot.recommended_credits !== undefined) {
+    lines.push(
+      t('initiativeAgreement:history.recommendedCredits', {
+        count: Number(snapshot.recommended_credits).toLocaleString()
+      })
+    )
+  }
+  if (entry.status?.status && entry.event === 'STATUS_CHANGE') {
+    lines.push(
+      t('initiativeAgreement:history.movedTo', { status: entry.status.status })
+    )
+  }
+
+  return (
+    <>
+      {lines.map((line) => (
+        <BCTypography key={line} variant="body4" component="p">
+          {line}
+        </BCTypography>
+      ))}
+      {snapshot.comment && (
+        <BCTypography
+          variant="body4"
+          component="p"
+          data-test="history-comment"
+          sx={{ fontStyle: 'italic', mt: 0.5 }}
+        >
+          &ldquo;{snapshot.comment}&rdquo;
+        </BCTypography>
+      )}
+      {Array.isArray(snapshot.evidence_requirements) &&
+        snapshot.evidence_requirements.length > 0 && (
+          <EvidenceDetail requirements={snapshot.evidence_requirements} />
+        )}
+    </>
+  )
+}
+
+export const DesignatedActionHistoryPanel = ({ designatedActionId }) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const [expanded, setExpanded] = useState(true)
+  const { data: entries = [], isLoading } =
+    useDesignatedActionHistory(designatedActionId)
+
+  return (
+    <BCBox mt={3} data-test="designated-action-history">
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: 1,
+          borderColor: 'divider',
+          pb: 1,
+          mb: 2
+        }}
+      >
+        <BCTypography variant="h6" color="primary">
+          {t('initiativeAgreement:history.title')}
+        </BCTypography>
+        <IconButton
+          size="small"
+          data-test="history-toggle"
+          aria-label={t('initiativeAgreement:history.title')}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+
+      <Collapse in={expanded}>
+        {isLoading ? (
+          <Loading message={t('initiativeAgreement:history.loading')} />
+        ) : entries.length === 0 ? (
+          <BCTypography variant="body4" color="text.secondary">
+            {t('initiativeAgreement:history.empty')}
+          </BCTypography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            {entries.map((entry) => (
+              <Paper
+                key={entry.designatedActionHistoryId}
+                variant="outlined"
+                data-test={`history-entry-${entry.designatedActionHistoryId}`}
+                sx={{
+                  p: 2,
+                  borderLeft: 4,
+                  borderLeftColor: railColour(entry.event)
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 2,
+                    flexWrap: 'wrap',
+                    alignItems: 'baseline'
+                  }}
+                >
+                  <BCTypography variant="body4" sx={{ fontWeight: 700 }}>
+                    {t(
+                      `initiativeAgreement:history.events.${
+                        EVENT_LABELS[entry.event] || 'unknown'
+                      }`
+                    )}
+                  </BCTypography>
+                  <BCTypography variant="body4" color="text.secondary">
+                    {[
+                      entry.displayName,
+                      timezoneFormatter({ value: entry.createDate })
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </BCTypography>
+                </Box>
+                <EntryDetail entry={entry} />
+              </Paper>
+            ))}
+          </Box>
+        )}
+      </Collapse>
+    </BCBox>
+  )
+}
+
+export default DesignatedActionHistoryPanel

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionHistoryPanel.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DesignatedActionHistoryPanel.test.jsx
@@ -1,0 +1,210 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DesignatedActionHistoryPanel } from '../DesignatedActionHistoryPanel'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Render the key plus its interpolations so assertions can see values.
+    t: (key, vars) => (vars ? `${key} ${JSON.stringify(vars)}` : key)
+  })
+}))
+
+vi.mock('@/utils/formatters', () => ({
+  timezoneFormatter: ({ value }) => (value ? '2026-08-26 10:14' : '')
+}))
+
+const mockHistory = vi.fn()
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useDesignatedActionHistory: () => mockHistory()
+}))
+
+const entry = (overrides = {}) => ({
+  designatedActionHistoryId: 1,
+  event: 'STATUS_CHANGE',
+  displayName: 'Alex Zorkin',
+  createDate: '2026-08-26T10:14:00Z',
+  status: { designatedActionStatusId: 7, status: 'Approved' },
+  snapshot: null,
+  ...overrides
+})
+
+describe('DesignatedActionHistoryPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHistory.mockReturnValue({ data: [entry()], isLoading: false })
+  })
+
+  it('shows who did what and when', () => {
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    const row = screen.getByTestId('history-entry-1')
+    expect(row).toHaveTextContent('Alex Zorkin')
+    expect(row).toHaveTextContent('2026-08-26 10:14')
+    expect(row).toHaveTextContent('history.events.statusChange')
+    expect(row).toHaveTextContent('Approved')
+  })
+
+  it('names the analyst on an assignment rather than showing an id', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 2,
+          event: 'ANALYST_REASSIGNED',
+          status: null,
+          snapshot: {
+            from_analyst_id: 5,
+            to_analyst_id: 7,
+            from_analyst: 'Harriet Fong',
+            to_analyst: 'Jo Willems'
+          }
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    const row = screen.getByTestId('history-entry-2')
+    expect(row).toHaveTextContent('Harriet Fong')
+    expect(row).toHaveTextContent('Jo Willems')
+    expect(row).not.toHaveTextContent('from_analyst_id')
+  })
+
+  it('shows the reason given with a request for information', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 3,
+          event: 'INFORMATION_REQUESTED',
+          status: null,
+          snapshot: { comment: 'Send the signed permit for stage two.' }
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    expect(screen.getByTestId('history-comment')).toHaveTextContent(
+      'Send the signed permit for stage two.'
+    )
+  })
+
+  it('shows the recommended amount', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 4,
+          event: 'CREDITS_RECOMMENDED',
+          status: null,
+          snapshot: { recommended_credits: 1200 }
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    expect(screen.getByTestId('history-entry-4')).toHaveTextContent('1,200')
+  })
+
+  it('shows a recommendation of nought rather than treating it as absent', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 5,
+          event: 'CREDITS_RECOMMENDED',
+          status: null,
+          snapshot: { recommended_credits: 0 }
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    expect(screen.getByTestId('history-entry-5')).toHaveTextContent(
+      'history.recommendedCredits'
+    )
+  })
+
+  it('keeps the captured evidence behind a toggle', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 6,
+          event: 'INFORMATION_REQUESTED',
+          status: null,
+          snapshot: {
+            comment: 'One outstanding.',
+            evidence_requirements: [
+              {
+                evidence_requirement_id: 1,
+                description: 'List of major permits',
+                review_outcome: 'Satisfactory',
+                analyst_review: 'Permits verified.'
+              },
+              {
+                evidence_requirement_id: 2,
+                description: 'Risk register',
+                review_outcome: 'Information requested',
+                analyst_review: null
+              }
+            ]
+          }
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    // Summary counts are visible without expanding.
+    const toggle = screen.getByTestId('history-evidence-toggle')
+    expect(toggle).toHaveTextContent('"satisfactory":1')
+    expect(toggle).toHaveTextContent('"outstanding":1')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const detail = screen.getByTestId('history-evidence-detail')
+    expect(detail).toHaveTextContent('List of major permits')
+    expect(detail).toHaveTextContent('Permits verified.')
+    expect(detail).toHaveTextContent('Risk register')
+  })
+
+  it('renders an entry whose event it does not recognise', () => {
+    mockHistory.mockReturnValue({
+      data: [
+        entry({
+          designatedActionHistoryId: 7,
+          event: 'SOMETHING_NEW',
+          status: null
+        })
+      ],
+      isLoading: false
+    })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    expect(screen.getByTestId('history-entry-7')).toHaveTextContent(
+      'history.events.unknown'
+    )
+  })
+
+  it('shows an empty state before anything has happened', () => {
+    mockHistory.mockReturnValue({ data: [], isLoading: false })
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    expect(
+      screen.getByText('initiativeAgreement:history.empty')
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('history-entry-1')).not.toBeInTheDocument()
+  })
+
+  it('collapses the panel', () => {
+    render(<DesignatedActionHistoryPanel designatedActionId="1" />, { wrapper })
+
+    const toggle = screen.getByTestId('history-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  })
+})


### PR DESCRIPTION
## Summary

The activity panel on the designated action page. Every workflow step was already recorded and readable through the API, but nothing displayed it — the audit history acceptance criterion on #4898 was satisfied in the data and missing from the screen.

The panel shows what happened, who did it, and when, newest first, with a coloured edge distinguishing information requests and acceptances from ordinary status changes.

### Notes for a reviewer

**Assignment events store analyst ids**, which say nothing to a reader. The history response resolves them to names in a single lookup. The stored snapshot keeps the ids — they are the stable reference — and the names are added for display only, so nothing rewrites history.

**The captured evidence is the point of this panel.** Where a round snapshotted the review, the entry summarises it as counts and expands to show each requirement as it stood at that moment. That is the payoff for storing the whole review rather than a bare event: an analyst can read back what an earlier round concluded, including findings that later rounds have since overwritten on the requirement itself.

**Snapshot keys stay snake_case** while the response around them is camelCase, because the snapshot is a free-form payload rather than schema fields. That will surprise the next reader, so it is now stated on the schema and in the component.

**Zero is rendered, not swallowed.** A recommendation of nought credits displays as a recommendation, consistent with how the column is defined. An unrecognised event renders with a neutral label rather than breaking the panel, so adding a workflow event later cannot produce a blank row.

### Testing

2 new backend tests (a reassignment naming both analysts, an unassignment naming only who was removed) and 9 frontend tests on the panel — actor and timestamp, analyst names rather than ids, the reason on an information request, the recommended amount including zero, the evidence toggle and its expanded detail, an unknown event, the empty state, and collapsing. 113 backend and 90 frontend tests pass across the module; type-check unchanged.

Refs #4898
