### PR TITLE
Fix: Persist priority score - 4796

### DIFF
--- a/backend/lcfs/tests/ci_application/test_ci_application_service.py
+++ b/backend/lcfs/tests/ci_application/test_ci_application_service.py
@@ -2263,7 +2263,7 @@ async def test_request_documentation_enables_upload_for_workflow_roles(
 
 
 @pytest.mark.anyio
-async def test_request_documentation_clears_previous_government_review(
+async def test_request_documentation_resets_review_and_preserves_latest_assessment(
     service, repo, mock_user
 ):
     mock_user.role_names = {RoleEnum.ANALYST}
@@ -2284,8 +2284,8 @@ async def test_request_documentation_clears_previous_government_review(
 
     result = await service.request_documentation(ci, mock_user)
 
-    assert ci.preliminary_risk_assessment is None
-    assert ci.priority_score is None
+    assert ci.preliminary_risk_assessment == "Medium"
+    assert ci.priority_score == 426
     assert ci.verification_1_user_id is None
     assert ci.verification_1_date is None
     assert ci.verification_2_user_id is None
@@ -2430,7 +2430,7 @@ async def test_step5_decision_can_return_recommended_to_submitted(
 
 
 @pytest.mark.anyio
-async def test_request_pathway_changes_clears_previous_government_review(
+async def test_request_pathway_changes_resets_review_and_preserves_assessment(
     service, repo, notification_service, mock_user
 ):
     mock_user.role_names = {RoleEnum.ANALYST}
@@ -2440,10 +2440,6 @@ async def test_request_pathway_changes_clears_previous_government_review(
     ci.priority_score = 511
     ci.verification_1_user_id = 22
     ci.verification_1_date = datetime(2026, 5, 19, tzinfo=timezone.utc)
-    ci.verification_2_user_id = 33
-    ci.verification_2_date = datetime(2026, 5, 20, tzinfo=timezone.utc)
-    ci.verification_2_risk_assessment = "Medium"
-    ci.verification_2_priority_score = 426
     ci.recommendation_user_id = 44
     ci.recommendation_date = datetime(2026, 5, 21, tzinfo=timezone.utc)
     repo.update.side_effect = lambda obj: obj
@@ -2455,8 +2451,8 @@ async def test_request_pathway_changes_clears_previous_government_review(
     assert ci.status_id == 2
     assert ci.ci_application_status.status == "Submitted"
     assert ci.assigned_analyst_id == 12
-    assert ci.preliminary_risk_assessment is None
-    assert ci.priority_score is None
+    assert ci.preliminary_risk_assessment == "High"
+    assert ci.priority_score == 511
     assert ci.verification_1_user_id is None
     assert ci.verification_1_date is None
     assert ci.verification_2_user_id is None

--- a/backend/lcfs/web/api/ci_application/services.py
+++ b/backend/lcfs/web/api/ci_application/services.py
@@ -1967,9 +1967,15 @@ class CIApplicationServices:
                 detail="Workflow actions can only be recorded on Submitted applications.",
             )
 
-    def _clear_government_workflow_review(self, ci_application: CIApplication) -> None:
-        ci_application.preliminary_risk_assessment = None
-        ci_application.priority_score = None
+    def _reset_government_workflow_review(self, ci_application: CIApplication) -> None:
+        if (
+            ci_application.verification_2_risk_assessment is not None
+            or ci_application.verification_2_priority_score is not None
+        ):
+            ci_application.preliminary_risk_assessment = (
+                ci_application.verification_2_risk_assessment
+            )
+            ci_application.priority_score = ci_application.verification_2_priority_score
         ci_application.verification_1_user_id = None
         ci_application.verification_1_date = None
         ci_application.verification_2_user_id = None
@@ -2354,7 +2360,7 @@ class CIApplicationServices:
         self._require_submitted_workflow(ci_application)
 
         requested_at = datetime.now(timezone.utc)
-        self._clear_government_workflow_review(ci_application)
+        self._reset_government_workflow_review(ci_application)
         ci_application.pathway_supplemental_edit_enabled = True
         ci_application.pathway_changes_requested_at = requested_at
         ci_application.pathway_changes_requested_by = user.keycloak_username
@@ -2399,7 +2405,7 @@ class CIApplicationServices:
         self._require_submitted_workflow(ci_application)
 
         requested_at = datetime.now(timezone.utc)
-        self._clear_government_workflow_review(ci_application)
+        self._reset_government_workflow_review(ci_application)
         ci_application.document_upload_enabled = True
         ci_application.document_changes_requested_at = requested_at
         ci_application.document_changes_requested_by = user.keycloak_username

--- a/frontend/src/hooks/__tests__/useCIApplication.test.js
+++ b/frontend/src/hooks/__tests__/useCIApplication.test.js
@@ -360,8 +360,8 @@ describe('useCIApplication hooks', () => {
       )
     })
 
-    it('does not restore a stale PUT when a newer autosave is already queued', async () => {
-      const stale = {
+    it('serializes PUTs so the latest autosave owns the final cache state', async () => {
+      const first = {
         ciApplicationId: 12,
         preliminaryRiskAssessment: 'Low',
         priorityScore: 10
@@ -396,10 +396,9 @@ describe('useCIApplication hooks', () => {
         preliminaryRiskAssessment: 'High',
         priorityScore: 20
       })
-      // Let the second mutate mark itself pending before the first PUT resolves.
       await Promise.resolve()
 
-      resolveFirst({ data: stale })
+      resolveFirst({ data: first })
 
       await waitFor(() => expect(mockPut).toHaveBeenCalledTimes(2))
       expect(mockPut).toHaveBeenLastCalledWith(
@@ -410,9 +409,42 @@ describe('useCIApplication hooks', () => {
         ['ci-application', '12'],
         latest
       )
-      expect(mockSetQueryData).not.toHaveBeenCalledWith(
+      expect(mockSetQueryData).toHaveBeenCalledWith(
         ['ci-application', '12'],
-        stale
+        first
+      )
+    })
+
+    it('continues with the latest queued autosave after an earlier PUT fails', async () => {
+      const latest = {
+        ciApplicationId: 12,
+        preliminaryRiskAssessment: 'High',
+        priorityScore: 20
+      }
+      mockPut
+        .mockRejectedValueOnce(new Error('temporary failure'))
+        .mockResolvedValueOnce({ data: latest })
+
+      const { result } = renderHook(
+        () => useUpdateCIApplicationRiskAssessment(12),
+        { wrapper }
+      )
+
+      result.current.mutate({
+        preliminaryRiskAssessment: 'Low',
+        priorityScore: 10
+      })
+      result.current.mutate({
+        preliminaryRiskAssessment: 'High',
+        priorityScore: 20
+      })
+
+      await waitFor(() => expect(mockPut).toHaveBeenCalledTimes(2))
+      await waitFor(() =>
+        expect(mockSetQueryData).toHaveBeenLastCalledWith(
+          ['ci-application', '12'],
+          latest
+        )
       )
     })
   })

--- a/frontend/src/hooks/useCIApplication.ts
+++ b/frontend/src/hooks/useCIApplication.ts
@@ -361,31 +361,22 @@ export const useUpdateCIApplicationRiskAssessment = (
 ) => {
   const client = useApiService()
   const queryClient = useQueryClient()
-  const inFlightRef = useRef(false)
-  const pendingPayloadRef = useRef<any>(null)
+  const saveQueueRef = useRef<Promise<unknown>>(Promise.resolve())
   const url = apiRoutes.updateCIApplicationRiskAssessment.replace(
     ':ciApplicationId',
     String(ciApplicationId ?? '')
   )
 
   return useMutation({
-    mutationFn: async (payload: any) => {
-      // Keep only the latest payload so a slower earlier PUT cannot win the
-      // cache (or the DB) after a newer autosave has already been queued.
-      pendingPayloadRef.current = payload
-      if (inFlightRef.current) return undefined
-      inFlightRef.current = true
-      let data
-      try {
-        while (pendingPayloadRef.current) {
-          const next = pendingPayloadRef.current
-          pendingPayloadRef.current = null
-          data = (await client.put(url, next)).data
-        }
-      } finally {
-        inFlightRef.current = false
-      }
-      return data
+    mutationFn: (payload: any) => {
+      const request = saveQueueRef.current
+        .catch(() => undefined)
+        .then(async () => (await client.put(url, payload)).data)
+      saveQueueRef.current = request.then(
+        () => undefined,
+        () => undefined
+      )
+      return request
     },
     onSuccess: (data) => {
       if (!data?.ciApplicationId) return

--- a/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
+++ b/frontend/src/views/CarbonIntensity/__tests__/GovernmentDecisionStep.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -23,6 +24,7 @@ const mockRecommendToDirector = vi.fn().mockResolvedValue(null)
 const mockRequestPathwayChanges = vi.fn().mockResolvedValue(null)
 const mockRequestDocumentation = vi.fn().mockResolvedValue(null)
 const mockGenerateFuelCodes = vi.fn().mockResolvedValue(null)
+const mockSaveRiskAssessmentDraft = vi.fn().mockResolvedValue(null)
 
 vi.mock('@/hooks/useCIApplication', () => ({
   useCompleteCIApplicationVerification1: vi.fn(() => ({
@@ -54,7 +56,7 @@ vi.mock('@/hooks/useCIApplication', () => ({
     isPending: false
   })),
   useUpdateCIApplicationRiskAssessment: vi.fn(() => ({
-    mutate: vi.fn(),
+    mutateAsync: mockSaveRiskAssessmentDraft,
     isPending: false
   }))
 }))
@@ -88,13 +90,23 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 import { GovernmentDecisionStep } from '@/views/CarbonIntensity/components/GovernmentDecisionStep'
 
 const baseCi = { ciApplicationId: 10, status: { status: 'Submitted' } }
+const renderAnalystDecision = (ciApplication = baseCi) => {
+  mockUserRoles = [{ name: roles.analyst }]
+  return render(
+    <GovernmentDecisionStep ciApplication={ciApplication} isGovernment />,
+    { wrapper }
+  )
+}
 
 describe('GovernmentDecisionStep', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUserRoles = [{ name: roles.ci_applicant }]
   })
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
 
   it('renders the shared Comments widget targeting this CI application', () => {
     render(<GovernmentDecisionStep ciApplication={baseCi} />, { wrapper })
@@ -185,6 +197,49 @@ describe('GovernmentDecisionStep', () => {
 
     fireEvent.change(input, { target: { value: '12.5' } })
     expect(input).toHaveValue('999')
+  })
+
+  it('rehydrates the editable Verification 2 values after refresh', () => {
+    renderAnalystDecision({
+      ...baseCi,
+      preliminaryRiskAssessment: 'Medium',
+      priorityScore: 100,
+      verification1Date: '2026-05-19T12:00:00Z',
+      verification2RiskAssessment: 'High',
+      verification2PriorityScore: 200
+    })
+
+    expect(screen.getByTestId('ci-priority-score-input')).toHaveValue('200')
+    expect(screen.getByRole('radio', { name: 'High' })).toBeChecked()
+  })
+
+  it('auto-saves a changed assessment after the debounce', async () => {
+    vi.useFakeTimers()
+    renderAnalystDecision()
+
+    fireEvent.change(screen.getByTestId('ci-priority-score-input'), {
+      target: { value: '200' }
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(600))
+
+    expect(mockSaveRiskAssessmentDraft).toHaveBeenCalledWith({
+      preliminaryRiskAssessment: 'Low',
+      priorityScore: 200
+    })
+  })
+
+  it('flushes a changed assessment when navigating away before the debounce', () => {
+    const { unmount } = renderAnalystDecision()
+
+    fireEvent.change(screen.getByTestId('ci-priority-score-input'), {
+      target: { value: '200' }
+    })
+    unmount()
+
+    expect(mockSaveRiskAssessmentDraft).toHaveBeenCalledWith({
+      preliminaryRiskAssessment: 'Low',
+      priorityScore: 200
+    })
   })
 
   it.each([
@@ -613,14 +668,14 @@ describe('GovernmentDecisionStep', () => {
       within(modal).getByText('carbonIntensity:step5.requestPathwayChanges')
     )
 
+    await waitFor(() =>
+      expect(mockRequestPathwayChanges).toHaveBeenCalledTimes(1)
+    )
     expect(screen.getByTestId('ci-request-pathway-changes-btn')).toBeDisabled()
     expect(
       screen.getByTestId('ci-request-documentation-btn')
     ).not.toBeDisabled()
     expect(onSupplierRequest).toHaveBeenCalledWith('pathwayChanges')
-    await waitFor(() =>
-      expect(mockRequestPathwayChanges).toHaveBeenCalledTimes(1)
-    )
     expect(mockRecordDecision).not.toHaveBeenCalled()
   })
 
@@ -747,6 +802,41 @@ describe('GovernmentDecisionStep', () => {
     )
     expect(onSupplierRequest).toHaveBeenCalledWith('documentation')
     expect(screen.getByTestId('ci-request-documentation-btn')).toBeDisabled()
+  })
+
+  it('persists the latest assessment before requesting documentation', async () => {
+    let resolveSave
+    mockSaveRiskAssessmentDraft.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    renderAnalystDecision()
+
+    fireEvent.change(screen.getByTestId('ci-priority-score-input'), {
+      target: { value: '200' }
+    })
+    fireEvent.click(screen.getByTestId('ci-request-documentation-btn'))
+    fireEvent.click(
+      within(screen.getByTestId('modal')).getByText(
+        'carbonIntensity:step5.requestDocumentation'
+      )
+    )
+
+    await waitFor(() =>
+      expect(mockSaveRiskAssessmentDraft).toHaveBeenCalledWith({
+        preliminaryRiskAssessment: 'Low',
+        priorityScore: 200
+      })
+    )
+    expect(mockRequestDocumentation).not.toHaveBeenCalled()
+
+    await act(async () => resolveSave(null))
+
+    await waitFor(() =>
+      expect(mockRequestDocumentation).toHaveBeenCalledTimes(1)
+    )
   })
 
   it('can render only the decision panel for the submitted application page layout', () => {

--- a/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
+++ b/frontend/src/views/CarbonIntensity/components/GovernmentDecisionStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
@@ -43,6 +43,9 @@ type GovernmentDecisionStepProps = {
   showCommentsTitle?: boolean
 }
 
+const normalizeRisk = (risk?: string | null) =>
+  risk === 'Moderate' ? 'Medium' : risk
+
 export const GovernmentDecisionStep = ({
   ciApplication,
   isGovernment = false,
@@ -75,7 +78,7 @@ export const GovernmentDecisionStep = ({
   } = useRequestCIApplicationDocumentation(ciApplicationId)
   const { mutateAsync: generateFuelCodes, isPending: isGeneratingFuelCodes } =
     useGenerateCIApplicationFuelCodes(ciApplicationId)
-  const { mutate: saveRiskAssessmentDraft } =
+  const { mutateAsync: saveRiskAssessmentDraft } =
     useUpdateCIApplicationRiskAssessment(ciApplicationId)
 
   const [error, setError] = useState<string | null>(null)
@@ -88,11 +91,22 @@ export const GovernmentDecisionStep = ({
   const isRecommended = status === 'Recommended'
   const isSubmitted = status === 'Submitted'
   const isWithdrawn = status === 'Withdrawn'
+  const preliminaryRisk = normalizeRisk(
+    ciApplication?.preliminaryRiskAssessment
+  )
+  const verification2Risk = normalizeRisk(
+    ciApplication?.verification2RiskAssessment
+  )
+  const hasVerification2Draft =
+    ciApplication?.verification2RiskAssessment != null ||
+    ciApplication?.verification2PriorityScore != null
   const [riskAssessment, setRiskAssessment] = useState(
-    ciApplication?.preliminaryRiskAssessment || 'Low'
+    verification2Risk || preliminaryRisk || 'Low'
   )
   const [priorityScore, setPriorityScore] = useState(
-    ciApplication?.priorityScore || ''
+    hasVerification2Draft
+      ? (ciApplication?.verification2PriorityScore ?? '')
+      : (ciApplication?.priorityScore ?? '')
   )
   const [requestedPathwayChanges, setRequestedPathwayChanges] = useState(false)
   const [requestedDocumentation, setRequestedDocumentation] = useState(false)
@@ -122,9 +136,6 @@ export const GovernmentDecisionStep = ({
     !isPriorityScoreValid
       ? t('carbonIntensity:step5.priorityScoreInvalid')
       : null
-
-  const normalizeRisk = (risk?: string | null) =>
-    risk === 'Moderate' ? 'Medium' : risk
 
   // The radio group stores 'Medium' but labels it "Moderate"; legacy rows may
   // already hold 'Moderate'. Keep the read-only text using the same wording.
@@ -192,12 +203,6 @@ export const GovernmentDecisionStep = ({
     }
   }
 
-  const preliminaryRisk = normalizeRisk(
-    ciApplication?.preliminaryRiskAssessment
-  )
-  const verification2Risk = normalizeRisk(
-    ciApplication?.verification2RiskAssessment
-  )
   // Medium and High risk applications both go through Verification 2; only Low
   // risk completes after Verification 1. Keeping Medium here also keeps the
   // Risk Assessment / Priority Score fields visible, since they render inside
@@ -267,33 +272,67 @@ export const GovernmentDecisionStep = ({
 
   const canEditRiskAssessment =
     !readOnly && (showVerification1Panel || showVerification2Panel)
-  const isFirstRiskAssessmentRender = useRef(true)
-  useEffect(() => {
-    if (!canEditRiskAssessment) return
-    if (isFirstRiskAssessmentRender.current) {
-      isFirstRiskAssessmentRender.current = false
-      return
-    }
-    const timeoutId = setTimeout(() => {
-      saveRiskAssessmentDraft(
-        {
-          preliminaryRiskAssessment: riskAssessment,
-          priorityScore: isPriorityScoreValid ? priorityScoreNumber : null
-        },
-        {
-          onError: (err: any) => {
-            setError(
-              err?.response?.data?.detail ||
-                err?.message ||
-                'Failed to save risk assessment.'
-            )
-          }
-        }
+  const currentRiskAssessmentDraft = {
+    preliminaryRiskAssessment: riskAssessment,
+    priorityScore: isPriorityScoreValid ? priorityScoreNumber : null
+  }
+  const riskAssessmentAutosaveRef = useRef({
+    draft: currentRiskAssessmentDraft,
+    dirty: false,
+    enabled: canEditRiskAssessment,
+    save: saveRiskAssessmentDraft,
+    pending: Promise.resolve()
+  })
+  Object.assign(riskAssessmentAutosaveRef.current, {
+    draft: currentRiskAssessmentDraft,
+    enabled: canEditRiskAssessment,
+    save: saveRiskAssessmentDraft
+  })
+
+  const persistRiskAssessmentDraft = useCallback(async () => {
+    const state = riskAssessmentAutosaveRef.current
+    if (!state.enabled) return
+    if (!state.dirty) return state.pending
+
+    state.dirty = false
+    const request = state.save(state.draft)
+    state.pending = request
+    try {
+      await request
+    } catch (err: any) {
+      if (state.pending === request) state.dirty = true
+      setError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          'Failed to save risk assessment.'
       )
+      throw err
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!canEditRiskAssessment || !riskAssessmentAutosaveRef.current.dirty)
+      return
+    const timeout = setTimeout(() => {
+      void persistRiskAssessmentDraft().catch(() => undefined)
     }, 600)
-    return () => clearTimeout(timeoutId)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [riskAssessment, priorityScore, canEditRiskAssessment])
+    return () => clearTimeout(timeout)
+  }, [
+    canEditRiskAssessment,
+    priorityScore,
+    persistRiskAssessmentDraft,
+    riskAssessment
+  ])
+
+  useEffect(
+    () => () => {
+      const state = riskAssessmentAutosaveRef.current
+      if (state.enabled && state.dirty) {
+        void state.save(state.draft).catch(() => undefined)
+      }
+    },
+    []
+  )
 
   const workflowButtonSx = {
     minHeight: 44,
@@ -316,10 +355,10 @@ export const GovernmentDecisionStep = ({
     setIsRequestDocumentationConfirmOpen(false)
     setRequestedDocumentation(true)
     onSupplierRequest?.('documentation')
-    recordWorkflowAction(
-      () => requestDocumentation(),
-      t('carbonIntensity:step5.workflowSuccess')
-    )
+    recordWorkflowAction(async () => {
+      await persistRiskAssessmentDraft()
+      return requestDocumentation()
+    }, t('carbonIntensity:step5.workflowSuccess'))
   }
 
   const handleRequestPathwayChanges = () => {
@@ -333,10 +372,10 @@ export const GovernmentDecisionStep = ({
     setIsRequestPathwayChangesConfirmOpen(false)
     setRequestedPathwayChanges(true)
     onSupplierRequest?.('pathwayChanges')
-    recordWorkflowAction(
-      () => requestPathwayChanges(),
-      t('carbonIntensity:step5.workflowSuccess')
-    )
+    recordWorkflowAction(async () => {
+      await persistRiskAssessmentDraft()
+      return requestPathwayChanges()
+    }, t('carbonIntensity:step5.workflowSuccess'))
   }
 
   const requireValidPriorityScore = () => {
@@ -352,28 +391,26 @@ export const GovernmentDecisionStep = ({
     const validPriorityScore = requireValidPriorityScore()
     if (validPriorityScore === null) return
 
-    recordWorkflowAction(
-      () =>
-        completeVerification1({
-          preliminaryRiskAssessment: riskAssessment,
-          priorityScore: validPriorityScore
-        } as any),
-      t('carbonIntensity:step5.workflowSuccess')
-    )
+    recordWorkflowAction(async () => {
+      await persistRiskAssessmentDraft()
+      return completeVerification1({
+        preliminaryRiskAssessment: riskAssessment,
+        priorityScore: validPriorityScore
+      } as any)
+    }, t('carbonIntensity:step5.workflowSuccess'))
   }
 
   const handleCompleteVerification2 = () => {
     const validPriorityScore = requireValidPriorityScore()
     if (validPriorityScore === null) return
 
-    recordWorkflowAction(
-      () =>
-        completeVerification2({
-          preliminaryRiskAssessment: riskAssessment,
-          priorityScore: validPriorityScore
-        } as any),
-      t('carbonIntensity:step5.workflowSuccess')
-    )
+    recordWorkflowAction(async () => {
+      await persistRiskAssessmentDraft()
+      return completeVerification2({
+        preliminaryRiskAssessment: riskAssessment,
+        priorityScore: validPriorityScore
+      } as any)
+    }, t('carbonIntensity:step5.workflowSuccess'))
   }
 
   return (
@@ -434,9 +471,10 @@ export const GovernmentDecisionStep = ({
                     <RadioGroup
                       row
                       value={riskAssessment}
-                      onChange={(event) =>
+                      onChange={(event) => {
+                        riskAssessmentAutosaveRef.current.dirty = true
                         setRiskAssessment(event.target.value)
-                      }
+                      }}
                     >
                       <FormControlLabel
                         labelPlacement="start"
@@ -480,10 +518,16 @@ export const GovernmentDecisionStep = ({
                         }}
                         value={priorityScore}
                         error={!!priorityScoreError}
-                        onBlur={() => setPriorityScoreTouched(true)}
+                        onBlur={() => {
+                          setPriorityScoreTouched(true)
+                          void persistRiskAssessmentDraft().catch(
+                            () => undefined
+                          )
+                        }}
                         onChange={(event) => {
                           const nextValue = event.target.value
                           if (!/^\d*$/.test(nextValue)) return
+                          riskAssessmentAutosaveRef.current.dirty = true
                           if (nextValue === '') {
                             setPriorityScore('')
                             return


### PR DESCRIPTION
This PR ensures priority scores remain saved correctly. Closes #4796

Please refer to the issue reported by the Product Owner.
> This still isn't autosaving the way we had hoped in Test. In dev, it is working to a certain extent, but still reverts back to the originally saved priority score and risk assessment if I leave the page or refresh. I think we are hoping that it will auto save in the UI on entry and within the breadcrumb area of what stage the application is at. In dev, it looks like this if I navigate away from the page after changing the priority score to 200 and refresh

<img width="1866" height="650" alt="image" src="https://github.com/user-attachments/assets/0c152000-01da-41f7-b5c6-11c625fdb416" />