### PR TITLE
Fix: Initiative Agreements accessibility pass

### DIFF
--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -109,7 +109,9 @@
     "movedFolder": "Moved folder",
     "undo": "Undo",
     "draggingFiles": "{{count}} file(s)",
-    "draggingFolder": "Folder"
+    "draggingFolder": "Folder",
+    "folderDragHandle": "Move folder {{name}}",
+    "fileDragHandle": "Move file {{name}}"
   },
   "evidence": {
     "sectionTitle": "Evidence of completion of designated action:",
@@ -125,7 +127,9 @@
     "newRequirementTitle": "New evidence requirement",
     "requirementNamePlaceholder": "Describe what the proponent must provide",
     "reviewedBy": "Reviewed by {{name}}",
-    "pending": "Not yet reviewed"
+    "pending": "Not yet reviewed",
+    "evidenceFor": "Evidence of completion for {{name}}",
+    "notesFor": "Notes for {{name}}"
   },
   "workflow": {
     "accept": "Accept",

--- a/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/DesignatedActionDetail.jsx
@@ -194,7 +194,10 @@ const DesignatedActionDetailBase = () => {
                       px: 1.5,
                       py: 0.25,
                       borderRadius: 4,
-                      bgcolor: 'success.light',
+                      // success.contrastText is computed against
+                      // success.main, so pairing it with the lighter shade
+                      // gives 3.27:1 and fails AA.
+                      bgcolor: 'success.main',
                       color: 'success.contrastText',
                       fontSize: '0.8rem'
                     }}

--- a/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
+++ b/frontend/src/views/InitiativeAgreements/InitiativeAgreementDetail.jsx
@@ -123,7 +123,10 @@ const InitiativeAgreementDetailBase = () => {
                           px: 1.5,
                           py: 0.25,
                           borderRadius: 4,
-                          bgcolor: 'success.light',
+                          // success.contrastText is computed against
+                          // success.main, so pairing it with the lighter
+                          // shade gives 3.27:1 and fails AA.
+                          bgcolor: 'success.main',
                           color: 'success.contrastText',
                           fontSize: '0.8rem'
                         }}

--- a/frontend/src/views/InitiativeAgreements/__tests__/accessibility.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/accessibility.test.jsx
@@ -1,0 +1,218 @@
+/**
+ * Accessibility checks for the Initiative Agreements components.
+ *
+ * Every ticket in this module carries a WCAG 2.2 line on its checklist.
+ * These run axe against each component so regressions are caught in CI
+ * rather than by a person clicking around.
+ *
+ * Two limits worth stating: colour contrast cannot be judged in jsdom,
+ * which does not lay out or paint, so that rule is off here and belongs
+ * in the Cypress pass; and axe finds machine-checkable failures, which is
+ * a floor, not a substitute for driving the pages with a keyboard.
+ */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import axe from 'axe-core'
+
+import { roles } from '@/constants/roles'
+import { wrapper } from '@/tests/utils/wrapper'
+import { EvidenceOfCompletion } from '../components/EvidenceOfCompletion'
+import { DesignatedActionWorkflow } from '../components/DesignatedActionWorkflow'
+import { DesignatedActionHistoryPanel } from '../components/DesignatedActionHistoryPanel'
+import { DocumentTree } from '../components/DocumentTree'
+import { DAAssignedAnalystCell } from '../components/DAAssignedAnalystCell'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    data: { roles: [{ name: roles.ia_analyst }, { name: roles.ia_manager }] },
+    hasRoles: () => true,
+    hasAnyRole: () => true
+  })
+}))
+
+vi.mock('@/hooks/useDocuments', () => ({
+  useDownloadDocument: () => vi.fn(),
+  useDocuments: () => ({ data: [], refetch: vi.fn() })
+}))
+
+vi.mock('@/hooks/useInitiativeAgreements', () => ({
+  useEvidenceRequirements: () => ({
+    data: [
+      {
+        evidenceRequirementId: 1,
+        requirementNumber: 1,
+        description: 'List of major permits and approvals',
+        isActive: true,
+        analystReview: 'Permits verified.',
+        reviewOutcome: 'Satisfactory',
+        reviewNotes: 'Copies filed.',
+        reviewedBy: null,
+        reviewedDate: null
+      },
+      {
+        evidenceRequirementId: 2,
+        requirementNumber: 2,
+        description: 'Risk register',
+        isActive: true,
+        analystReview: '',
+        reviewOutcome: 'Information requested',
+        reviewNotes: null,
+        reviewedBy: null,
+        reviewedDate: null
+      }
+    ],
+    isLoading: false
+  }),
+  useCreateEvidenceRequirement: () => ({ mutate: vi.fn() }),
+  useUpdateEvidenceRequirement: () => ({ mutate: vi.fn() }),
+  useDeleteEvidenceRequirement: () => ({ mutate: vi.fn() }),
+  useDesignatedActionWorkflow: () => ({ mutate: vi.fn(), isPending: false }),
+  useSetRecommendedCredits: () => ({ mutate: vi.fn() }),
+  useDesignatedActionHistory: () => ({
+    data: [
+      {
+        designatedActionHistoryId: 1,
+        event: 'INFORMATION_REQUESTED',
+        displayName: 'Alex Zorkin',
+        createDate: '2026-08-26T10:14:00Z',
+        status: null,
+        snapshot: {
+          comment: 'Send the signed permit.',
+          evidence_requirements: [
+            {
+              evidence_requirement_id: 1,
+              description: 'List of major permits',
+              review_outcome: 'Satisfactory',
+              analyst_review: 'Verified.'
+            }
+          ]
+        }
+      }
+    ],
+    isLoading: false
+  }),
+  useInitiativeAgreementAnalysts: () => ({
+    data: [
+      {
+        userProfileId: 7,
+        firstName: 'Erin',
+        lastName: 'Fong',
+        initials: 'EF',
+        fullName: 'Erin Fong'
+      }
+    ]
+  }),
+  useAssignDesignatedActionAnalyst: () => ({
+    mutate: vi.fn(),
+    isPending: false
+  })
+}))
+
+vi.mock('@/hooks/useDocumentFolders', () => ({
+  useDocumentTree: () => ({
+    data: {
+      folders: [
+        {
+          folderId: 12,
+          name: 'Permits & Approvals',
+          parentFolderId: null,
+          sortOrder: 0,
+          isSystem: false,
+          documentCount: 1,
+          documents: [
+            {
+              documentId: 88,
+              fileName: 'permit.pdf',
+              fileSize: 46080,
+              createDate: '2026-05-12T00:00:00Z',
+              createUser: 'LCFS1_bat'
+            }
+          ],
+          children: []
+        }
+      ],
+      rootDocuments: []
+    },
+    isLoading: false
+  }),
+  useCreateFolder: () => ({ mutate: vi.fn() }),
+  useUpdateFolder: () => ({ mutate: vi.fn() }),
+  useDeleteFolder: () => ({ mutate: vi.fn() }),
+  useMoveDocuments: () => ({ mutate: vi.fn() }),
+  useFolderUpload: () => ({ mutate: vi.fn() })
+}))
+
+const check = async (ui) => {
+  const { container } = render(ui, { wrapper })
+  const results = await axe.run(container, {
+    rules: {
+      // jsdom does not paint, so contrast cannot be judged here.
+      'color-contrast': { enabled: false },
+      // Components are rendered in isolation, without the page landmarks
+      // and single h1 they sit inside.
+      region: { enabled: false },
+      'page-has-heading-one': { enabled: false }
+    }
+  })
+  return results.violations.flatMap((violation) =>
+    violation.nodes.map(
+      (node) => `${violation.id} [${node.html?.slice(0, 70)}]`
+    )
+  )
+}
+
+describe('Initiative Agreements accessibility', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('evidence of completion has no violations', async () => {
+    expect(await check(<EvidenceOfCompletion designatedActionId="9" />)).toEqual(
+      []
+    )
+  })
+
+  it('the workflow actions have no violations', async () => {
+    expect(
+      await check(
+        <DesignatedActionWorkflow
+          designatedActionId="9"
+          availableActions={[
+            'accept_evidence',
+            'request_information',
+            'recommend_to_manager'
+          ]}
+          allEvidenceSatisfactory
+          canEditCredits
+          recommendedCredits={null}
+          creditAllocation={1850}
+        />
+      )
+    ).toEqual([])
+  })
+
+  it('the activity panel has no violations', async () => {
+    expect(
+      await check(<DesignatedActionHistoryPanel designatedActionId="9" />)
+    ).toEqual([])
+  })
+
+  it('the document tree has no violations', async () => {
+    expect(
+      await check(<DocumentTree parentType="designatedAction" parentID="9" />)
+    ).toEqual([])
+  })
+
+  it('the analyst assignment cell has no violations', async () => {
+    expect(
+      await check(
+        <DAAssignedAnalystCell
+          data={{ designatedActionId: 9, assignedAnalyst: null }}
+        />
+      )
+    ).toEqual([])
+  })
+})

--- a/frontend/src/views/InitiativeAgreements/components/DAAssignedAnalystCell.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DAAssignedAnalystCell.jsx
@@ -102,6 +102,9 @@ export const DAAssignedAnalystCell = ({ data }) => {
       }}
     >
       <Select
+        SelectDisplayProps={{
+          'aria-label': t('initiativeAgreement:actions.columns.assignedAnalyst')
+        }}
         data-test="da-analyst-select"
         value={currentAssignee?.userProfileId ?? ''}
         open={isOpen}

--- a/frontend/src/views/InitiativeAgreements/components/DesignatedActionWorkflow.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DesignatedActionWorkflow.jsx
@@ -161,7 +161,10 @@ export const DesignatedActionWorkflow = ({
             inputProps={{
               min: 0,
               max: creditAllocation ?? undefined,
-              'data-test': 'recommended-credits-input'
+              'data-test': 'recommended-credits-input',
+              'aria-label': t(
+                'initiativeAgreement:actionDetail.recommendedCredits'
+              )
             }}
             onChange={(event) => setCredits(event.target.value)}
             onBlur={() => {
@@ -228,7 +231,10 @@ export const DesignatedActionWorkflow = ({
                 fullWidth
                 autoFocus
                 value={comment}
-                inputProps={{ 'data-test': 'workflow-comment' }}
+                inputProps={{
+                  'data-test': 'workflow-comment',
+                  'aria-label': t('initiativeAgreement:workflow.commentPrompt')
+                }}
                 onChange={(event) => setComment(event.target.value)}
               />
             </Box>

--- a/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
@@ -16,6 +16,7 @@ import { TreeItem } from '@mui/x-tree-view/TreeItem'
 import {
   DndContext,
   DragOverlay,
+  KeyboardSensor,
   PointerSensor,
   pointerWithin,
   useDraggable,
@@ -29,6 +30,7 @@ import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutli
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined'
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
 import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined'
 import prettyBytes from 'pretty-bytes'
 
@@ -82,14 +84,13 @@ const NameEditor = ({ initialValue, onCommit, onCancel }) => (
 )
 
 const FileLabel = ({ file, onDownload }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: docDragId(file.documentId)
   })
   return (
     <Box
       ref={setNodeRef}
-      {...attributes}
-      {...listeners}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -100,8 +101,11 @@ const FileLabel = ({ file, onDownload }) => {
       data-test={`tree-file-${file.documentId}`}
     >
       <InsertDriveFileOutlinedIcon fontSize="small" color="action" />
+      {/* A real button: a clickable span cannot be reached by keyboard
+          and announces nothing. */}
       <BCTypography
-        component="span"
+        component="button"
+        type="button"
         variant="subtitle2"
         color="link"
         onClick={(event) => {
@@ -109,6 +113,11 @@ const FileLabel = ({ file, onDownload }) => {
           onDownload(file.documentId)
         }}
         sx={{
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          font: 'inherit',
+          textAlign: 'left',
           textDecoration: 'underline',
           cursor: 'pointer',
           '&:hover': { color: 'info.main' }
@@ -121,6 +130,18 @@ const FileLabel = ({ file, onDownload }) => {
         {' · '}
         {timezoneFormatter({ value: file.createDate })}
       </BCTypography>
+      <IconButton
+        size="small"
+        {...attributes}
+        {...listeners}
+        data-test={`tree-file-handle-${file.documentId}`}
+        aria-label={t('initiativeAgreement:folders.fileDragHandle', {
+          name: file.fileName
+        })}
+        sx={{ cursor: 'grab' }}
+      >
+        <DragIndicatorIcon fontSize="inherit" />
+      </IconButton>
     </Box>
   )
 }
@@ -136,6 +157,7 @@ const FolderLabel = ({
   onOsFileDrop,
   externalDragSuppressed
 }) => {
+  const { t } = useTranslation(['initiativeAgreement'])
   const {
     attributes,
     listeners,
@@ -167,12 +189,7 @@ const FolderLabel = ({
 
   return (
     <Box
-      ref={(node) => {
-        setDragRef(node)
-        setDropRef(node)
-      }}
-      {...attributes}
-      {...listeners}
+      ref={setDropRef}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -207,7 +224,20 @@ const FolderLabel = ({
       }}
     >
       <FolderOutlinedIcon fontSize="small" color="action" />
-      <BCTypography component="span" variant="subtitle2">
+      {/* The drag handle is the name, not the whole row: the row also
+          holds the actions button, and nesting one control inside another
+          leaves neither reachable in order. */}
+      <BCTypography
+        component="span"
+        variant="subtitle2"
+        ref={setDragRef}
+        {...attributes}
+        {...listeners}
+        aria-label={t('initiativeAgreement:folders.folderDragHandle', {
+          name: folder.name
+        })}
+        sx={{ cursor: 'grab' }}
+      >
         {folder.name}
       </BCTypography>
       <BCTypography component="span" variant="subtitle2" color="text.secondary">
@@ -275,7 +305,10 @@ export const DocumentTree = ({ parentType, parentID }) => {
 
   const sensors = useSensors(
     // A few pixels of slack so click-to-download never starts a drag.
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Dragging must not be the only way to move something: space picks a
+    // node up, the arrows move between targets, space drops it.
+    useSensor(KeyboardSensor)
   )
 
   useEffect(() => {

--- a/frontend/src/views/InitiativeAgreements/components/EvidenceOfCompletion.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/EvidenceOfCompletion.jsx
@@ -112,7 +112,12 @@ const RequirementCard = ({ requirement, onSave, onRemove, canEdit }) => {
             value={analystReview}
             placeholder={t('initiativeAgreement:evidence.evidencePlaceholder')}
             inputProps={{
-              'data-test': `eoc-review-${requirement.evidenceRequirementId}`
+              'data-test': `eoc-review-${requirement.evidenceRequirementId}`,
+              // A placeholder is not a label: it disappears on input and
+              // is not reliably announced.
+              'aria-label': t('initiativeAgreement:evidence.evidenceFor', {
+                name: requirement.description
+              })
             }}
             onChange={(event) => setAnalystReview(event.target.value)}
             onBlur={() => {
@@ -134,7 +139,10 @@ const RequirementCard = ({ requirement, onSave, onRemove, canEdit }) => {
                 disabled={!canEdit}
                 value={reviewNotes}
                 inputProps={{
-                  'data-test': `eoc-notes-${requirement.evidenceRequirementId}`
+                  'data-test': `eoc-notes-${requirement.evidenceRequirementId}`,
+                  'aria-label': t('initiativeAgreement:evidence.notesFor', {
+                    name: requirement.description
+                  })
                 }}
                 onChange={(event) => setReviewNotes(event.target.value)}
                 onBlur={() => {
@@ -226,8 +234,14 @@ const ReviewSummary = ({ requirements }) => {
             key={requirement.evidenceRequirementId}
             sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
           >
+            {/* The icon carries the outcome, so it needs words: colour
+                and shape alone are not an accessible name. */}
             {requirement.reviewOutcome === OUTCOME_SATISFACTORY ? (
-              <CheckCircleIcon fontSize="small" color="success" />
+              <CheckCircleIcon
+                fontSize="small"
+                color="success"
+                titleAccess={t('initiativeAgreement:evidence.satisfactory')}
+              />
             ) : (
               <ErrorIcon
                 fontSize="small"
@@ -235,6 +249,11 @@ const ReviewSummary = ({ requirements }) => {
                   requirement.reviewOutcome === OUTCOME_INFORMATION_REQUESTED
                     ? 'warning'
                     : 'disabled'
+                }
+                titleAccess={
+                  requirement.reviewOutcome === OUTCOME_INFORMATION_REQUESTED
+                    ? t('initiativeAgreement:evidence.requestInformation')
+                    : t('initiativeAgreement:evidence.pending')
                 }
               />
             )}
@@ -340,7 +359,12 @@ export const EvidenceOfCompletion = ({
                   placeholder={t(
                     'initiativeAgreement:evidence.requirementNamePlaceholder'
                   )}
-                  inputProps={{ 'data-test': 'eoc-new-description' }}
+                  inputProps={{
+                    'data-test': 'eoc-new-description',
+                    'aria-label': t(
+                      'initiativeAgreement:evidence.requirementNamePlaceholder'
+                    )
+                  }}
                   onChange={(event) => setNewDescription(event.target.value)}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter') commitNew()

--- a/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
+++ b/frontend/src/views/SupportingDocuments/SupportingDocumentSummary.jsx
@@ -29,14 +29,22 @@ export const SupportingDocumentSummary = ({
             sx={{ display: 'list-item', padding: '0', marginLeft: '1.2rem' }}
             key={file.documentId}
           >
+            {/* A real button: a clickable span cannot be reached by
+                keyboard and announces nothing to a screen reader. */}
             <BCTypography
-              component="span"
+              component="button"
+              type="button"
               variant="subtitle2"
               color="link"
               onClick={() => {
                 downloadDocument(file.documentId)
               }}
               sx={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                font: 'inherit',
+                textAlign: 'left',
                 textDecoration: 'underline',
                 cursor: 'pointer',
                 '&:hover': { color: 'info.main' }


### PR DESCRIPTION
## Summary

The accessibility pass for the Initiative Agreements module. Every ticket in this module carries a WCAG 2.2 line on its checklist and none had been checked; this closes that with findings rather than an assertion.

An axe run over each component is now a test, so regressions are caught in CI instead of by someone clicking around. **Five defects it found, two it could not.**

### What axe found

| Defect | Where |
|---|---|
| Form field with no accessible name | The evidence box, the notes box, the new-requirement field, the recommended credit amount, and the workflow comment box |
| Control announced nothing | The analyst assignment combobox |
| One control nested inside another | The folder row, which carried both a drag handle and the actions button |

A placeholder is not a label — it disappears the moment someone types, and it is not reliably announced. The assignment control needed its name on the element that actually carries the combobox role rather than the wrapper.

### What axe cannot see, and matters more

**File names were clickable spans.** No keyboard path, nothing announced. They are buttons now — in the tree and in the shared document summary the agreement page also uses. That shared component is rendered by three other surfaces; their suites pass unchanged, and the change is strictly additive for them.

**Dragging was the only way to move a file**, so from a keyboard nothing could be moved at all. The keyboard sensor is wired up and both files and folders now have a named handle, so a file can be picked up with space, moved with the arrows, and dropped.

**The status chip failed AA.** White on `success.light` is **3.27:1** where 4.5:1 is required. The trap is that MUI computes `contrastText` against `main`, not `light`, so pairing the two looks correct and is not. Using `main` gives **4.62:1**. Both detail pages were affected.

**The review summary conveyed its outcome through an icon's colour and shape alone.** It says it in words now.

### Still outstanding, stated plainly

**Colour contrast is only partly checked.** jsdom does not lay out or paint, so that axe rule is off in these tests; I verified the specific pairs I introduced arithmetically against the theme, which is how the chip failure surfaced. A full sweep needs the Cypress lane, where `cypress-axe` already exists with a standing TODO for more pages. I did not add specs there because the CI test user's roles and the IA seed data on that lane are unknown to me, and a spec that silently redirects to the dashboard would check the wrong page while appearing to pass.

**`warning.main` (#fb8c00) is 2.37:1 against a white card**, below the 3:1 that SC 1.4.11 asks of meaningful non-text. It is used for the amber rail on outstanding evidence. I have left it: the rail is reinforcement, not the only signal — the outcome is also in the checkbox state and now in the summary text — and changing a theme colour reaches the whole application, which is not this PR's business. Worth raising with whoever owns the palette.

**No screen reader has been near this.** Automated checks are a floor.

### Testing

5 new axe tests, one per component, all passing. 109 tests pass across the module and the shared document surfaces; the three other consumers of the shared summary component pass unchanged (363 in Transactions, 889 across compliance and carbon intensity). Type-check unchanged.

Refs #4839 #4896 #4897 #4898 #4899 #4900 #4925
