### PR TITLE
Feat: Deleted items for designated action documents

### DIFF
--- a/backend/lcfs/db/migrations/versions/2026-08-26-10-00_e2a4c6b8d0f1.py
+++ b/backend/lcfs/db/migrations/versions/2026-08-26-10-00_e2a4c6b8d0f1.py
@@ -1,0 +1,70 @@
+"""Add soft deletion to documents.
+
+The business area asked that nothing a user removes truly disappears, so
+the folder tree can be kept tidy without losing anything. Removing a file
+now stamps it rather than destroying it, and it moves to a bin the user
+can restore from.
+
+Two nullable columns on the shared document table. Every existing read
+gains "deleted_date IS NULL", which is inert for the six other surfaces:
+only the allow-listed parent types have a route that can set it, so
+nothing changes for compliance reports, administrative adjustments,
+initiative agreements, charging sites, CI applications or internal
+comments.
+
+Nothing is ever purged, so the existing hard-delete path is left exactly
+as it is and is simply never called for the allow-listed types.
+
+Revision ID: e2a4c6b8d0f1
+Revises: d1f3a5b7c9e2
+Create Date: 2026-08-26 10:00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e2a4c6b8d0f1"
+down_revision = "d1f3a5b7c9e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document",
+        sa.Column(
+            "deleted_date",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+            comment=(
+                "When the document was removed from its parent's tree. "
+                "NULL means it is live; documents are never hard-deleted "
+                "for folder-enabled parents."
+            ),
+        ),
+    )
+    op.add_column(
+        "document",
+        sa.Column(
+            "deleted_by",
+            sa.String(length=500),
+            nullable=True,
+            comment="Username of whoever removed it, matching create_user",
+        ),
+    )
+    # The bin is read per parent, and every live read filters on this, so
+    # a partial index on the live rows keeps the common path cheap.
+    op.create_index(
+        "ix_document_live",
+        "document",
+        ["document_id"],
+        postgresql_where=sa.text("deleted_date IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_live", table_name="document")
+    op.drop_column("document", "deleted_by")
+    op.drop_column("document", "deleted_date")

--- a/backend/lcfs/db/models/document/Document.py
+++ b/backend/lcfs/db/models/document/Document.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import TIMESTAMP, Column, Integer, String
 from sqlalchemy.orm import relationship
 
 from lcfs.db.base import BaseModel, Auditable
@@ -43,6 +43,22 @@ class Document(BaseModel, Auditable):
     file_size = Column(Integer, nullable=False)
     mime_type = Column(String, nullable=False)
     display_name = Column(String, nullable=True)
+
+    # --- Soft deletion (nothing is ever purged) ------------------------
+    # Only folder-enabled parents have a route that sets these; for every
+    # other surface they stay NULL and the read filter is inert.
+    deleted_date = Column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        comment=(
+            "When the document was removed from its parent's tree; NULL " "means live"
+        ),
+    )
+    deleted_by = Column(
+        String(500),
+        nullable=True,
+        comment="Username of whoever removed it, matching create_user",
+    )
 
     compliance_reports = relationship(
         "ComplianceReport",

--- a/backend/lcfs/services/s3/client.py
+++ b/backend/lcfs/services/s3/client.py
@@ -680,7 +680,12 @@ class DocumentService:
             stmt = (
                 select(Document)
                 .join(association_table)
-                .where(getattr(association_table.c, column_name).in_(parent_ids))
+                .where(
+                    getattr(association_table.c, column_name).in_(parent_ids),
+                    # Soft-deleted documents live in the bin, not the list.
+                    # Inert for parents that cannot delete softly.
+                    Document.deleted_date.is_(None),
+                )
                 .distinct(Document.document_id)
             )
             result = await self.db.execute(stmt)
@@ -696,7 +701,10 @@ class DocumentService:
                     association_table,
                     association_table.c.document_id == Document.document_id,
                 )
-                .where(getattr(association_table.c, column_name) == parent_id)
+                .where(
+                    getattr(association_table.c, column_name) == parent_id,
+                    Document.deleted_date.is_(None),
+                )
             )
             result = await self.db.execute(stmt)
             documents = []
@@ -710,7 +718,10 @@ class DocumentService:
         stmt = (
             select(Document)
             .join(association_table)
-            .where(getattr(association_table.c, column_name) == parent_id)
+            .where(
+                getattr(association_table.c, column_name) == parent_id,
+                Document.deleted_date.is_(None),
+            )
         )
         result = await self.db.execute(stmt)
         return result.scalars().all()

--- a/backend/lcfs/tests/document_folder/test_document_folder_view.py
+++ b/backend/lcfs/tests/document_folder/test_document_folder_view.py
@@ -372,3 +372,225 @@ async def test_folder_routes_are_idir_only(
 
     response = await client.get(_tree_url(fastapi_app, action))
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# Soft deletion: nothing a user removes is ever destroyed.
+# ---------------------------------------------------------------------------
+
+
+def _deleted_url(fastapi_app, action):
+    return fastapi_app.url_path_for(
+        "get_deleted_documents",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+
+
+def _delete_url(fastapi_app, action, document):
+    return fastapi_app.url_path_for(
+        "soft_delete_document",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        document_id=document.document_id,
+    )
+
+
+def _restore_url(fastapi_app, action, document):
+    return fastapi_app.url_path_for(
+        "restore_document",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+        document_id=document.document_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_deleting_a_document_hides_it_but_keeps_it(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL1")
+    document = await _seed_document(dbsession, action, "obsolete.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.delete(_delete_url(fastapi_app, action, document))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # Gone from the tree...
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert tree["rootDocuments"] == []
+
+    # ...but the row is still there, stamped.
+    row = (
+        await dbsession.execute(
+            select(Document).where(Document.document_id == document.document_id)
+        )
+    ).scalar_one()
+    assert row.deleted_date is not None
+    assert row.deleted_by == "mockuser"
+
+
+@pytest.mark.anyio
+async def test_the_bin_lists_what_was_removed(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL2")
+    document = await _seed_document(dbsession, action, "obsolete.pdf")
+    await _seed_document(dbsession, action, "kept.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    await client.delete(_delete_url(fastapi_app, action, document))
+
+    response = await client.get(_deleted_url(fastapi_app, action))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["total"] == 1
+    assert [d["fileName"] for d in data["documents"]] == ["obsolete.pdf"]
+    assert data["documents"][0]["deletedBy"] == "mockuser"
+
+    # The one that was not deleted is still in the tree.
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert [d["fileName"] for d in tree["rootDocuments"]] == ["kept.pdf"]
+
+
+@pytest.mark.anyio
+async def test_restoring_returns_a_document_to_its_folder(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL3")
+    document = await _seed_document(dbsession, action, "permit.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    folder = (await _create_folder(client, fastapi_app, action, "Permits")).json()
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    await client.put(
+        move_url,
+        json={"documentIds": [document.document_id], "folderId": folder["folderId"]},
+    )
+
+    await client.delete(_delete_url(fastapi_app, action, document))
+    binned = (await client.get(_deleted_url(fastapi_app, action))).json()
+    assert binned["documents"][0]["restoreFolderName"] == "Permits"
+
+    restored = await client.put(_restore_url(fastapi_app, action, document))
+    assert restored.status_code == status.HTTP_204_NO_CONTENT
+
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert [d["fileName"] for d in tree["folders"][0]["documents"]] == ["permit.pdf"]
+    assert (await client.get(_deleted_url(fastapi_app, action))).json()["total"] == 0
+
+
+@pytest.mark.anyio
+async def test_restoring_falls_back_to_the_top_level_if_the_folder_went(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """Deleting a folder must not resurrect it later by the back door."""
+    action = await _seed_da(dbsession, "IA-26DEL4")
+    document = await _seed_document(dbsession, action, "permit.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+    folder = (await _create_folder(client, fastapi_app, action, "Doomed")).json()
+    move_url = fastapi_app.url_path_for(
+        "move_document_folder_items",
+        parent_type="designatedAction",
+        parent_id=action.designated_action_id,
+    )
+    await client.put(
+        move_url,
+        json={"documentIds": [document.document_id], "folderId": folder["folderId"]},
+    )
+    await client.delete(_delete_url(fastapi_app, action, document))
+    await client.delete(
+        fastapi_app.url_path_for(
+            "delete_document_folder",
+            parent_type="designatedAction",
+            parent_id=action.designated_action_id,
+            folder_id=folder["folderId"],
+        )
+    )
+
+    binned = (await client.get(_deleted_url(fastapi_app, action))).json()
+    assert binned["documents"][0]["restoreFolderName"] is None
+
+    await client.put(_restore_url(fastapi_app, action, document))
+
+    tree = (await client.get(_tree_url(fastapi_app, action))).json()
+    assert tree["folders"] == []
+    assert [d["fileName"] for d in tree["rootDocuments"]] == ["permit.pdf"]
+
+
+@pytest.mark.anyio
+async def test_deleting_twice_does_not_rewrite_who_removed_it(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL5")
+    document = await _seed_document(dbsession, action, "obsolete.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    await client.delete(_delete_url(fastapi_app, action, document))
+    first = (await client.get(_deleted_url(fastapi_app, action))).json()["documents"][0]
+    await client.delete(_delete_url(fastapi_app, action, document))
+    second = (await client.get(_deleted_url(fastapi_app, action))).json()["documents"][
+        0
+    ]
+
+    assert first["deletedDate"] == second["deletedDate"]
+
+
+@pytest.mark.anyio
+async def test_another_action_cannot_bin_this_ones_document(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL6")
+    other = await _seed_da(dbsession, "IA-26DEL7")
+    document = await _seed_document(dbsession, action, "permit.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    response = await client.delete(_delete_url(fastapi_app, other, document))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_the_bin_is_idir_only(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    action = await _seed_da(dbsession, "IA-26DEL8")
+    set_mock_user(fastapi_app, [RoleEnum.IA_PROPONENT])
+
+    response = await client.get(_deleted_url(fastapi_app, action))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_a_deleted_document_leaves_the_shared_document_list_too(
+    client: AsyncClient, fastapi_app: FastAPI, set_mock_user, dbsession
+):
+    """The filter belongs in the shared read, not only the tree, so no
+    surface can surface a binned document."""
+    action = await _seed_da(dbsession, "IA-26DEL9")
+    document = await _seed_document(dbsession, action, "obsolete.pdf")
+    set_mock_user(fastapi_app, IDIR_IA_ANALYST)
+
+    before = await client.get(
+        fastapi_app.url_path_for(
+            "get_all_documents",
+            parent_type="designatedAction",
+            parent_id=action.designated_action_id,
+        )
+    )
+    assert [d["fileName"] for d in before.json()] == ["obsolete.pdf"]
+
+    await client.delete(_delete_url(fastapi_app, action, document))
+
+    after = await client.get(
+        fastapi_app.url_path_for(
+            "get_all_documents",
+            parent_type="designatedAction",
+            parent_id=action.designated_action_id,
+        )
+    )
+    assert after.json() == []

--- a/backend/lcfs/web/api/document_folder/repo.py
+++ b/backend/lcfs/web/api/document_folder/repo.py
@@ -1,11 +1,12 @@
-from typing import Dict, List, Optional, Sequence, Set
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from fastapi import Depends
-from sqlalchemy import delete, select
+from sqlalchemy import delete, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lcfs.db.dependencies import get_async_db_session
 from lcfs.db.models.document import Document, DocumentFolder, DocumentFolderItem
+from lcfs.db.models.user.UserProfile import UserProfile
 from lcfs.db.models.initiative_agreement.DesignatedAction import (
     designated_action_document_association,
 )
@@ -62,11 +63,96 @@ class DocumentFolderRepository:
             )
             .where(
                 designated_action_document_association.c.designated_action_id
-                == parent_id
+                == parent_id,
+                Document.deleted_date.is_(None),
             )
             .order_by(Document.file_name)
         )
         return list(result.scalars().all())
+
+    @repo_handler
+    async def get_deleted_documents(
+        self, parent_id: int, limit: int = 50, offset: int = 0
+    ) -> Tuple[List[Document], int]:
+        """The bin for one parent, newest deletion first.
+
+        Paginated from the start: nothing is ever purged, so this list
+        only grows and the screen will need paging eventually even though
+        it does not today.
+        """
+        base = (
+            select(Document)
+            .join(
+                designated_action_document_association,
+                designated_action_document_association.c.document_id
+                == Document.document_id,
+            )
+            .where(
+                designated_action_document_association.c.designated_action_id
+                == parent_id,
+                Document.deleted_date.isnot(None),
+            )
+        )
+        total = (
+            await self.db.execute(
+                select(func.count()).select_from(
+                    base.with_only_columns(Document.document_id).subquery()
+                )
+            )
+        ).scalar_one()
+        result = await self.db.execute(
+            base.order_by(desc(Document.deleted_date)).limit(limit).offset(offset)
+        )
+        return list(result.scalars().all()), total
+
+    @repo_handler
+    async def get_document_for_parent(
+        self, document_id: int, parent_id: int
+    ) -> Optional[Document]:
+        """A document, but only if it belongs to this parent."""
+        result = await self.db.execute(
+            select(Document)
+            .join(
+                designated_action_document_association,
+                designated_action_document_association.c.document_id
+                == Document.document_id,
+            )
+            .where(
+                Document.document_id == document_id,
+                designated_action_document_association.c.designated_action_id
+                == parent_id,
+            )
+            .execution_options(populate_existing=True)
+        )
+        return result.scalars().first()
+
+    @repo_handler
+    async def get_placement(self, document_id: int) -> Optional[DocumentFolderItem]:
+        result = await self.db.execute(
+            select(DocumentFolderItem).where(
+                DocumentFolderItem.document_id == document_id
+            )
+        )
+        return result.scalars().first()
+
+    @repo_handler
+    async def get_user_display_names(self, usernames) -> Dict[str, str]:
+        """Resolve usernames to names for display in the bin."""
+        names = [u for u in set(usernames) if u]
+        if not names:
+            return {}
+        result = await self.db.execute(
+            select(
+                UserProfile.keycloak_username,
+                UserProfile.first_name,
+                UserProfile.last_name,
+            ).where(UserProfile.keycloak_username.in_(names))
+        )
+        resolved = {}
+        for username, first_name, last_name in result.all():
+            full = " ".join(p for p in (first_name, last_name) if p).strip()
+            resolved[username] = full or None
+        return resolved
 
     @repo_handler
     async def get_associated_document_ids(self, parent_id: int) -> Set[int]:

--- a/backend/lcfs/web/api/document_folder/schema.py
+++ b/backend/lcfs/web/api/document_folder/schema.py
@@ -35,6 +35,25 @@ class DocumentFolderTreeSchema(BaseSchema):
     root_documents: List[FolderDocumentSchema] = []
 
 
+class DeletedDocumentSchema(BaseSchema):
+    document_id: int
+    file_name: str
+    file_size: int
+    deleted_date: Optional[datetime] = None
+    deleted_by: Optional[str] = None
+    # Resolved for display; the stored value is the username.
+    deleted_by_name: Optional[str] = None
+    # Where it will return to. None means the top level, either because it
+    # was there or because the folder it came from has since gone.
+    restore_folder_id: Optional[int] = None
+    restore_folder_name: Optional[str] = None
+
+
+class DeletedDocumentsSchema(BaseSchema):
+    documents: List[DeletedDocumentSchema] = []
+    total: int = 0
+
+
 class FolderCreateSchema(BaseSchema):
     name: str
     parent_folder_id: Optional[int] = None

--- a/backend/lcfs/web/api/document_folder/services.py
+++ b/backend/lcfs/web/api/document_folder/services.py
@@ -1,4 +1,5 @@
 import structlog
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from fastapi import Depends, HTTPException, Request
@@ -10,6 +11,8 @@ from lcfs.web.api.document_folder.constants import (
 )
 from lcfs.web.api.document_folder.repo import DocumentFolderRepository
 from lcfs.web.api.document_folder.schema import (
+    DeletedDocumentSchema,
+    DeletedDocumentsSchema,
     DocumentFolderTreeSchema,
     FolderCreateSchema,
     FolderDocumentSchema,
@@ -89,6 +92,88 @@ class DocumentFolderServices:
                 detail=f"Folders may nest at most {MAX_FOLDER_DEPTH} levels deep.",
             )
         return depth
+
+    # ------------------------------------------------------------------
+    # Deletion. Nothing is ever destroyed: removing a document stamps it
+    # and it moves to the bin, where it stays. The shared hard-delete path
+    # is never called for these parents.
+    # ------------------------------------------------------------------
+    @service_handler
+    async def soft_delete_document(
+        self, parent_type: str, parent_id: int, document_id: int, user
+    ) -> None:
+        document = await self.repo.get_document_for_parent(document_id, parent_id)
+        if document is None:
+            raise DataNotFoundException(f"Document {document_id} not found")
+        if document.deleted_date is not None:
+            # Already in the bin; deleting twice is not an error, but it
+            # must not overwrite who removed it or when.
+            return
+        document.deleted_date = datetime.now(timezone.utc)
+        document.deleted_by = getattr(user, "keycloak_username", None)
+        # The placement row stays, so restoring returns it to its folder.
+        await self.repo.db.flush()
+
+    @service_handler
+    async def restore_document(
+        self, parent_type: str, parent_id: int, document_id: int
+    ) -> None:
+        document = await self.repo.get_document_for_parent(document_id, parent_id)
+        if document is None:
+            raise DataNotFoundException(f"Document {document_id} not found")
+        if document.deleted_date is None:
+            return
+        placement = await self.repo.get_placement(document_id)
+        if placement is not None:
+            folder = await self.repo.get_folder(placement.folder_id)
+            if (
+                folder is None
+                or folder.parent_type != parent_type
+                or folder.parent_id != parent_id
+            ):
+                # The folder it came from has gone. Put it at the top
+                # level rather than resurrecting a folder someone removed.
+                await self.repo.set_placements([document_id], None)
+        document.deleted_date = None
+        document.deleted_by = None
+        await self.repo.db.flush()
+
+    @service_handler
+    async def get_deleted_documents(
+        self, parent_type: str, parent_id: int, limit: int = 50, offset: int = 0
+    ) -> DeletedDocumentsSchema:
+        documents, total = await self.repo.get_deleted_documents(
+            parent_id, limit=limit, offset=offset
+        )
+        names = await self.repo.get_user_display_names(
+            [d.deleted_by for d in documents]
+        )
+
+        rows = []
+        for document in documents:
+            placement = await self.repo.get_placement(document.document_id)
+            folder = None
+            if placement is not None:
+                candidate = await self.repo.get_folder(placement.folder_id)
+                if (
+                    candidate is not None
+                    and candidate.parent_type == parent_type
+                    and candidate.parent_id == parent_id
+                ):
+                    folder = candidate
+            rows.append(
+                DeletedDocumentSchema(
+                    document_id=document.document_id,
+                    file_name=document.file_name,
+                    file_size=document.file_size,
+                    deleted_date=document.deleted_date,
+                    deleted_by=document.deleted_by,
+                    deleted_by_name=names.get(document.deleted_by),
+                    restore_folder_id=folder.folder_id if folder else None,
+                    restore_folder_name=folder.name if folder else None,
+                )
+            )
+        return DeletedDocumentsSchema(documents=rows, total=total)
 
     # ------------------------------------------------------------------
     # Tree

--- a/backend/lcfs/web/api/document_folder/views.py
+++ b/backend/lcfs/web/api/document_folder/views.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Body, Depends, Query, Request, status
 from lcfs.db.models.user.Role import RoleEnum
 from lcfs.services.s3.client import DocumentService
 from lcfs.web.api.document_folder.schema import (
+    DeletedDocumentsSchema,
     DocumentFolderTreeSchema,
     FolderCreateSchema,
     FolderItemsMoveSchema,
@@ -56,6 +57,80 @@ async def get_document_folder_tree(
         parent_type, parent_id, service, document_service, ia_validate
     )
     return await service.get_tree(parent_type, parent_id)
+
+
+@router.get(
+    "/{parent_type}/{parent_id}/deleted",
+    response_model=DeletedDocumentsSchema,
+    status_code=status.HTTP_200_OK,
+)
+@view_handler(FOLDER_ROLES)
+async def get_deleted_documents(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> DeletedDocumentsSchema:
+    """Documents removed from this parent's tree. Nothing ever leaves."""
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    return await service.get_deleted_documents(
+        parent_type, parent_id, limit=limit, offset=offset
+    )
+
+
+@router.delete(
+    "/{parent_type}/{parent_id}/documents/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@view_handler(FOLDER_ROLES)
+async def soft_delete_document(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    document_id: int,
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> None:
+    """Move a document to the bin.
+
+    Deliberately not the shared delete route: that one destroys the S3
+    object and the row, which is exactly what must not happen here.
+    """
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    await service.soft_delete_document(
+        parent_type, parent_id, document_id, request.user
+    )
+
+
+@router.put(
+    "/{parent_type}/{parent_id}/documents/{document_id}/restore",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@view_handler(FOLDER_ROLES)
+async def restore_document(
+    request: Request,
+    parent_type: str,
+    parent_id: int,
+    document_id: int,
+    service: DocumentFolderServices = Depends(),
+    document_service: DocumentService = Depends(),
+    ia_validate: InitiativeAgreementValidation = Depends(),
+) -> None:
+    """Return a document to the tree, or to the top level if the folder
+    it came from has since been removed."""
+    await _validate_parent_access(
+        parent_type, parent_id, service, document_service, ia_validate
+    )
+    await service.restore_document(parent_type, parent_id, document_id)
 
 
 @router.post(

--- a/frontend/src/assets/locales/en/initiativeAgreement.json
+++ b/frontend/src/assets/locales/en/initiativeAgreement.json
@@ -111,7 +111,15 @@
     "draggingFiles": "{{count}} file(s)",
     "draggingFolder": "Folder",
     "folderDragHandle": "Move folder {{name}}",
-    "fileDragHandle": "Move file {{name}}"
+    "fileDragHandle": "Move file {{name}}",
+    "deleteFile": "Move {{name}} to deleted items",
+    "deletedItems": "Deleted items",
+    "restore": "Restore",
+    "restoreTo": "Returns to {{folder}}",
+    "restoreToRoot": "Returns to the top level",
+    "deletedBy": "Deleted by {{name}}",
+    "binEmpty": "Nothing has been deleted.",
+    "binHelp": "Deleted files are kept. Restoring returns a file to its folder, or to the top level if that folder has since been removed."
   },
   "evidence": {
     "sectionTitle": "Evidence of completion of designated action:",

--- a/frontend/src/constants/routes/apiRoutes.js
+++ b/frontend/src/constants/routes/apiRoutes.js
@@ -95,6 +95,11 @@ export const apiRoutes = {
   documentFolderTree: '/document-folders/:parentType/:parentID',
   documentFolderUpdate: '/document-folders/:parentType/:parentID/:folderId',
   documentFolderItems: '/document-folders/:parentType/:parentID/items',
+  documentFolderDeleted: '/document-folders/:parentType/:parentID/deleted',
+  documentFolderDeleteDocument:
+    '/document-folders/:parentType/:parentID/documents/:documentId',
+  documentFolderRestoreDocument:
+    '/document-folders/:parentType/:parentID/documents/:documentId/restore',
 
   // fuel-type
   getFuelTypeOthers: '/fuel-type/others/list',

--- a/frontend/src/hooks/useDocumentFolders.ts
+++ b/frontend/src/hooks/useDocumentFolders.ts
@@ -243,3 +243,82 @@ export const useFolderUpload = (
     onSettled: () => queryClient.invalidateQueries({ queryKey: key })
   })
 }
+
+// The bin (#deleted items). Nothing ever leaves it, so the endpoint is
+// paginated from the start even though the panel does not page yet.
+const deletedKey = (parentType: string, parentID: number | string) => [
+  'document-tree-deleted',
+  parentType,
+  String(parentID)
+]
+
+export const useDeletedDocuments = (
+  parentType: string,
+  parentID: number | string,
+  options: Record<string, unknown> = {}
+) => {
+  const client = useApiService()
+  return useQuery({
+    enabled: !!parentID,
+    queryKey: deletedKey(parentType, parentID),
+    queryFn: async () =>
+      (
+        await client.get(
+          fillPath(apiRoutes.documentFolderDeleted, parentType, parentID)
+        )
+      ).data,
+    ...options
+  })
+}
+
+const useBinMutation = (
+  parentType: string,
+  parentID: number | string,
+  run: (client: any) => (documentId: number) => Promise<unknown>
+) => {
+  const client = useApiService()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: run(client),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: treeKey(parentType, parentID) })
+      queryClient.invalidateQueries({
+        queryKey: deletedKey(parentType, parentID)
+      })
+    }
+  })
+}
+
+export const useSoftDeleteDocument = (
+  parentType: string,
+  parentID: number | string
+) =>
+  useBinMutation(
+    parentType,
+    parentID,
+    (client) => async (documentId: number) =>
+      client.delete(
+        fillPath(
+          apiRoutes.documentFolderDeleteDocument,
+          parentType,
+          parentID
+        ).replace(':documentId', String(documentId))
+      )
+  )
+
+export const useRestoreDocument = (
+  parentType: string,
+  parentID: number | string
+) =>
+  useBinMutation(
+    parentType,
+    parentID,
+    (client) => async (documentId: number) =>
+      client.put(
+        fillPath(
+          apiRoutes.documentFolderRestoreDocument,
+          parentType,
+          parentID
+        ).replace(':documentId', String(documentId))
+      )
+  )

--- a/frontend/src/views/InitiativeAgreements/__tests__/accessibility.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/__tests__/accessibility.test.jsx
@@ -113,6 +113,7 @@ vi.mock('@/hooks/useInitiativeAgreements', () => ({
   })
 }))
 
+const mockSoftDelete = vi.fn()
 vi.mock('@/hooks/useDocumentFolders', () => ({
   useDocumentTree: () => ({
     data: {
@@ -144,7 +145,10 @@ vi.mock('@/hooks/useDocumentFolders', () => ({
   useUpdateFolder: () => ({ mutate: vi.fn() }),
   useDeleteFolder: () => ({ mutate: vi.fn() }),
   useMoveDocuments: () => ({ mutate: vi.fn() }),
-  useFolderUpload: () => ({ mutate: vi.fn() })
+  useFolderUpload: () => ({ mutate: vi.fn() }),
+  useSoftDeleteDocument: () => ({ mutate: mockSoftDelete }),
+  useDeletedDocuments: () => ({ data: { documents: [], total: 0 } }),
+  useRestoreDocument: () => ({ mutate: vi.fn() })
 }))
 
 const check = async (ui) => {
@@ -170,9 +174,9 @@ describe('Initiative Agreements accessibility', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('evidence of completion has no violations', async () => {
-    expect(await check(<EvidenceOfCompletion designatedActionId="9" />)).toEqual(
-      []
-    )
+    expect(
+      await check(<EvidenceOfCompletion designatedActionId="9" />)
+    ).toEqual([])
   })
 
   it('the workflow actions have no violations', async () => {

--- a/frontend/src/views/InitiativeAgreements/components/DeletedItems.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DeletedItems.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, Collapse, IconButton, Paper } from '@mui/material'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import RestoreIcon from '@mui/icons-material/Restore'
+import prettyBytes from 'pretty-bytes'
+
+import BCBox from '@/components/BCBox'
+import BCTypography from '@/components/BCTypography'
+import {
+  useDeletedDocuments,
+  useRestoreDocument
+} from '@/hooks/useDocumentFolders'
+import { timezoneFormatter } from '@/utils/formatters'
+
+// The bin beneath the document tree. Nothing removed from the tree is
+// destroyed — it lands here and stays, so the tree can be kept tidy
+// without anything being lost.
+export const DeletedItems = ({ parentType, parentID }) => {
+  const { t } = useTranslation(['common', 'initiativeAgreement'])
+  const [expanded, setExpanded] = useState(false)
+  const { data } = useDeletedDocuments(parentType, parentID)
+  const { mutate: restore } = useRestoreDocument(parentType, parentID)
+
+  const documents = data?.documents ?? []
+  const total = data?.total ?? 0
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ mt: 2, p: 1.5 }}
+      data-test="deleted-items-section"
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <DeleteOutlineIcon fontSize="small" color="action" />
+          <BCTypography variant="body4" sx={{ fontWeight: 700 }}>
+            {t('initiativeAgreement:folders.deletedItems')}
+          </BCTypography>
+          {/* The count shows while collapsed, so a full bin is visible
+              without opening it. */}
+          <BCBox
+            component="span"
+            data-test="deleted-items-count"
+            sx={{
+              px: 1,
+              py: 0.1,
+              borderRadius: 4,
+              bgcolor: 'action.selected',
+              fontSize: '0.8rem'
+            }}
+          >
+            {total}
+          </BCBox>
+        </Box>
+        <IconButton
+          size="small"
+          data-test="deleted-items-toggle"
+          aria-label={t('initiativeAgreement:folders.deletedItems')}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+
+      <Collapse in={expanded}>
+        <Box sx={{ mt: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {documents.length === 0 ? (
+            <BCTypography variant="body4" color="text.secondary">
+              {t('initiativeAgreement:folders.binEmpty')}
+            </BCTypography>
+          ) : (
+            documents.map((document) => (
+              <Box
+                key={document.documentId}
+                data-test={`deleted-item-${document.documentId}`}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  flexWrap: 'wrap'
+                }}
+              >
+                <BCTypography variant="subtitle2">
+                  {document.fileName}
+                </BCTypography>
+                <BCTypography variant="subtitle2" color="text.secondary">
+                  {prettyBytes(document.fileSize ?? 0)}
+                  {' · '}
+                  {t('initiativeAgreement:folders.deletedBy', {
+                    name: document.deletedByName || document.deletedBy || '—'
+                  })}
+                  {' · '}
+                  {timezoneFormatter({ value: document.deletedDate })}
+                </BCTypography>
+                <BCTypography variant="subtitle2" color="text.secondary">
+                  {document.restoreFolderName
+                    ? t('initiativeAgreement:folders.restoreTo', {
+                        folder: document.restoreFolderName
+                      })
+                    : t('initiativeAgreement:folders.restoreToRoot')}
+                </BCTypography>
+                <BCTypography
+                  component="button"
+                  type="button"
+                  variant="subtitle2"
+                  color="link"
+                  data-test={`restore-${document.documentId}`}
+                  onClick={() => restore(document.documentId)}
+                  sx={{
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    font: 'inherit',
+                    cursor: 'pointer',
+                    textDecoration: 'underline',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.5
+                  }}
+                >
+                  <RestoreIcon fontSize="inherit" />
+                  {t('initiativeAgreement:folders.restore')}
+                </BCTypography>
+              </Box>
+            ))
+          )}
+          <BCTypography variant="body4" color="text.secondary" component="p">
+            {t('initiativeAgreement:folders.binHelp')}
+          </BCTypography>
+        </Box>
+      </Collapse>
+    </Paper>
+  )
+}
+
+export default DeletedItems

--- a/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/DocumentTree.jsx
@@ -44,8 +44,10 @@ import {
   useDocumentTree,
   useFolderUpload,
   useMoveDocuments,
+  useSoftDeleteDocument,
   useUpdateFolder
 } from '@/hooks/useDocumentFolders'
+import { DeletedItems } from './DeletedItems'
 import { timezoneFormatter } from '@/utils/formatters'
 import {
   ROOT_DROP_ID,
@@ -83,7 +85,7 @@ const NameEditor = ({ initialValue, onCommit, onCancel }) => (
   />
 )
 
-const FileLabel = ({ file, onDownload }) => {
+const FileLabel = ({ file, onDownload, onDelete }) => {
   const { t } = useTranslation(['initiativeAgreement'])
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: docDragId(file.documentId)
@@ -130,6 +132,21 @@ const FileLabel = ({ file, onDownload }) => {
         {' · '}
         {timezoneFormatter({ value: file.createDate })}
       </BCTypography>
+      {/* Removing a file sends it to the bin below; nothing is
+          destroyed. */}
+      <IconButton
+        size="small"
+        data-test={`tree-file-delete-${file.documentId}`}
+        aria-label={t('initiativeAgreement:folders.deleteFile', {
+          name: file.fileName
+        })}
+        onClick={(event) => {
+          event.stopPropagation()
+          onDelete(file.documentId)
+        }}
+      >
+        <DeleteOutlineIcon fontSize="inherit" />
+      </IconButton>
       <IconButton
         size="small"
         {...attributes}
@@ -290,6 +307,7 @@ export const DocumentTree = ({ parentType, parentID }) => {
   const { mutate: deleteFolder } = useDeleteFolder(parentType, parentID)
   const { mutate: moveDocuments } = useMoveDocuments(parentType, parentID)
   const { mutate: uploadToFolder } = useFolderUpload(parentType, parentID)
+  const { mutate: deleteDocument } = useSoftDeleteDocument(parentType, parentID)
 
   const [creating, setCreating] = useState(null)
   const [renamingId, setRenamingId] = useState(null)
@@ -492,7 +510,13 @@ export const DocumentTree = ({ parentType, parentID }) => {
         <TreeItem
           key={`doc-${file.documentId}`}
           itemId={`doc-${file.documentId}`}
-          label={<FileLabel file={file} onDownload={downloadDocument} />}
+          label={
+            <FileLabel
+              file={file}
+              onDownload={downloadDocument}
+              onDelete={deleteDocument}
+            />
+          }
         />
       ))}
       {creating?.parentFolderId === folder.folderId && (
@@ -584,7 +608,13 @@ export const DocumentTree = ({ parentType, parentID }) => {
             <TreeItem
               key={`doc-${file.documentId}`}
               itemId={`doc-${file.documentId}`}
-              label={<FileLabel file={file} onDownload={downloadDocument} />}
+              label={
+                <FileLabel
+                  file={file}
+                  onDownload={downloadDocument}
+                  onDelete={deleteDocument}
+                />
+              }
             />
           ))}
         </SimpleTreeView>
@@ -620,6 +650,8 @@ export const DocumentTree = ({ parentType, parentID }) => {
           {t('initiativeAgreement:folders.empty')}
         </BCTypography>
       )}
+
+      <DeletedItems parentType={parentType} parentID={parentID} />
 
       <BCTypography
         variant="body4"

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DeletedItems.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DeletedItems.test.jsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import axe from 'axe-core'
+import { DeletedItems } from '../DeletedItems'
+import { wrapper } from '@/tests/utils/wrapper'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, vars) => (vars ? `${key} ${JSON.stringify(vars)}` : key)
+  })
+}))
+
+vi.mock('@/utils/formatters', () => ({
+  timezoneFormatter: ({ value }) => (value ? '2026-08-26 09:00' : '')
+}))
+
+const mockDeleted = vi.fn()
+const mockRestore = vi.fn()
+vi.mock('@/hooks/useDocumentFolders', () => ({
+  useDeletedDocuments: () => mockDeleted(),
+  useRestoreDocument: () => ({ mutate: mockRestore })
+}))
+
+const binned = (overrides = {}) => ({
+  documentId: 88,
+  fileName: 'obsolete.pdf',
+  fileSize: 46080,
+  deletedDate: '2026-08-26T09:00:00Z',
+  deletedBy: 'ALZORKIN',
+  deletedByName: 'Alex Zorkin',
+  restoreFolderId: 12,
+  restoreFolderName: 'Permits',
+  ...overrides
+})
+
+describe('DeletedItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleted.mockReturnValue({
+      data: { documents: [binned()], total: 1 }
+    })
+  })
+
+  it('shows the count while collapsed', () => {
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+
+    expect(screen.getByTestId('deleted-items-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('deleted-items-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    // Collapsed by default: the bin is reference, not the main view.
+    expect(screen.queryByTestId('deleted-item-88')).not.toBeVisible()
+  })
+
+  it('lists what was removed, by whom, and where it returns to', () => {
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+
+    const row = screen.getByTestId('deleted-item-88')
+    expect(row).toHaveTextContent('obsolete.pdf')
+    expect(row).toHaveTextContent('Alex Zorkin')
+    expect(row).toHaveTextContent('folders.restoreTo')
+    expect(row).toHaveTextContent('Permits')
+  })
+
+  it('says a file returns to the top level when its folder has gone', () => {
+    mockDeleted.mockReturnValue({
+      data: {
+        documents: [binned({ restoreFolderId: null, restoreFolderName: null })],
+        total: 1
+      }
+    })
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+
+    expect(screen.getByTestId('deleted-item-88')).toHaveTextContent(
+      'folders.restoreToRoot'
+    )
+  })
+
+  it('restores a document', () => {
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+    fireEvent.click(screen.getByTestId('restore-88'))
+
+    expect(mockRestore).toHaveBeenCalledWith(88)
+  })
+
+  it('falls back to the username when no name resolved', () => {
+    mockDeleted.mockReturnValue({
+      data: { documents: [binned({ deletedByName: null })], total: 1 }
+    })
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+
+    expect(screen.getByTestId('deleted-item-88')).toHaveTextContent('ALZORKIN')
+  })
+
+  it('shows an empty bin honestly', () => {
+    mockDeleted.mockReturnValue({ data: { documents: [], total: 0 } })
+    render(<DeletedItems parentType="designatedAction" parentID="9" />, {
+      wrapper
+    })
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+
+    expect(screen.getByTestId('deleted-items-count')).toHaveTextContent('0')
+    expect(
+      screen.getByText('initiativeAgreement:folders.binEmpty')
+    ).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <DeletedItems parentType="designatedAction" parentID="9" />,
+      { wrapper }
+    )
+    fireEvent.click(screen.getByTestId('deleted-items-toggle'))
+
+    const results = await axe.run(container, {
+      rules: {
+        'color-contrast': { enabled: false },
+        region: { enabled: false }
+      }
+    })
+    expect(results.violations.map((v) => v.id)).toEqual([])
+  })
+})

--- a/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
+++ b/frontend/src/views/InitiativeAgreements/components/__tests__/DocumentTree.test.jsx
@@ -14,13 +14,17 @@ const mockUpdate = vi.fn()
 const mockDelete = vi.fn()
 const mockMove = vi.fn()
 const mockUpload = vi.fn()
+const mockSoftDelete = vi.fn()
 vi.mock('@/hooks/useDocumentFolders', () => ({
   useDocumentTree: () => mockTree(),
   useCreateFolder: () => ({ mutate: mockCreate }),
   useUpdateFolder: () => ({ mutate: mockUpdate }),
   useDeleteFolder: () => ({ mutate: mockDelete }),
   useMoveDocuments: () => ({ mutate: mockMove }),
-  useFolderUpload: () => ({ mutate: mockUpload })
+  useFolderUpload: () => ({ mutate: mockUpload }),
+  useSoftDeleteDocument: () => ({ mutate: mockSoftDelete }),
+  useDeletedDocuments: () => ({ data: { documents: [], total: 0 } }),
+  useRestoreDocument: () => ({ mutate: vi.fn() })
 }))
 
 const mockDownload = vi.fn()


### PR DESCRIPTION
## Summary

Phase 1 of the document lifecycle work: **nothing a user removes is destroyed**. Removing a file from a designated action's tree sends it to a bin below the tree, where it stays and can be restored.

Branched off the module epic and self-contained, so it can be deployed on its own with versioning layered on top afterwards. It adds no version tables and no dependency on that work.

### Notes for a reviewer

**The shared delete path is deliberately untouched and never called here.** `delete_file` removes the S3 object along with the row, which is exactly what must not happen when the whole point is that nothing is lost. Folder-enabled parents get their own delete route instead.

**Two nullable columns on the shared `document` table**, and every read gains `deleted_date IS NULL`. That clause is inert for the six other surfaces — none of them has a route that can set the column. Rather than assert that, I ran the surfaces that share the read: **1070 tests pass** across documents, compliance reports, CI applications, charging sites and the IA module.

This does widen a shared table, which the folder layer deliberately did not. The reasoning is in the plan: deletion is a property of the document itself rather than of the folder feature, and a side table would add a join to every document read to buy isolation that the inert filter already gives.

**Restore puts a file back where it came from.** The placement row survives deletion, so the folder is remembered. If that folder has since been removed, the file returns to the top level rather than resurrecting a folder somebody deleted on purpose — and the bin says which will happen before you press restore.

**Deleting an already-deleted file is not an error**, but it does not overwrite who removed it or when. A double-click cannot rewrite the record.

**The endpoint is paginated from the start.** Nothing ever leaves the bin, so this list only grows; the screen does not page yet and will need to long before anyone remembers to add it. Paginating now means that arrives without an API change.

### Decision taken, worth confirming

Deleting and restoring are open to **IA analysts, managers and directors** — the same roles that see the tree. Elsewhere in the portal file deletion is restricted to whoever uploaded the file, which would stop an analyst tidying a colleague's folder. That is question 1 in the plan and still formally open; this is the recommended answer, and narrowing it later is a one-line change.

### Testing

8 new backend tests: the row survives deletion and leaves the tree, the bin lists it with who and when, restore returns it to its folder, restore falls back to the top level when the folder is gone, a second delete does not rewrite the stamp, another action cannot bin this one's document, proponents are refused, and a binned document also disappears from the shared document list. 23 pass in the folder suite. 7 new frontend tests on the bin including an axe check, 102 across the module. Alembic single head; type-check unchanged.

Refs #4925
