### PR TITLE
Feat: Add global search

### DIFF
--- a/backend/lcfs/tests/search/test_entities.py
+++ b/backend/lcfs/tests/search/test_entities.py
@@ -1,0 +1,48 @@
+from lcfs.web.api.search.entities import SEARCH_ENTITIES
+from lcfs.web.api.search.entities.base import SearchContext
+from lcfs.web.api.search.query import parse_query
+
+
+def test_entity_registry_has_stable_unique_order():
+    assert tuple(entity.entity_type for entity in SEARCH_ENTITIES) == (
+        "organization",
+        "report",
+        "transfer",
+        "fuel_code",
+        "ci_application",
+        "initiative_agreement",
+        "admin_adjustment",
+        "user",
+    )
+    assert len({entity.entity_type for entity in SEARCH_ENTITIES}) == len(
+        SEARCH_ENTITIES
+    )
+
+
+def test_every_entity_is_implemented_in_its_own_module():
+    modules = {entity.handler.__module__ for entity in SEARCH_ENTITIES}
+
+    assert len(modules) == len(SEARCH_ENTITIES)
+    assert all(module.startswith("lcfs.web.api.search.entities.") for module in modules)
+
+
+def test_every_registry_entry_has_user_facing_metadata():
+    assert all(entity.entity_type and entity.label for entity in SEARCH_ENTITIES)
+
+
+def test_unbound_supplier_cannot_access_organization_records():
+    context = SearchContext(
+        query=parse_query("transfers"),
+        organization_id=None,
+        is_government=False,
+    )
+
+    assert not context.can_access_organization_records
+
+
+def test_government_and_bound_supplier_can_access_organization_records():
+    government = SearchContext(parse_query("transfers"), None, True)
+    supplier = SearchContext(parse_query("transfers"), 7, False)
+
+    assert government.can_access_organization_records
+    assert supplier.can_access_organization_records

--- a/backend/lcfs/tests/search/test_entity_authorization.py
+++ b/backend/lcfs/tests/search/test_entity_authorization.py
@@ -1,0 +1,118 @@
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.web.api.search.entities import SEARCH_ENTITIES
+from lcfs.web.api.search.entities.base import EntitySearch, SearchContext
+from lcfs.web.api.search.query import parse_query
+
+_ENTITIES = {entity.entity_type: entity for entity in SEARCH_ENTITIES}
+
+
+def _db_without_rows() -> AsyncMock:
+    result = MagicMock()
+    result.all.return_value = []
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = result
+    return db
+
+
+def _supplier_context(
+    entity_type: str,
+    organization_id: Optional[int],
+) -> SearchContext:
+    return SearchContext(
+        query=parse_query(entity_type),
+        organization_id=organization_id,
+        is_government=False,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "entity",
+    [
+        _ENTITIES["report"],
+        _ENTITIES["transfer"],
+        _ENTITIES["ci_application"],
+        _ENTITIES["initiative_agreement"],
+        _ENTITIES["admin_adjustment"],
+        _ENTITIES["user"],
+    ],
+    ids=lambda entity: entity.entity_type,
+)
+async def test_unbound_supplier_never_reaches_scoped_queries(entity: EntitySearch):
+    db = _db_without_rows()
+
+    results = await entity.execute(db, _supplier_context(entity.entity_type, None))
+
+    assert results == []
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_organization_search_is_government_only():
+    db = _db_without_rows()
+
+    results = await _ENTITIES["organization"].execute(
+        db,
+        _supplier_context("organization", 17),
+    )
+
+    assert results == []
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("entity_type", "expected_scope"),
+    [
+        ("report", "v_compliance_report.organization_id = 17"),
+        ("ci_application", "ci_application.organization_id = 17"),
+        (
+            "initiative_agreement",
+            "initiative_agreement.to_organization_id = 17",
+        ),
+        ("admin_adjustment", "admin_adjustment.to_organization_id = 17"),
+        ("user", "user_profile.organization_id = 17"),
+    ],
+)
+async def test_supplier_queries_include_organization_scope(
+    entity_type: str,
+    expected_scope: str,
+):
+    db = _db_without_rows()
+
+    await _ENTITIES[entity_type].execute(db, _supplier_context(entity_type, 17))
+
+    statement = db.execute.await_args.args[0]
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        ),
+    )
+    assert expected_scope in sql
+
+
+@pytest.mark.anyio
+async def test_supplier_transfer_scope_includes_both_participants():
+    db = _db_without_rows()
+
+    await _ENTITIES["transfer"].execute(
+        db,
+        _supplier_context("transfer", 17),
+    )
+
+    statement = db.execute.await_args.args[0]
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        ),
+    )
+    assert "transfer.from_organization_id = 17" in sql
+    assert "transfer.to_organization_id = 17" in sql

--- a/backend/lcfs/tests/search/test_entity_results.py
+++ b/backend/lcfs/tests/search/test_entity_results.py
@@ -1,0 +1,261 @@
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.admin_adjustment.AdminAdjustmentStatus import (
+    AdminAdjustmentStatusEnum,
+)
+from lcfs.db.models.initiative_agreement.InitiativeAgreementStatus import (
+    InitiativeAgreementStatusEnum,
+)
+from lcfs.db.models.transfer.TransferStatus import TransferStatusEnum
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.web.api.search.entities.admin_adjustments import search_admin_adjustments
+from lcfs.web.api.search.entities.base import SearchContext
+from lcfs.web.api.search.entities.fuel_codes import (
+    FUEL_CODE_RESULT_LIMIT,
+    search_fuel_codes,
+)
+from lcfs.web.api.search.entities.initiative_agreements import (
+    search_initiative_agreements,
+)
+from lcfs.web.api.search.entities.transfers import search_transfers
+from lcfs.web.api.search.entities.users import search_users
+from lcfs.web.api.search.query import parse_query
+
+
+def _db_returning(*rows) -> AsyncMock:
+    result = MagicMock()
+    result.all.return_value = list(rows)
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = result
+    return db
+
+
+def _context(query: str, *, organization_id: int = 17) -> SearchContext:
+    return SearchContext(
+        query=parse_query(query),
+        organization_id=organization_id,
+        is_government=False,
+    )
+
+
+def _executed_sql(db: AsyncMock) -> str:
+    statement = db.execute.await_args.args[0]
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_supplier_user_result_keeps_organization_context():
+    user = UserProfile(
+        user_profile_id=4,
+        keycloak_username="jsmith",
+        first_name="Jordan",
+        last_name="Smith",
+        email="jordan@example.com",
+        title="Compliance manager",
+        organization_id=17,
+        is_active=True,
+    )
+    db = _db_returning((user, "Example Fuels", None))
+
+    results = await search_users(db, _context("user"))
+
+    assert len(results) == 1
+    assert results[0].route == "/organization/users/4"
+    assert results[0].meta == "Compliance manager · Example Fuels"
+    assert [(detail.label, detail.value) for detail in results[0].details] == [
+        ("Email", "jordan@example.com"),
+        ("Title", "Compliance manager"),
+        ("Organization", "Example Fuels"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_fuel_code_result_exposes_professional_labelled_details():
+    fuel_code = SimpleNamespace(
+        fuel_code_id=42,
+        prefix="PROXY",
+        fuel_suffix="42.1",
+        company="Example Fuels",
+        fuel_type="HDRD",
+        carbon_intensity=12.58,
+        feedstock="Yellow grease",
+        fuel_production_facility_city="Prince George",
+        status="Approved",
+    )
+    db = _db_returning((fuel_code, "Facility city: Prince George"))
+
+    results = await search_fuel_codes(db, _context("prin"))
+
+    assert len(results) == 1
+    assert results[0].title == "PROXY42.1"
+    assert results[0].route == "/fuel-codes/42/view"
+    assert results[0].match_context == "Facility city: Prince George"
+    assert [(detail.label, detail.value) for detail in results[0].details] == [
+        ("Company", "Example Fuels"),
+        ("Fuel type", "HDRD"),
+        ("Carbon intensity", "12.58"),
+        ("Feedstock", "Yellow grease"),
+        ("Facility", "Prince George"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_bceid_fuel_code_search_includes_owned_and_all_approved_records():
+    db = _db_returning()
+
+    await search_fuel_codes(db, _context("fuel_code", organization_id=17))
+
+    sql = _executed_sql(db)
+    assert "fuel_code.organization_id = 17" in sql
+    assert "CAST(vw_fuel_code_base.status AS VARCHAR) = 'Approved'" in sql
+    assert " OR " in sql
+    where_clause = sql.split("WHERE", maxsplit=1)[1]
+    assert "effective_date <" not in where_clause
+    assert "expiration_date >" not in where_clause
+
+
+@pytest.mark.anyio
+async def test_bceid_without_an_organization_only_sees_approved_records():
+    db = _db_returning()
+    context = SearchContext(
+        query=parse_query("fuel_code"),
+        organization_id=None,
+        is_government=False,
+    )
+
+    await search_fuel_codes(db, context)
+
+    sql = _executed_sql(db)
+    assert "CAST(vw_fuel_code_base.status AS VARCHAR) = 'Approved'" in sql
+    assert "fuel_code.organization_id" not in sql
+
+
+@pytest.mark.anyio
+async def test_idir_fuel_code_search_remains_unscoped():
+    db = _db_returning()
+    context = SearchContext(
+        query=parse_query("fuel_code"),
+        organization_id=None,
+        is_government=True,
+    )
+
+    await search_fuel_codes(db, context)
+
+    sql = _executed_sql(db)
+    assert "CAST(vw_fuel_code_base.status AS VARCHAR) = 'Approved'" not in sql
+    assert "fuel_code.organization_id" not in sql
+
+
+@pytest.mark.anyio
+async def test_fuel_code_search_supports_large_company_result_sets():
+    db = _db_returning()
+
+    await search_fuel_codes(db, _context("company"))
+
+    assert FUEL_CODE_RESULT_LIMIT == 100
+    assert f"LIMIT {FUEL_CODE_RESULT_LIMIT}" in _executed_sql(db)
+
+
+@pytest.mark.anyio
+async def test_transfer_result_formats_quantities_prices_and_dates():
+    transfer = SimpleNamespace(
+        transfer_id=7,
+        from_name="Supplier A",
+        to_name="Supplier B",
+        status=TransferStatusEnum.Draft,
+        quantity=1_250,
+        price_per_unit=3.5,
+        agreement_date=date(2026, 8, 27),
+        match_context=None,
+    )
+    db = _db_returning(transfer)
+
+    results = await search_transfers(db, _context("transfer"))
+
+    assert len(results) == 1
+    assert results[0].title == "Supplier A → Supplier B"
+    assert results[0].status == "Draft"
+    assert results[0].meta == "1,250 units · $3.50/unit · 2026-08-27"
+    assert [(detail.label, detail.value) for detail in results[0].details] == [
+        ("Transfer ID", "7"),
+        ("Quantity", "1,250 units"),
+        ("Unit price", "$3.50"),
+        ("Agreement date", "2026-08-27"),
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("is_government", "expected_route"),
+    [
+        (True, "/initiative-agreement/42"),
+        (False, "/org-initiative-agreement/42"),
+    ],
+)
+async def test_initiative_agreement_link_uses_entity_id(
+    is_government: bool,
+    expected_route: str,
+):
+    agreement = SimpleNamespace(
+        initiative_agreement_id=42,
+        compliance_units=1_500,
+        org_name="Example Fuels",
+        status=InitiativeAgreementStatusEnum.Draft,
+        match_context=None,
+    )
+    db = _db_returning(agreement)
+    context = SearchContext(
+        query=parse_query("initiative_agreement"),
+        organization_id=None if is_government else 17,
+        is_government=is_government,
+    )
+
+    results = await search_initiative_agreements(db, context)
+
+    assert len(results) == 1
+    assert results[0].entity_id == 42
+    assert results[0].route == expected_route
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("is_government", "expected_route"),
+    [
+        (True, "/admin-adjustment/24"),
+        (False, "/org-admin-adjustment/24"),
+    ],
+)
+async def test_admin_adjustment_link_uses_entity_id(
+    is_government: bool,
+    expected_route: str,
+):
+    adjustment = SimpleNamespace(
+        admin_adjustment_id=24,
+        compliance_units=750,
+        org_name="Example Fuels",
+        status=AdminAdjustmentStatusEnum.Draft,
+        match_context=None,
+    )
+    db = _db_returning(adjustment)
+    context = SearchContext(
+        query=parse_query("admin_adjustment"),
+        organization_id=None if is_government else 17,
+        is_government=is_government,
+    )
+
+    results = await search_admin_adjustments(db, context)
+
+    assert len(results) == 1
+    assert results[0].entity_id == 24
+    assert results[0].route == expected_route

--- a/backend/lcfs/tests/search/test_matching.py
+++ b/backend/lcfs/tests/search/test_matching.py
@@ -1,0 +1,123 @@
+from sqlalchemy import column
+from sqlalchemy.dialects import postgresql
+
+from lcfs.web.api.search.matching import (
+    SearchField,
+    _base_match,
+    _escape_like,
+    _match_excerpt,
+    applies,
+    contains_any,
+    contains_any_field,
+    date_years,
+    equals_any,
+    ids_filter,
+    search_clause,
+)
+from lcfs.web.api.search.query import parse_query
+
+
+def _sql(expression) -> str:
+    return str(
+        expression.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_date_year_filter_uses_index_friendly_ranges():
+    sql = _sql(date_years(column("created_at"), ("2023", "2024")))
+
+    assert "to_char" not in sql
+    assert "created_at >= '2023-01-01'" in sql
+    assert "created_at < '2024-01-01'" in sql
+    assert "created_at >= '2024-01-01'" in sql
+    assert "created_at < '2025-01-01'" in sql
+
+
+def test_malformed_explicit_id_matches_nothing():
+    assert _sql(ids_filter(column("record_id"), ("not-a-number",))) == "false"
+
+
+def test_out_of_range_explicit_id_matches_nothing():
+    assert _sql(ids_filter(column("record_id"), ("99999999999999999999",))) == "false"
+
+
+def test_status_filter_is_exact_not_a_substring():
+    sql = _sql(equals_any(column("status"), ("active", "draft")))
+
+    assert "lower(CAST(status AS VARCHAR)) IN ('active', 'draft')" == sql
+
+
+def test_malformed_year_matches_nothing():
+    assert _sql(date_years(column("created_at"), ("9999",))) == "false"
+
+
+def test_like_wildcards_from_user_input_are_escaped():
+    sql = _sql(contains_any(column("name"), ("100%", "A_B")))
+
+    assert _escape_like("100%_complete") == r"100\%\_complete"
+    assert "ESCAPE" in sql
+
+
+def test_search_clause_combines_terms_and_requires_primary_context():
+    query = parse_query("parkland vancouver")
+    clause, score = search_clause(
+        [
+            SearchField("Name", column("name"), primary=True, fuzzy=True),
+            SearchField("City", column("city")),
+        ],
+        query,
+    )
+    sql = _sql(clause)
+
+    assert score is not None
+    assert "parkland" in sql
+    assert "vancouver" in sql
+    assert "name" in sql
+    assert "city" in sql
+
+
+def test_short_partial_word_matches_from_the_start_of_a_word():
+    sql = _sql(_base_match(column("city"), "prin"))
+
+    assert r"\mprin" in sql
+    assert r"\M" not in sql
+
+
+def test_short_partial_word_escapes_regex_metacharacters():
+    expression = _base_match(column("code"), "b.c")
+
+    assert expression.right.value == r"\mb\.c"
+
+
+def test_longer_partial_word_uses_case_insensitive_substring_matching():
+    sql = _sql(_base_match(column("city"), "georg"))
+
+    assert "ILIKE '%%georg%%'" in sql
+
+
+def test_match_excerpt_fallback_contains_only_the_stored_value():
+    sql = _sql(_match_excerpt(column("name"), "bc"))
+
+    assert "bc —" not in sql
+    assert "substr(CAST(name AS VARCHAR), 1, 100)" in sql
+
+
+def test_contains_any_field_returns_none_when_no_values_are_supplied():
+    assert contains_any_field((column("name"), column("city")), ()) is None
+
+
+def test_entity_must_support_every_combined_filter():
+    query = parse_query("approved 2023")
+
+    assert applies(query, {"status", "year"}, "fuel_code")
+    assert not applies(query, {"status", "org"}, "transfer")
+
+
+def test_entity_type_restricts_results_without_becoming_a_data_filter():
+    query = parse_query("active users")
+
+    assert applies(query, {"status", "org", "user_type", "id"}, "user")
+    assert not applies(query, {"status", "city", "org", "id"}, "organization")

--- a/backend/lcfs/tests/search/test_query.py
+++ b/backend/lcfs/tests/search/test_query.py
@@ -1,0 +1,109 @@
+import pytest
+
+from lcfs.web.api.search.query import parse_query
+
+
+def test_combines_free_text_with_multiple_inferred_filters():
+    query = parse_query("parkland 2023 assessed")
+
+    assert query.text == "parkland"
+    assert query.terms == ("parkland",)
+    assert query.values("year") == ("2023",)
+    assert query.values("status") == ("assessed",)
+    assert query.entities == ()
+
+
+def test_repeated_filter_values_are_retained_and_deduplicated():
+    query = parse_query("draft submitted DRAFT 2023 2024")
+
+    assert query.values("status") == ("draft", "submitted")
+    assert query.values("year") == ("2023", "2024")
+    assert query.applied_filters == {
+        "status": "draft, submitted",
+        "year": "2023, 2024",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw", "entity", "filters"),
+    [
+        ("draft transfers", "transfer", {"status": ("draft",)}),
+        ("fuel codes", "fuel_code", {}),
+        ("ci applications", "ci_application", {}),
+        ("idir users", "user", {"user_type": ("idir",)}),
+    ],
+)
+def test_infers_entity_and_common_natural_language_filters(raw, entity, filters):
+    query = parse_query(raw)
+
+    assert query.entities == (entity,)
+    assert query.text == ""
+    for name, values in filters.items():
+        assert query.values(name) == values
+
+
+def test_every_canonical_entity_key_is_recognized_as_bare_text():
+    canonical_types = (
+        "organization",
+        "report",
+        "transfer",
+        "fuel_code",
+        "ci_application",
+        "initiative_agreement",
+        "admin_adjustment",
+        "user",
+    )
+
+    for entity_type in canonical_types:
+        assert parse_query(entity_type).entities == (entity_type,)
+
+
+def test_common_filter_value_spelling_is_normalized():
+    assert parse_query("cancelled transfers").values("status") == ("canceled",)
+
+
+def test_multiple_inferred_values_keep_repeated_filter_semantics():
+    query = parse_query("draft submitted 2023 2024 transfers")
+
+    assert query.entities == ("transfer",)
+    assert query.values("status") == ("draft", "submitted")
+    assert query.values("year") == ("2023", "2024")
+    assert query.terms == ()
+
+
+def test_unknown_filter_is_regular_search_text():
+    query = parse_query("parkland made_up:value")
+
+    assert query.terms == ("parkland", "made_up:value")
+    assert query.filters == {}
+
+
+def test_unfinished_quote_never_breaks_search_while_user_is_typing():
+    query = parse_query('"Parkland Fuels')
+
+    assert query.terms == ("Parkland Fuels",)
+
+
+def test_context_terms_are_case_insensitively_deduplicated():
+    query = parse_query("Parkland parkland 2023")
+
+    assert query.context_terms == ("parkland", "2023")
+
+
+@pytest.mark.parametrize("raw", ["", " ", "a"])
+def test_empty_or_too_short_search_is_empty(raw):
+    assert parse_query(raw).is_empty
+
+
+def test_bare_numeric_query_is_an_exact_id_candidate():
+    query = parse_query("42")
+
+    assert query.is_id_only
+    assert query.numeric_id == 42
+
+
+def test_out_of_range_numeric_query_cannot_reach_integer_database_columns():
+    query = parse_query("99999999999999999999")
+
+    assert query.is_id_only
+    assert query.numeric_id is None

--- a/backend/lcfs/tests/search/test_services.py
+++ b/backend/lcfs/tests/search/test_services.py
@@ -1,0 +1,107 @@
+from typing import Optional, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.web.api.search.entities.base import EntitySearch, SearchContext
+from lcfs.web.api.search.schema import SearchResultItem
+from lcfs.web.api.search.services import SearchService
+
+
+def _result(entity_type: str, entity_id: int) -> SearchResultItem:
+    return SearchResultItem(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        title=f"Result {entity_id}",
+        subtitle="",
+        route=f"/{entity_type}/{entity_id}",
+    )
+
+
+def _user(organization_id: Optional[int] = None) -> UserProfile:
+    user = MagicMock(spec=UserProfile)
+    user.organization_id = organization_id
+    return cast(UserProfile, user)
+
+
+@pytest.mark.anyio
+async def test_empty_query_does_not_execute_entity_searches(monkeypatch):
+    handler = AsyncMock(return_value=[_result("organization", 1)])
+    monkeypatch.setattr(
+        "lcfs.web.api.search.services.SEARCH_ENTITIES",
+        (EntitySearch("organization", "Organizations", handler),),
+    )
+    service = SearchService(AsyncMock(spec=AsyncSession))
+
+    response = await service.search("   ", _user())
+
+    assert response.query == "   "
+    assert response.groups == []
+    assert response.total == 0
+    assert response.applied_filters == {}
+    handler.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_search_preserves_registry_order_and_omits_empty_groups(monkeypatch):
+    first_handler = AsyncMock(return_value=[_result("organization", 1)])
+    empty_handler = AsyncMock(return_value=[])
+    last_handler = AsyncMock(return_value=[_result("user", 2), _result("user", 3)])
+    monkeypatch.setattr(
+        "lcfs.web.api.search.services.SEARCH_ENTITIES",
+        (
+            EntitySearch("organization", "Organizations", first_handler),
+            EntitySearch("transfer", "Transfers", empty_handler),
+            EntitySearch("user", "Users", last_handler),
+        ),
+    )
+    monkeypatch.setattr(
+        "lcfs.web.api.search.services.is_government_user", lambda _user: True
+    )
+    db = AsyncMock(spec=AsyncSession)
+    service = SearchService(db)
+
+    response = await service.search("parkland active", _user(42))
+
+    assert [group.entity_type for group in response.groups] == [
+        "organization",
+        "user",
+    ]
+    assert response.total == 3
+    assert response.applied_filters == {"status": "active"}
+    for handler in (first_handler, empty_handler, last_handler):
+        handler.assert_awaited_once()
+        called_db, context = handler.await_args.args
+        assert called_db is db
+        assert isinstance(context, SearchContext)
+        assert context.is_government
+        assert context.organization_id is None
+        assert context.query.text == "parkland"
+
+
+@pytest.mark.anyio
+async def test_supplier_organization_is_propagated_to_every_entity(monkeypatch):
+    contexts: list[SearchContext] = []
+
+    async def capture_context(
+        _db: AsyncSession, context: SearchContext
+    ) -> list[SearchResultItem]:
+        contexts.append(context)
+        return []
+
+    monkeypatch.setattr(
+        "lcfs.web.api.search.services.SEARCH_ENTITIES",
+        (EntitySearch("transfer", "Transfers", capture_context),),
+    )
+    monkeypatch.setattr(
+        "lcfs.web.api.search.services.is_government_user", lambda _user: False
+    )
+    service = SearchService(AsyncMock(spec=AsyncSession))
+
+    await service.search("transfers", _user(17))
+
+    assert len(contexts) == 1
+    assert not contexts[0].is_government
+    assert contexts[0].organization_id == 17

--- a/backend/lcfs/tests/search/test_views.py
+++ b/backend/lcfs/tests/search/test_views.py
@@ -1,0 +1,95 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lcfs.web.api.search.schema import (
+    SearchGroup,
+    SearchResponse,
+    SearchResultDetail,
+    SearchResultItem,
+)
+from lcfs.web.api.search.services import SearchService
+
+
+@pytest.mark.anyio
+async def test_search_endpoint_returns_the_frontend_contract(client, fastapi_app):
+    service = AsyncMock(spec=SearchService)
+    service.search.return_value = SearchResponse(
+        query="prin",
+        groups=[
+            SearchGroup(
+                entity_type="fuel_code",
+                label="Fuel codes",
+                items=[
+                    SearchResultItem(
+                        entity_type="fuel_code",
+                        entity_id=42,
+                        title="PROXY42.1",
+                        subtitle="Example supplier",
+                        route="/fuel-codes/42/view",
+                        details=[
+                            SearchResultDetail(
+                                label="Facility",
+                                value="Prince George",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+        total=1,
+    )
+    fastapi_app.dependency_overrides[SearchService] = lambda: service
+
+    try:
+        response = await client.get("/api/search/", params={"q": "prin"})
+    finally:
+        fastapi_app.dependency_overrides.pop(SearchService, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "query": "prin",
+        "groups": [
+            {
+                "entityType": "fuel_code",
+                "label": "Fuel codes",
+                "items": [
+                    {
+                        "entityType": "fuel_code",
+                        "entityId": 42,
+                        "title": "PROXY42.1",
+                        "subtitle": "Example supplier",
+                        "route": "/fuel-codes/42/view",
+                        "status": None,
+                        "meta": None,
+                        "matchContext": None,
+                        "details": [
+                            {"label": "Facility", "value": "Prince George"},
+                        ],
+                    },
+                ],
+            },
+        ],
+        "total": 1,
+        "appliedFilters": {},
+    }
+    service.search.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_search_endpoint_rejects_queries_outside_length_limits(
+    client,
+    fastapi_app,
+):
+    service = AsyncMock(spec=SearchService)
+    fastapi_app.dependency_overrides[SearchService] = lambda: service
+
+    try:
+        too_short = await client.get("/api/search/", params={"q": "a"})
+        too_long = await client.get("/api/search/", params={"q": "x" * 101})
+    finally:
+        fastapi_app.dependency_overrides.pop(SearchService, None)
+
+    assert too_short.status_code == 422
+    assert too_long.status_code == 422
+    service.search.assert_not_awaited()

--- a/backend/lcfs/web/api/router.py
+++ b/backend/lcfs/web/api/router.py
@@ -40,6 +40,7 @@ from lcfs.web.api import (
     charging_site,
     login_bg_image,
     release_notes,
+    search,
 )
 
 api_router = APIRouter()
@@ -146,3 +147,4 @@ api_router.include_router(
 api_router.include_router(
     release_notes.router, prefix="/release-notes", tags=["release_notes"]
 )
+api_router.include_router(search.router, prefix="/search", tags=["search"])

--- a/backend/lcfs/web/api/search/__init__.py
+++ b/backend/lcfs/web/api/search/__init__.py
@@ -1,0 +1,5 @@
+"""Global portal search API."""
+
+from lcfs.web.api.search.views import router
+
+__all__ = ["router"]

--- a/backend/lcfs/web/api/search/entities/__init__.py
+++ b/backend/lcfs/web/api/search/entities/__init__.py
@@ -1,0 +1,23 @@
+from lcfs.web.api.search.entities.admin_adjustments import ENTITY as ADMIN_ADJUSTMENTS
+from lcfs.web.api.search.entities.ci_applications import ENTITY as CI_APPLICATIONS
+from lcfs.web.api.search.entities.compliance_reports import ENTITY as COMPLIANCE_REPORTS
+from lcfs.web.api.search.entities.fuel_codes import ENTITY as FUEL_CODES
+from lcfs.web.api.search.entities.initiative_agreements import (
+    ENTITY as INITIATIVE_AGREEMENTS,
+)
+from lcfs.web.api.search.entities.organizations import ENTITY as ORGANIZATIONS
+from lcfs.web.api.search.entities.transfers import ENTITY as TRANSFERS
+from lcfs.web.api.search.entities.users import ENTITY as USERS
+
+SEARCH_ENTITIES = (
+    ORGANIZATIONS,
+    COMPLIANCE_REPORTS,
+    TRANSFERS,
+    FUEL_CODES,
+    CI_APPLICATIONS,
+    INITIATIVE_AGREEMENTS,
+    ADMIN_ADJUSTMENTS,
+    USERS,
+)
+
+__all__ = ["SEARCH_ENTITIES"]

--- a/backend/lcfs/web/api/search/entities/admin_adjustments.py
+++ b/backend/lcfs/web/api/search/entities/admin_adjustments.py
@@ -1,0 +1,136 @@
+"""Administrative-adjustment search definition."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.admin_adjustment.AdminAdjustment import AdminAdjustment
+from lcfs.db.models.admin_adjustment.AdminAdjustmentStatus import AdminAdjustmentStatus
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    date_text_expression,
+    date_years,
+    equals_any,
+    match_context_expression,
+    search_clause,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "admin_adjustment"
+SUPPORTED_FILTERS = {"status", "year"}
+
+
+async def search_admin_adjustments(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search administrative adjustments visible to the caller."""
+    query = context.query
+    if not context.can_access_organization_records or not applies(
+        query, SUPPORTED_FILTERS, ENTITY_TYPE
+    ):
+        return []
+
+    fields = [
+        SearchField("Organization", Organization.name, primary=True, fuzzy=True),
+        SearchField("Adjustment ID", AdminAdjustment.admin_adjustment_id, primary=True),
+        SearchField("Status", AdminAdjustmentStatus.status, primary=True),
+        SearchField("Compliance units", AdminAdjustment.compliance_units),
+        SearchField("Government comment", AdminAdjustment.gov_comment),
+        SearchField(
+            "Effective date",
+            date_text_expression(AdminAdjustment.transaction_effective_date),
+        ),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = AdminAdjustment.admin_adjustment_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = (
+        select(
+            AdminAdjustment.admin_adjustment_id,
+            AdminAdjustment.compliance_units,
+            Organization.name.label("org_name"),
+            AdminAdjustmentStatus.status.label("status"),
+            match_context,
+        )
+        .join(
+            Organization,
+            AdminAdjustment.to_organization_id == Organization.organization_id,
+        )
+        .join(
+            AdminAdjustmentStatus,
+            AdminAdjustment.current_status_id
+            == AdminAdjustmentStatus.admin_adjustment_status_id,
+        )
+    )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(AdminAdjustmentStatus.status, query.values("status")),
+        date_years(AdminAdjustment.transaction_effective_date, query.values("year")),
+        (
+            AdminAdjustment.to_organization_id == context.organization_id
+            if not context.is_government and context.organization_id is not None
+            else None
+        ),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(AdminAdjustment.admin_adjustment_id.desc()).limit(
+        RESULT_LIMIT
+    )
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for adjustment in rows:
+        route_prefix = "" if context.is_government else "org-"
+        details: list[SearchResultDetail] = []
+        if adjustment.org_name:
+            details.append(
+                SearchResultDetail(label="Organization", value=adjustment.org_name)
+            )
+        if adjustment.compliance_units is not None:
+            details.append(
+                SearchResultDetail(
+                    label="Compliance units",
+                    value=f"{adjustment.compliance_units:,}",
+                )
+            )
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=adjustment.admin_adjustment_id,
+                title=(f"Administrative Adjustment #{adjustment.admin_adjustment_id}"),
+                subtitle=adjustment.org_name or "",
+                route=(
+                    f"/{route_prefix}admin-adjustment/"
+                    f"{adjustment.admin_adjustment_id}"
+                ),
+                status=adjustment.status.value if adjustment.status else None,
+                meta=(
+                    f"{adjustment.compliance_units:,} units"
+                    if adjustment.compliance_units is not None
+                    else None
+                ),
+                match_context=adjustment.match_context or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Administrative adjustments",
+    handler=search_admin_adjustments,
+)

--- a/backend/lcfs/web/api/search/entities/base.py
+++ b/backend/lcfs/web/api/search/entities/base.py
@@ -1,0 +1,56 @@
+"""Shared contract for independently maintained entity searches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from lcfs.web.api.search.query import SearchQuery
+from lcfs.web.api.search.schema import SearchResultItem
+
+RESULT_LIMIT = 8
+
+
+@dataclass(frozen=True)
+class SearchContext:
+    """Caller and query information shared by every entity search."""
+
+    query: SearchQuery
+    organization_id: Optional[int]
+    is_government: bool
+
+    @property
+    def can_access_organization_records(self) -> bool:
+        """Prevent an unbound supplier account from seeing scoped records."""
+        return self.is_government or self.organization_id is not None
+
+
+SearchHandler = Callable[
+    [AsyncSession, SearchContext], Awaitable[list[SearchResultItem]]
+]
+
+
+@dataclass(frozen=True)
+class EntitySearch:
+    """One registered entity search and its result-group metadata."""
+
+    entity_type: str
+    label: str
+    handler: SearchHandler
+
+    async def execute(
+        self, db: AsyncSession, context: SearchContext
+    ) -> list[SearchResultItem]:
+        """Execute the entity handler through one uniform interface."""
+        return await self.handler(db, context)
+
+
+def where_present(statement: Any, *predicates: Optional[ColumnElement[bool]]) -> Any:
+    """Apply optional predicates without repeating defensive branching."""
+    for predicate in predicates:
+        if predicate is not None:
+            statement = statement.where(predicate)
+    return statement

--- a/backend/lcfs/web/api/search/entities/ci_applications.py
+++ b/backend/lcfs/web/api/search/entities/ci_applications.py
@@ -1,0 +1,139 @@
+"""Carbon-intensity application search definition."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.ci_application.CIApplication import CIApplication
+from lcfs.db.models.ci_application.CIApplicationStatus import CIApplicationStatus
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    date_text_expression,
+    date_years,
+    equals_any,
+    match_context_expression,
+    search_clause,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "ci_application"
+SUPPORTED_FILTERS = {"status", "year"}
+
+
+async def search_ci_applications(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search CI applications while enforcing organization visibility."""
+    query = context.query
+    if not context.can_access_organization_records or not applies(
+        query, SUPPORTED_FILTERS, ENTITY_TYPE
+    ):
+        return []
+
+    fields = [
+        SearchField("Organization", Organization.name, primary=True, fuzzy=True),
+        SearchField("Application ID", CIApplication.ci_application_id, primary=True),
+        SearchField("Status", CIApplicationStatus.status, primary=True),
+        SearchField("Facility city", CIApplication.facility_city, primary=True),
+        SearchField("Province/state", CIApplication.facility_province_state),
+        SearchField("Country", CIApplication.facility_country),
+        SearchField("Consultant name", CIApplication.consultant_name),
+        SearchField("Consultant company", CIApplication.consultant_company),
+        SearchField("Consultant email", CIApplication.consultant_email),
+        SearchField("Pathway description", CIApplication.pathway_description),
+        SearchField("Verification level", CIApplication.verification_level),
+        SearchField("Risk assessment", CIApplication.preliminary_risk_assessment),
+        SearchField(
+            "Created date",
+            date_text_expression(CIApplication.create_date),
+            searchable=False,
+        ),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = CIApplication.ci_application_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = (
+        select(
+            CIApplication.ci_application_id,
+            Organization.name.label("org_name"),
+            CIApplicationStatus.status.label("status"),
+            CIApplication.facility_city,
+            CIApplication.facility_province_state,
+            match_context,
+        )
+        .join(
+            Organization,
+            CIApplication.organization_id == Organization.organization_id,
+        )
+        .join(
+            CIApplicationStatus,
+            CIApplication.status_id == CIApplicationStatus.ci_application_status_id,
+        )
+    )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(CIApplicationStatus.status, query.values("status")),
+        date_years(CIApplication.create_date, query.values("year")),
+        (
+            CIApplication.organization_id == context.organization_id
+            if not context.is_government and context.organization_id is not None
+            else None
+        ),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(CIApplication.ci_application_id.desc()).limit(
+        RESULT_LIMIT
+    )
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for application in rows:
+        location = ", ".join(
+            value
+            for value in (
+                application.facility_city,
+                application.facility_province_state,
+            )
+            if value
+        )
+        details: list[SearchResultDetail] = []
+        if application.org_name:
+            details.append(
+                SearchResultDetail(label="Organization", value=application.org_name)
+            )
+        if location:
+            details.append(SearchResultDetail(label="Facility", value=location))
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=application.ci_application_id,
+                title=f"CI Application #{application.ci_application_id}",
+                subtitle=application.org_name or "",
+                route=f"/ci-applications/{application.ci_application_id}",
+                status=application.status,
+                meta=location or None,
+                match_context=application.match_context or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="CI applications",
+    handler=search_ci_applications,
+)

--- a/backend/lcfs/web/api/search/entities/compliance_reports.py
+++ b/backend/lcfs/web/api/search/entities/compliance_reports.py
@@ -1,0 +1,120 @@
+"""Compliance-report search definition."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.compliance.ComplianceReportListView import ComplianceReportListView
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    equals_any,
+    match_context_expression,
+    search_clause,
+    starts_with_any,
+    text_expression,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "report"
+SUPPORTED_FILTERS = {"status", "year"}
+
+
+async def search_compliance_reports(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search the latest compliance-report revisions visible to the caller."""
+    query = context.query
+    if not context.can_access_organization_records or not applies(
+        query, SUPPORTED_FILTERS, ENTITY_TYPE
+    ):
+        return []
+
+    view = ComplianceReportListView
+    fields = [
+        SearchField("Organization", view.organization_name, primary=True, fuzzy=True),
+        SearchField("Compliance period", view.compliance_period, primary=True),
+        SearchField("Report type", view.report_type, primary=True),
+        SearchField("Status", text_expression(view.report_status), primary=True),
+        SearchField("Report ID", view.compliance_report_id, primary=True),
+        SearchField(
+            "Analyst first name", view.assigned_analyst_first_name, primary=True
+        ),
+        SearchField("Analyst last name", view.assigned_analyst_last_name, primary=True),
+        SearchField("Supplemental initiator", view.supplemental_initiator),
+        SearchField("Reporting frequency", view.reporting_frequency),
+        SearchField("Assessment statement", view.assessment_statement),
+        SearchField("Legacy ID", view.legacy_id),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = view.compliance_report_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = select(view, match_context).where(view.is_latest.is_(True))
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(view.report_status, query.values("status")),
+        starts_with_any(view.compliance_period, query.values("year")),
+        (
+            view.organization_id == context.organization_id
+            if context.organization_id is not None
+            else None
+        ),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(view.update_date.desc()).limit(RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for report, matched_value in rows:
+        analyst = " ".join(
+            value
+            for value in (
+                report.assigned_analyst_first_name,
+                report.assigned_analyst_last_name,
+            )
+            if value
+        )
+        meta = [report.report_type] if report.report_type else []
+        details: list[SearchResultDetail] = []
+        if report.report_type:
+            details.append(
+                SearchResultDetail(label="Report type", value=report.report_type)
+            )
+        if analyst:
+            meta.append(f"Analyst: {analyst}")
+            details.append(SearchResultDetail(label="Analyst", value=analyst))
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=report.compliance_report_id,
+                title=f"{report.organization_name} — {report.compliance_period}",
+                subtitle=report.report_type or "",
+                route=(
+                    f"/compliance-reporting/{report.compliance_period}/"
+                    f"{report.compliance_report_id}"
+                ),
+                status=report.report_status.value if report.report_status else None,
+                meta=" · ".join(meta) or None,
+                match_context=matched_value or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Compliance reports",
+    handler=search_compliance_reports,
+)

--- a/backend/lcfs/web/api/search/entities/fuel_codes.py
+++ b/backend/lcfs/web/api/search/entities/fuel_codes.py
@@ -1,0 +1,163 @@
+"""Fuel-code search definition."""
+
+from sqlalchemy import String, cast, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.fuel.FuelCode import FuelCode
+from lcfs.db.models.fuel.FuelCodeListView import FuelCodeListView
+from lcfs.db.models.fuel.FuelCodeStatus import FuelCodeStatusEnum
+from lcfs.web.api.search.entities.base import (
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    date_text_expression,
+    date_years,
+    equals_any,
+    match_context_expression,
+    relevance_rank,
+    search_clause,
+    starts_with_any,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "fuel_code"
+SUPPORTED_FILTERS = {"status", "year"}
+FUEL_CODE_RESULT_LIMIT = 100
+
+
+def _visibility_scope(context: SearchContext):
+    """Limit BCeID results to owned fuel codes and public approved records."""
+    if context.is_government:
+        return None
+
+    approved = (
+        cast(FuelCodeListView.status, String) == FuelCodeStatusEnum.Approved.value
+    )
+    if context.organization_id is None:
+        return approved
+
+    owned_fuel_code_ids = select(FuelCode.fuel_code_id).where(
+        FuelCode.organization_id == context.organization_id
+    )
+    return or_(
+        FuelCodeListView.fuel_code_id.in_(owned_fuel_code_ids),
+        approved,
+    )
+
+
+async def search_fuel_codes(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search fuel-code list-view records."""
+    query = context.query
+    if not applies(query, SUPPORTED_FILTERS, ENTITY_TYPE):
+        return []
+
+    view = FuelCodeListView
+    code = view.prefix + view.fuel_suffix
+    fields = [
+        SearchField("Fuel code", code, primary=True, fuzzy=True),
+        SearchField("Company", view.company, primary=True, fuzzy=True),
+        SearchField("Fuel type", view.fuel_type, primary=True),
+        SearchField("Feedstock", view.feedstock, primary=True),
+        SearchField("Status", view.status, primary=True),
+        SearchField("Facility city", view.fuel_production_facility_city, primary=True),
+        SearchField("Feedstock location", view.feedstock_location, primary=True),
+        SearchField("Feedstock details", view.feedstock_misc),
+        SearchField("Province/state", view.fuel_production_facility_province_state),
+        SearchField("Country", view.fuel_production_facility_country),
+        SearchField("Contact name", view.contact_name),
+        SearchField("Contact email", view.contact_email),
+        SearchField("Former company", view.former_company),
+        SearchField("Notes", view.notes),
+        SearchField("EDRMS record", view.edrms),
+        SearchField("Carbon intensity", view.carbon_intensity),
+        SearchField("Approval date", date_text_expression(view.approval_date)),
+        SearchField("Effective date", date_text_expression(view.effective_date)),
+        SearchField(
+            "Finished fuel transport",
+            func.array_to_string(view.finished_fuel_transport_modes, " "),
+        ),
+        SearchField(
+            "Feedstock transport",
+            func.array_to_string(view.feedstock_fuel_transport_modes, " "),
+        ),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.is_id_only:
+        clause = starts_with_any(view.fuel_suffix, query.terms)
+    if query.text and clause is None:
+        return []
+
+    statement = where_present(
+        select(view, match_context),
+        clause,
+        _visibility_scope(context),
+        equals_any(view.status, query.values("status")),
+        date_years(view.approval_date, query.values("year")),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(
+        relevance_rank(code, query).desc(), view.fuel_suffix
+    ).limit(FUEL_CODE_RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for fuel_code, matched_value in rows:
+        meta = []
+        details: list[SearchResultDetail] = []
+        if fuel_code.company:
+            details.append(SearchResultDetail(label="Company", value=fuel_code.company))
+        if fuel_code.fuel_type:
+            details.append(
+                SearchResultDetail(label="Fuel type", value=fuel_code.fuel_type)
+            )
+        if fuel_code.carbon_intensity is not None:
+            meta.append(f"CI {fuel_code.carbon_intensity}")
+            details.append(
+                SearchResultDetail(
+                    label="Carbon intensity", value=str(fuel_code.carbon_intensity)
+                )
+            )
+        if fuel_code.feedstock:
+            meta.append(fuel_code.feedstock)
+            details.append(
+                SearchResultDetail(label="Feedstock", value=fuel_code.feedstock)
+            )
+        if fuel_code.fuel_production_facility_city:
+            meta.append(fuel_code.fuel_production_facility_city)
+            details.append(
+                SearchResultDetail(
+                    label="Facility",
+                    value=fuel_code.fuel_production_facility_city,
+                )
+            )
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=fuel_code.fuel_code_id,
+                title=f"{fuel_code.prefix}{fuel_code.fuel_suffix}",
+                subtitle=(
+                    f"{fuel_code.company or ''} · {fuel_code.fuel_type or ''}"
+                ).strip(" ·"),
+                route=f"/fuel-codes/{fuel_code.fuel_code_id}/view",
+                status=fuel_code.status,
+                meta=" · ".join(meta) or None,
+                match_context=matched_value or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Fuel codes",
+    handler=search_fuel_codes,
+)

--- a/backend/lcfs/web/api/search/entities/initiative_agreements.py
+++ b/backend/lcfs/web/api/search/entities/initiative_agreements.py
@@ -1,0 +1,143 @@
+"""Initiative-agreement search definition."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.models.initiative_agreement.InitiativeAgreement import InitiativeAgreement
+from lcfs.db.models.initiative_agreement.InitiativeAgreementStatus import (
+    InitiativeAgreementStatus,
+)
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    date_text_expression,
+    date_years,
+    equals_any,
+    match_context_expression,
+    search_clause,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "initiative_agreement"
+SUPPORTED_FILTERS = {"status", "year"}
+
+
+async def search_initiative_agreements(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search initiative agreements visible to the caller."""
+    query = context.query
+    if not context.can_access_organization_records or not applies(
+        query, SUPPORTED_FILTERS, ENTITY_TYPE
+    ):
+        return []
+
+    fields = [
+        SearchField("Organization", Organization.name, primary=True, fuzzy=True),
+        SearchField(
+            "Initiative agreement ID",
+            InitiativeAgreement.initiative_agreement_id,
+            primary=True,
+        ),
+        SearchField("Status", InitiativeAgreementStatus.status, primary=True),
+        SearchField("Compliance units", InitiativeAgreement.compliance_units),
+        SearchField("Government comment", InitiativeAgreement.gov_comment),
+        SearchField(
+            "Effective date",
+            date_text_expression(InitiativeAgreement.transaction_effective_date),
+        ),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = InitiativeAgreement.initiative_agreement_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = (
+        select(
+            InitiativeAgreement.initiative_agreement_id,
+            InitiativeAgreement.compliance_units,
+            Organization.name.label("org_name"),
+            InitiativeAgreementStatus.status.label("status"),
+            match_context,
+        )
+        .join(
+            Organization,
+            InitiativeAgreement.to_organization_id == Organization.organization_id,
+        )
+        .join(
+            InitiativeAgreementStatus,
+            InitiativeAgreement.current_status_id
+            == InitiativeAgreementStatus.initiative_agreement_status_id,
+        )
+    )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(InitiativeAgreementStatus.status, query.values("status")),
+        date_years(
+            InitiativeAgreement.transaction_effective_date, query.values("year")
+        ),
+        (
+            InitiativeAgreement.to_organization_id == context.organization_id
+            if not context.is_government and context.organization_id is not None
+            else None
+        ),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(
+        InitiativeAgreement.initiative_agreement_id.desc()
+    ).limit(RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for agreement in rows:
+        route_prefix = "" if context.is_government else "org-"
+        details: list[SearchResultDetail] = []
+        if agreement.org_name:
+            details.append(
+                SearchResultDetail(label="Organization", value=agreement.org_name)
+            )
+        if agreement.compliance_units is not None:
+            details.append(
+                SearchResultDetail(
+                    label="Compliance units", value=f"{agreement.compliance_units:,}"
+                )
+            )
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=agreement.initiative_agreement_id,
+                title=f"Initiative Agreement #{agreement.initiative_agreement_id}",
+                subtitle=agreement.org_name or "",
+                route=(
+                    f"/{route_prefix}initiative-agreement/"
+                    f"{agreement.initiative_agreement_id}"
+                ),
+                status=agreement.status.value if agreement.status else None,
+                meta=(
+                    f"{agreement.compliance_units:,} units"
+                    if agreement.compliance_units is not None
+                    else None
+                ),
+                match_context=agreement.match_context or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Initiative agreements",
+    handler=search_initiative_agreements,
+)

--- a/backend/lcfs/web/api/search/entities/organizations.py
+++ b/backend/lcfs/web/api/search/entities/organizations.py
@@ -1,0 +1,150 @@
+"""Organization search definition."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.organization.OrganizationAddress import OrganizationAddress
+from lcfs.db.models.organization.OrganizationStatus import OrganizationStatus
+from lcfs.db.models.organization.OrganizationType import OrganizationType
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    equals_any,
+    match_context_expression,
+    relevance_rank,
+    search_clause,
+    text_expression,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "organization"
+SUPPORTED_FILTERS = {"status"}
+
+
+async def search_organizations(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search organizations visible to a government caller."""
+    query = context.query
+    if not context.is_government or not applies(query, SUPPORTED_FILTERS, ENTITY_TYPE):
+        return []
+
+    address = aliased(OrganizationAddress)
+    status = aliased(OrganizationStatus)
+    organization_type = aliased(OrganizationType)
+    fields = [
+        SearchField("Organization", Organization.name, primary=True, fuzzy=True),
+        SearchField("Organization ID", Organization.organization_id, primary=True),
+        SearchField(
+            "Operating name", Organization.operating_name, primary=True, fuzzy=True
+        ),
+        SearchField("Organization code", Organization.organization_code, primary=True),
+        SearchField("City", address.city, primary=True),
+        SearchField("Province/state", address.province_state, primary=True),
+        SearchField("Status", text_expression(status.status), primary=True),
+        SearchField("Email", Organization.email),
+        SearchField("Phone", Organization.phone),
+        SearchField("Contact", Organization.contact_name),
+        SearchField("EDRMS record", Organization.edrms_record),
+        SearchField("Records address", Organization.records_address),
+        SearchField("Credit market contact", Organization.credit_market_contact_name),
+        SearchField("Credit market email", Organization.credit_market_contact_email),
+        SearchField("Street address", address.street_address),
+        SearchField("Country", address.country),
+        SearchField("Postal code", address.postalCode_zipCode),
+        SearchField("Organization type", organization_type.org_type),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = Organization.organization_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = (
+        select(Organization, address, status, match_context)
+        .outerjoin(
+            address,
+            Organization.organization_address_id == address.organization_address_id,
+        )
+        .outerjoin(
+            status,
+            Organization.organization_status_id == status.organization_status_id,
+        )
+        .outerjoin(
+            organization_type,
+            Organization.organization_type_id == organization_type.organization_type_id,
+        )
+    )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(status.status, query.values("status")),
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(
+        relevance_rank(Organization.name, query).desc(), Organization.name
+    ).limit(RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for organization, organization_address, organization_status, matched_value in rows:
+        location = ", ".join(
+            value
+            for value in (
+                getattr(organization_address, "city", None),
+                getattr(organization_address, "province_state", None),
+            )
+            if value
+        )
+        details: list[SearchResultDetail] = []
+        if organization.operating_name:
+            details.append(
+                SearchResultDetail(
+                    label="Operating name", value=organization.operating_name
+                )
+            )
+        elif organization.organization_code:
+            details.append(
+                SearchResultDetail(
+                    label="Organization code", value=organization.organization_code
+                )
+            )
+        if location:
+            details.append(SearchResultDetail(label="Location", value=location))
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=organization.organization_id,
+                title=organization.name,
+                subtitle=(
+                    organization.operating_name or organization.organization_code or ""
+                ),
+                route=f"/organizations/{organization.organization_id}",
+                status=(
+                    organization_status.status.value
+                    if organization_status and organization_status.status
+                    else None
+                ),
+                meta=location or None,
+                match_context=matched_value or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Organizations",
+    handler=search_organizations,
+)

--- a/backend/lcfs/web/api/search/entities/transfers.py
+++ b/backend/lcfs/web/api/search/entities/transfers.py
@@ -1,0 +1,168 @@
+"""Transfer search definition."""
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.transfer.Transfer import Transfer
+from lcfs.db.models.transfer.TransferCategory import TransferCategory
+from lcfs.db.models.transfer.TransferComment import TransferComment
+from lcfs.db.models.transfer.TransferStatus import TransferStatus
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    date_text_expression,
+    date_years,
+    equals_any,
+    match_context_expression,
+    search_clause,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "transfer"
+SUPPORTED_FILTERS = {"status", "year"}
+
+
+async def search_transfers(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search transfers while enforcing organization visibility."""
+    query = context.query
+    if not context.can_access_organization_records or not applies(
+        query, SUPPORTED_FILTERS, ENTITY_TYPE
+    ):
+        return []
+
+    from_organization = aliased(Organization, name="from_org")
+    to_organization = aliased(Organization, name="to_org")
+    comments = (
+        select(func.string_agg(TransferComment.comment, " "))
+        .where(TransferComment.transfer_id == Transfer.transfer_id)
+        .correlate(Transfer)
+        .scalar_subquery()
+    )
+    fields = [
+        SearchField(
+            "From organization", from_organization.name, primary=True, fuzzy=True
+        ),
+        SearchField("To organization", to_organization.name, primary=True, fuzzy=True),
+        SearchField("Transfer ID", Transfer.transfer_id, primary=True),
+        SearchField("Status", TransferStatus.status, primary=True),
+        SearchField("Category", TransferCategory.category),
+        SearchField("Quantity", Transfer.quantity),
+        SearchField("Price per unit", Transfer.price_per_unit),
+        SearchField("Agreement date", date_text_expression(Transfer.agreement_date)),
+        SearchField(
+            "Effective date",
+            date_text_expression(Transfer.transaction_effective_date),
+        ),
+        SearchField("Recommendation", Transfer.recommendation),
+        SearchField("Comment", func.coalesce(comments, "")),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = Transfer.transfer_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = (
+        select(
+            Transfer.transfer_id,
+            from_organization.name.label("from_name"),
+            to_organization.name.label("to_name"),
+            TransferStatus.status.label("status"),
+            Transfer.quantity,
+            Transfer.price_per_unit,
+            Transfer.agreement_date,
+            match_context,
+        )
+        .join(
+            from_organization,
+            Transfer.from_organization_id == from_organization.organization_id,
+        )
+        .join(
+            to_organization,
+            Transfer.to_organization_id == to_organization.organization_id,
+        )
+        .join(
+            TransferStatus,
+            Transfer.current_status_id == TransferStatus.transfer_status_id,
+        )
+        .outerjoin(
+            TransferCategory,
+            Transfer.transfer_category_id == TransferCategory.transfer_category_id,
+        )
+    )
+    organization_scope = None
+    if not context.is_government and context.organization_id is not None:
+        organization_scope = or_(
+            Transfer.from_organization_id == context.organization_id,
+            Transfer.to_organization_id == context.organization_id,
+        )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(TransferStatus.status, query.values("status")),
+        date_years(Transfer.agreement_date, query.values("year")),
+        organization_scope,
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(Transfer.transfer_id.desc()).limit(RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for transfer in rows:
+        meta = []
+        details = [
+            SearchResultDetail(label="Transfer ID", value=str(transfer.transfer_id))
+        ]
+        if transfer.quantity is not None:
+            meta.append(f"{transfer.quantity:,} units")
+            details.append(
+                SearchResultDetail(
+                    label="Quantity", value=f"{transfer.quantity:,} units"
+                )
+            )
+        if transfer.price_per_unit is not None:
+            meta.append(f"${transfer.price_per_unit:,.2f}/unit")
+            details.append(
+                SearchResultDetail(
+                    label="Unit price", value=f"${transfer.price_per_unit:,.2f}"
+                )
+            )
+        if transfer.agreement_date:
+            formatted_date = transfer.agreement_date.strftime("%Y-%m-%d")
+            meta.append(formatted_date)
+            details.append(
+                SearchResultDetail(label="Agreement date", value=formatted_date)
+            )
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=transfer.transfer_id,
+                title=f"{transfer.from_name} → {transfer.to_name}",
+                subtitle=f"Transfer #{transfer.transfer_id}",
+                route=f"/transfers/{transfer.transfer_id}",
+                status=transfer.status.value if transfer.status else None,
+                meta=" · ".join(meta) or None,
+                match_context=transfer.match_context or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Transfers",
+    handler=search_transfers,
+)

--- a/backend/lcfs/web/api/search/entities/users.py
+++ b/backend/lcfs/web/api/search/entities/users.py
@@ -1,0 +1,163 @@
+"""Portal-user search definition."""
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from lcfs.db.models.organization.Organization import Organization
+from lcfs.db.models.user.Role import Role
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.db.models.user.UserRole import UserRole
+from lcfs.web.api.search.entities.base import (
+    RESULT_LIMIT,
+    EntitySearch,
+    SearchContext,
+    where_present,
+)
+from lcfs.web.api.search.matching import (
+    SearchField,
+    applies,
+    equals_any,
+    match_context_expression,
+    relevance_rank,
+    search_clause,
+    text_expression,
+)
+from lcfs.web.api.search.schema import SearchResultDetail, SearchResultItem
+
+ENTITY_TYPE = "user"
+SUPPORTED_FILTERS = {"status", "user_type"}
+KNOWN_AUDIENCES = {"idir", "bceid"}
+
+
+async def search_users(
+    db: AsyncSession, context: SearchContext
+) -> list[SearchResultItem]:
+    """Search portal users while preserving IDIR and supplier boundaries."""
+    query = context.query
+    if not applies(query, SUPPORTED_FILTERS, ENTITY_TYPE):
+        return []
+
+    requested_audiences = {value.casefold() for value in query.values("user_type")}
+    audiences = requested_audiences & KNOWN_AUDIENCES
+    if requested_audiences and not audiences:
+        return []
+    if not context.is_government and (
+        context.organization_id is None or audiences == {"idir"}
+    ):
+        return []
+
+    user_organization = aliased(Organization)
+    full_name = UserProfile.first_name + " " + UserProfile.last_name
+    user_status = case((UserProfile.is_active.is_(True), "Active"), else_="Inactive")
+    roles = (
+        select(func.string_agg(text_expression(Role.name), " "))
+        .select_from(UserRole)
+        .join(Role, UserRole.role_id == Role.role_id)
+        .where(UserRole.user_profile_id == UserProfile.user_profile_id)
+        .correlate(UserProfile)
+        .scalar_subquery()
+    )
+    fields = [
+        SearchField("Full name", full_name, primary=True, fuzzy=True),
+        SearchField("User ID", UserProfile.user_profile_id, primary=True),
+        SearchField("First name", UserProfile.first_name, primary=True),
+        SearchField("Last name", UserProfile.last_name, primary=True),
+        SearchField("Email", UserProfile.email, primary=True),
+        SearchField("Username", UserProfile.keycloak_username, primary=True),
+        SearchField("Organization", user_organization.name, primary=True),
+        SearchField("Identity email", UserProfile.keycloak_email),
+        SearchField("Title", UserProfile.title),
+        SearchField("Phone", UserProfile.phone),
+        SearchField("Mobile phone", UserProfile.mobile_phone),
+        SearchField("Roles", func.coalesce(roles, "")),
+        SearchField("Status", user_status, primary=True),
+    ]
+    match_context = match_context_expression(fields, query)
+    clause, score = search_clause(fields, query)
+    if clause is None and query.numeric_id is not None:
+        clause = UserProfile.user_profile_id == query.numeric_id
+    if query.text and clause is None:
+        return []
+
+    statement = select(
+        UserProfile,
+        user_organization.name.label("org_name"),
+        match_context,
+    ).outerjoin(
+        user_organization,
+        UserProfile.organization_id == user_organization.organization_id,
+    )
+    audience_scope = None
+    if context.is_government and audiences == {"idir"}:
+        audience_scope = UserProfile.organization_id.is_(None)
+    elif context.is_government and audiences == {"bceid"}:
+        audience_scope = UserProfile.organization_id.is_not(None)
+    organization_scope = (
+        UserProfile.organization_id == context.organization_id
+        if not context.is_government
+        else None
+    )
+    statement = where_present(
+        statement,
+        clause,
+        equals_any(user_status, query.values("status")),
+        audience_scope,
+        organization_scope,
+    )
+    if score is not None:
+        statement = statement.order_by(score.desc())
+    statement = statement.order_by(
+        UserProfile.is_active.desc(),
+        relevance_rank(full_name, query).desc(),
+        UserProfile.last_name,
+    ).limit(RESULT_LIMIT)
+
+    rows = (await db.execute(statement)).all()
+    results = []
+    for user, organization_name, matched_value in rows:
+        if not context.is_government:
+            route = f"/organization/users/{user.user_profile_id}"
+        elif user.organization_id:
+            route = (
+                f"/organizations/{user.organization_id}/users/"
+                f"{user.user_profile_id}"
+            )
+        else:
+            route = f"/admin/users/{user.user_profile_id}"
+
+        organization = organization_name
+        if context.is_government and not organization:
+            organization = "Government of B.C."
+        details: list[SearchResultDetail] = []
+        if user.email:
+            details.append(SearchResultDetail(label="Email", value=user.email))
+        if user.title:
+            details.append(SearchResultDetail(label="Title", value=user.title))
+        if organization:
+            details.append(SearchResultDetail(label="Organization", value=organization))
+        results.append(
+            SearchResultItem(
+                entity_type=ENTITY_TYPE,
+                entity_id=user.user_profile_id,
+                title=(
+                    f"{user.first_name or ''} {user.last_name or ''}".strip()
+                    or user.keycloak_username
+                ),
+                subtitle=user.email or "",
+                route=route,
+                status="Active" if user.is_active else "Inactive",
+                meta=" · ".join(value for value in (user.title, organization) if value)
+                or None,
+                match_context=matched_value or None,
+                details=details,
+            )
+        )
+    return results
+
+
+ENTITY = EntitySearch(
+    entity_type=ENTITY_TYPE,
+    label="Users",
+    handler=search_users,
+)

--- a/backend/lcfs/web/api/search/matching.py
+++ b/backend/lcfs/web/api/search/matching.py
@@ -1,0 +1,231 @@
+"""Composable SQLAlchemy primitives for global search."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Iterable, Optional, Sequence, Tuple
+
+from sqlalchemy import String, and_, case, cast, false, func, literal, or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from lcfs.web.api.search.query import MAX_RECORD_ID, SearchQuery
+
+_REGEX_META = re.compile(r"([.^$*+?()\[\]{}|\\])")
+
+
+@dataclass(frozen=True)
+class SearchField:
+    """One searchable expression and the behaviour attached to it."""
+
+    label: str
+    expression: Any
+    primary: bool = False
+    fuzzy: bool = False
+    searchable: bool = True
+
+
+def text_expression(expression: Any) -> ColumnElement[str]:
+    """Coerce enums, numbers, and other scalar expressions to text."""
+    return cast(expression, String)
+
+
+def date_text_expression(expression: Any) -> ColumnElement[str]:
+    """Represent a date for match explanations, not for year filtering."""
+    return func.to_char(expression, "YYYY-MM-DD")
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _base_match(expression: Any, term: str) -> ColumnElement[bool]:
+    if len(term) <= 4 and " " not in term:
+        pattern = r"\m" + _REGEX_META.sub(r"\\\1", term)
+        return expression.op("~*")(pattern)
+    return expression.ilike(f"%{_escape_like(term)}%", escape="\\")
+
+
+def _field_match(field: SearchField, term: str) -> ColumnElement[bool]:
+    value = text_expression(field.expression)
+    raw = _base_match(value, term)
+    if not field.fuzzy:
+        return raw
+    normalized = func.regexp_replace(value, r"[^\w\s]", "", "g")
+    return or_(raw, _base_match(normalized, term))
+
+
+def search_clause(
+    fields: Sequence[SearchField], query: SearchQuery
+) -> Tuple[Optional[ColumnElement[bool]], Optional[ColumnElement[Any]]]:
+    """Return a relevance predicate and score for the free-text terms."""
+    searchable = [field for field in fields if field.searchable]
+    if not query.terms or query.is_id_only or not searchable:
+        return None, None
+
+    per_term = [
+        or_(*[_field_match(field, term) for field in searchable])
+        for term in query.terms
+    ]
+    score = sum((case((condition, 1), else_=0) for condition in per_term), literal(0))
+    required = (
+        len(query.terms) if len(query.terms) <= 2 else math.ceil(len(query.terms) * 0.6)
+    )
+    primary = [field for field in searchable if field.primary]
+    primary_hit = (
+        or_(*[_field_match(field, term) for field in primary for term in query.terms])
+        if primary
+        else or_(*per_term)
+    )
+    return and_(score >= required, primary_hit), score
+
+
+def _match_excerpt(expression: Any, term: str) -> ColumnElement[str]:
+    """Return only persisted text, including for punctuation-normalized matches."""
+    value = text_expression(expression)
+    position = func.strpos(func.lower(value), term.casefold())
+    start = func.greatest(position - 40, 1)
+    excerpt = func.substr(value, start, 100)
+    return case(
+        (
+            position > 0,
+            func.concat(
+                case((start > 1, "…"), else_=""),
+                excerpt,
+                case((func.length(value) > start + 99, "…"), else_=""),
+            ),
+        ),
+        else_=func.substr(value, 1, 100),
+    )
+
+
+def match_context_expression(
+    fields: Sequence[SearchField], query: SearchQuery
+) -> ColumnElement[str]:
+    """Return labelled values explaining where each query term matched."""
+    if not query.context_terms:
+        return cast(literal(None), String).label("match_context")
+
+    matches = []
+    for term in query.context_terms:
+        matched_value = case(
+            *[
+                (
+                    _field_match(field, term),
+                    func.concat(
+                        field.label,
+                        ": ",
+                        _match_excerpt(field.expression, term),
+                    ),
+                )
+                for field in fields
+            ],
+            else_=None,
+        )
+        matches.append(matched_value)
+    return func.concat_ws(" · ", *matches).label("match_context")
+
+
+def relevance_rank(expression: Any, query: SearchQuery) -> ColumnElement[int]:
+    """Prefer exact primary values, then prefixes, then substrings."""
+    if not query.text:
+        return literal(0)
+    value = func.lower(text_expression(expression))
+    normalized = _escape_like(query.text.strip().casefold())
+    return case(
+        (value == query.text.strip().casefold(), 100),
+        (value.like(f"{normalized}%", escape="\\"), 60),
+        (value.like(f"%{normalized}%", escape="\\"), 30),
+        else_=0,
+    )
+
+
+def contains_any(
+    expression: Any, values: Iterable[str]
+) -> Optional[ColumnElement[bool]]:
+    """Case-insensitive substring match for any supplied filter value."""
+    values = tuple(value for value in values if value)
+    if not values:
+        return None
+    text = text_expression(expression)
+    return or_(
+        *[text.ilike(f"%{_escape_like(value)}%", escape="\\") for value in values]
+    )
+
+
+def equals_any(expression: Any, values: Iterable[str]) -> Optional[ColumnElement[bool]]:
+    """Case-insensitive exact match for enumerated filter values."""
+    normalized = tuple(value.strip().casefold() for value in values if value.strip())
+    if not normalized:
+        return None
+    return func.lower(text_expression(expression)).in_(normalized)
+
+
+def contains_any_field(
+    expressions: Iterable[Any], values: Iterable[str]
+) -> Optional[ColumnElement[bool]]:
+    """Match any value against any of the supplied expressions."""
+    values = tuple(values)
+    clauses = tuple(
+        clause
+        for expression in expressions
+        if (clause := contains_any(expression, values)) is not None
+    )
+    return or_(*clauses) if clauses else None
+
+
+def starts_with_any(
+    expression: Any, values: Iterable[str]
+) -> Optional[ColumnElement[bool]]:
+    values = tuple(value for value in values if value)
+    if not values:
+        return None
+    text = text_expression(expression)
+    return or_(
+        *[text.ilike(f"{_escape_like(value)}%", escape="\\") for value in values]
+    )
+
+
+def date_years(expression: Any, values: Iterable[str]) -> Optional[ColumnElement[bool]]:
+    """Build index-friendly date ranges instead of formatting the column."""
+    raw_values = tuple(value.strip() for value in values if value.strip())
+    clauses = []
+    for value in raw_values:
+        if len(value) != 4 or not value.isdigit() or not value.startswith(("19", "20")):
+            continue
+        year = int(value)
+        clauses.append(
+            and_(expression >= date(year, 1, 1), expression < date(year + 1, 1, 1))
+        )
+    if clauses:
+        return or_(*clauses)
+    return false() if raw_values else None
+
+
+def ids_filter(expression: Any, values: Iterable[str]) -> Optional[ColumnElement[bool]]:
+    """Match explicit numeric IDs; malformed IDs intentionally match nothing."""
+    raw_values = tuple(value.strip() for value in values if value.strip())
+    if not raw_values:
+        return None
+    identifiers = [
+        identifier
+        for value in raw_values
+        if value.isdigit() and 0 < (identifier := int(value)) <= MAX_RECORD_ID
+    ]
+    return expression.in_(identifiers) if identifiers else false()
+
+
+def applies(query: SearchQuery, supported: Iterable[str], entity: str) -> bool:
+    """Return whether this entity can contribute meaningful results."""
+    supported_filters = set(supported)
+    requested_filters = set(query.filters)
+
+    if not requested_filters.issubset(supported_filters):
+        return False
+    if query.entities and entity not in query.entities:
+        return False
+    if query.terms:
+        return True
+    return bool(query.entities or requested_filters)

--- a/backend/lcfs/web/api/search/query.py
+++ b/backend/lcfs/web/api/search/query.py
@@ -1,0 +1,179 @@
+"""Parsing and normalization for the global-search query language."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Iterable, Mapping, Optional, Tuple
+
+_YEAR_RE = re.compile(r"^(19|20)\d{2}$")
+MAX_RECORD_ID = 2_147_483_647
+MIN_TERM_LENGTH = 2
+
+_FILTER_VALUE_ALIASES = {
+    "status": {
+        "cancelled": "canceled",
+    },
+}
+
+_ENTITY_ALIASES = {
+    "organization": {"organizations", "org", "orgs", "supplier", "suppliers"},
+    "report": {"reports", "compliance report", "compliance reports"},
+    "transfer": {"transfers"},
+    "fuel_code": {"fuel codes"},
+    "ci_application": {"ci", "ci applications"},
+    "initiative_agreement": {"initiative agreements"},
+    "admin_adjustment": {"administrative adjustment", "administrative adjustments"},
+    "user": {"users", "person", "people", "staff"},
+}
+
+_STATUS_WORDS = {
+    "draft",
+    "deleted",
+    "sent",
+    "submitted",
+    "recommended",
+    "recorded",
+    "refused",
+    "declined",
+    "rescinded",
+    "assessed",
+    "exempted",
+    "rejected",
+    "approved",
+    "registered",
+    "unregistered",
+    "suspended",
+    "canceled",
+    "cancelled",
+    "active",
+    "inactive",
+}
+_USER_AUDIENCE_WORDS = {"idir", "bceid"}
+
+
+def _normalize_alias(value: str) -> str:
+    return re.sub(r"[\s_-]+", "", value).casefold()
+
+
+_ALIAS_TO_ENTITY = {
+    _normalize_alias(alias): entity
+    for entity, aliases in _ENTITY_ALIASES.items()
+    for alias in aliases | {entity}
+}
+
+
+def _try_shell_split(raw: str) -> Optional[list[str]]:
+    try:
+        return shlex.split(raw, posix=True)
+    except ValueError:
+        return None
+
+
+def _split(raw: str) -> list[str]:
+    """Split like a shell so quoted phrases remain one search term."""
+    parts = _try_shell_split(raw)
+    if parts is not None:
+        return parts
+
+    if raw.count('"') % 2:
+        parts = _try_shell_split(f'{raw}"')
+        if parts is not None:
+            return parts
+    return raw.replace('"', "").replace("'", "").split()
+
+
+def _append(values: dict[str, list[str]], key: str, value: str) -> None:
+    stripped = value.strip()
+    normalized = _FILTER_VALUE_ALIASES.get(key, {}).get(stripped.casefold(), stripped)
+    if normalized and normalized.casefold() not in {
+        existing.casefold() for existing in values.get(key, [])
+    }:
+        values.setdefault(key, []).append(normalized)
+
+
+def _infer_filters(terms: Iterable[str]) -> Tuple[dict[str, list[str]], list[str]]:
+    """Infer status/year/user_type filters from bare search terms."""
+    filters: dict[str, list[str]] = {}
+    remaining: list[str] = []
+    for term in terms:
+        normalized = term.casefold()
+        if _YEAR_RE.fullmatch(normalized):
+            _append(filters, "year", normalized)
+        elif normalized in _STATUS_WORDS:
+            _append(filters, "status", normalized)
+        elif normalized in _USER_AUDIENCE_WORDS:
+            _append(filters, "user_type", normalized)
+        else:
+            remaining.append(term)
+    return filters, remaining
+
+
+def _resolve_entities(terms: list[str]) -> Tuple[Tuple[str, ...], list[str]]:
+    if not terms:
+        return (), terms
+
+    inferred = _ALIAS_TO_ENTITY.get(_normalize_alias(" ".join(terms)))
+    return ((inferred,), []) if inferred is not None else ((), terms)
+
+
+@dataclass(frozen=True)
+class SearchQuery:
+    """Normalized, immutable representation of one global-search request."""
+
+    raw: str
+    text: str
+    terms: Tuple[str, ...]
+    filters: Mapping[str, Tuple[str, ...]]
+    entities: Tuple[str, ...]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.terms and not self.filters and not self.entities
+
+    @property
+    def is_id_only(self) -> bool:
+        return len(self.terms) == 1 and self.terms[0].isdigit()
+
+    @property
+    def numeric_id(self) -> Optional[int]:
+        if not self.is_id_only:
+            return None
+        value = int(self.terms[0])
+        return value if 0 < value <= MAX_RECORD_ID else None
+
+    def values(self, key: str) -> Tuple[str, ...]:
+        return self.filters.get(key, ())
+
+    @property
+    def context_terms(self) -> Tuple[str, ...]:
+        values = list(self.terms)
+        for key, filter_values in self.filters.items():
+            if key != "user_type":
+                values.extend(filter_values)
+        return tuple(dict.fromkeys(value.casefold() for value in values if value))
+
+    @property
+    def applied_filters(self) -> dict[str, str]:
+        """Serialize repeated values without changing the public API shape."""
+        return {key: ", ".join(values) for key, values in self.filters.items()}
+
+
+def parse_query(raw: str) -> SearchQuery:
+    mutable_filters, remaining = _infer_filters(_split(raw))
+    entities, remaining = _resolve_entities(remaining)
+    meaningful_terms = tuple(
+        term.strip() for term in remaining if len(term.strip()) >= MIN_TERM_LENGTH
+    )
+    filters = MappingProxyType(
+        {key: tuple(values) for key, values in mutable_filters.items()}
+    )
+    return SearchQuery(
+        raw=raw,
+        text=" ".join(meaningful_terms),
+        terms=meaningful_terms,
+        filters=filters,
+        entities=entities,
+    )

--- a/backend/lcfs/web/api/search/schema.py
+++ b/backend/lcfs/web/api/search/schema.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from pydantic import Field
+
+from lcfs.web.api.base import BaseSchema
+
+
+class SearchResultDetail(BaseSchema):
+    """One labelled fact displayed within a search result."""
+
+    label: str
+    value: str
+
+
+class SearchResultItem(BaseSchema):
+    """Normalized result contract shared by every searchable entity."""
+
+    entity_type: str
+    entity_id: int
+    title: str
+    subtitle: str
+    route: str
+    status: Optional[str] = None
+    meta: Optional[str] = None
+    match_context: Optional[str] = None
+    details: list[SearchResultDetail] = Field(default_factory=list)
+
+
+class SearchGroup(BaseSchema):
+    """Results belonging to one registered entity type."""
+
+    entity_type: str
+    label: str
+    items: list[SearchResultItem]
+
+
+class SearchResponse(BaseSchema):
+    """Complete response returned by global search."""
+
+    query: str
+    groups: list[SearchGroup]
+    total: int
+    applied_filters: dict[str, str] = Field(default_factory=dict)

--- a/backend/lcfs/web/api/search/services.py
+++ b/backend/lcfs/web/api/search/services.py
@@ -1,0 +1,56 @@
+from typing import Optional, cast
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from lcfs.db.dependencies import get_async_db_session
+from lcfs.db.models.user.UserProfile import UserProfile
+from lcfs.web.api.role.schema import is_government_user
+from lcfs.web.api.search.entities import SEARCH_ENTITIES
+from lcfs.web.api.search.entities.base import SearchContext
+from lcfs.web.api.search.query import parse_query
+from lcfs.web.api.search.schema import SearchGroup, SearchResponse
+
+
+class SearchService:
+    """Parse one query and collect results from registered entity searches."""
+
+    def __init__(self, db: AsyncSession = Depends(get_async_db_session)):
+        self.db = db
+
+    async def search(self, raw_query: str, user: UserProfile) -> SearchResponse:
+        """Search every applicable entity in stable display order."""
+        query = parse_query(raw_query)
+        if query.is_empty:
+            return SearchResponse(query=raw_query, groups=[], total=0)
+
+        government_user = is_government_user(user)
+        context = SearchContext(
+            query=query,
+            organization_id=(
+                None if government_user else cast(Optional[int], user.organization_id)
+            ),
+            is_government=government_user,
+        )
+        groups = await self._search_entities(context)
+        return SearchResponse(
+            query=raw_query,
+            groups=groups,
+            total=sum(len(group.items) for group in groups),
+            applied_filters=query.applied_filters,
+        )
+
+    async def _search_entities(self, context: SearchContext) -> list[SearchGroup]:
+        """Execute the registry sequentially on this request's DB session."""
+        groups = []
+        for entity in SEARCH_ENTITIES:
+            items = await entity.execute(self.db, context)
+            if items:
+                groups.append(
+                    SearchGroup(
+                        entity_type=entity.entity_type,
+                        label=entity.label,
+                        items=items,
+                    )
+                )
+        return groups

--- a/backend/lcfs/web/api/search/views.py
+++ b/backend/lcfs/web/api/search/views.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends, Query, Request
+
+from lcfs.web.api.search.schema import SearchResponse
+from lcfs.web.api.search.services import SearchService
+from lcfs.web.core.decorators import view_handler
+
+router = APIRouter()
+
+
+@router.get("/", response_model=SearchResponse)
+@view_handler(["*"])
+async def global_search(
+    request: Request,
+    q: str = Query(min_length=2, max_length=100),
+    service: SearchService = Depends(),
+) -> SearchResponse:
+    return await service.search(q, request.user)

--- a/frontend/src/components/BCNavbar/__tests__/BCNavbar.test.tsx
+++ b/frontend/src/components/BCNavbar/__tests__/BCNavbar.test.tsx
@@ -51,14 +51,11 @@ const TestWrapper = ({
 }
 
 const renderNavbar = (initialPath = '/') => {
-  return render(
-    <BCNavbar routes={sampleRoutes} />,
-    {
-      wrapper: ({ children }) => (
-        <TestWrapper initialEntries={[initialPath]}>{children}</TestWrapper>
-      )
-    }
-  )
+  return render(<BCNavbar routes={sampleRoutes} />, {
+    wrapper: ({ children }) => (
+      <TestWrapper initialEntries={[initialPath]}>{children}</TestWrapper>
+    )
+  })
 }
 
 describe('BCNavbar', () => {
@@ -175,10 +172,9 @@ describe('BCNavbar', () => {
     })
 
     it('renders without beta flag when disabled', () => {
-      render(
-        <BCNavbar beta={false} routes={sampleRoutes} />,
-        { wrapper: TestWrapper }
-      )
+      render(<BCNavbar beta={false} routes={sampleRoutes} />, {
+        wrapper: TestWrapper
+      })
 
       expect(screen.getByTestId('bc-navbar')).toBeInTheDocument()
     })
@@ -206,14 +202,24 @@ describe('BCNavbar', () => {
 
       expect(screen.getByTestId('menu-right')).toBeInTheDocument()
     })
+
+    it('renders a utility in the global header', () => {
+      render(
+        <BCNavbar
+          routes={sampleRoutes}
+          headerUtilityPart={<div data-test="header-utility">Search</div>}
+        />,
+        { wrapper: TestWrapper }
+      )
+
+      expect(screen.getByTestId('header-utility')).toBeInTheDocument()
+    })
   })
 
   describe('icons', () => {
     it('renders route with icon', () => {
       render(
-        <BCNavbar
-          routes={[{ icon: 'home', name: 'Home', route: '/' }]}
-        />,
+        <BCNavbar routes={[{ icon: 'home', name: 'Home', route: '/' }]} />,
         { wrapper: TestWrapper }
       )
 
@@ -221,12 +227,9 @@ describe('BCNavbar', () => {
     })
 
     it('renders route without icon', () => {
-      render(
-        <BCNavbar
-          routes={[{ name: 'No Icon', route: '/no-icon' }]}
-        />,
-        { wrapper: TestWrapper }
-      )
+      render(<BCNavbar routes={[{ name: 'No Icon', route: '/no-icon' }]} />, {
+        wrapper: TestWrapper
+      })
 
       expect(screen.getByText('No Icon')).toBeInTheDocument()
     })

--- a/frontend/src/components/BCNavbar/components/HeaderBar.tsx
+++ b/frontend/src/components/BCNavbar/components/HeaderBar.tsx
@@ -60,6 +60,17 @@ const HeaderBar = ({
               </BCTypography>
             )}
           </BCTypography>
+          {data.headerUtilityPart && (
+            <BCBox
+              display={{ xs: 'none', xl: 'flex' }}
+              alignItems="center"
+              ml={3}
+              pl={2.5}
+              sx={{ borderLeft: '1px solid rgba(255, 255, 255, 0.35)' }}
+            >
+              {React.cloneElement(data.headerUtilityPart, { data })}
+            </BCBox>
+          )}
         </BCBox>
       </BCBox>
       <BCBox
@@ -80,9 +91,7 @@ const HeaderBar = ({
         sx={{ cursor: 'pointer' }}
         {...bindTrigger(popupState)}
       >
-        <Icon fontSize="inherit">
-          {popupState.isOpen ? 'close' : 'menu'}
-        </Icon>
+        <Icon fontSize="inherit">{popupState.isOpen ? 'close' : 'menu'}</Icon>
       </BCBox>
     </Toolbar>
   )

--- a/frontend/src/components/BCNavbar/components/MenuBar.tsx
+++ b/frontend/src/components/BCNavbar/components/MenuBar.tsx
@@ -72,8 +72,7 @@ const MenuBar = ({ routes, data }: MenuBarProps) => {
         py={1}
         flexDirection="row"
       >
-        {data.menuRightPart &&
-          React.cloneElement(data.menuRightPart, { data })}
+        {data.menuRightPart && React.cloneElement(data.menuRightPart, { data })}
       </BCBox>
     </Toolbar>
   )

--- a/frontend/src/components/BCNavbar/index.tsx
+++ b/frontend/src/components/BCNavbar/index.tsx
@@ -20,6 +20,7 @@ function BCNavbar({
   routes = defaultRoutes,
   beta = true,
   headerRightPart = null,
+  headerUtilityPart = null,
   menuRightPart = null
 }: BCNavbarProps) {
   const theme = useTheme()
@@ -30,6 +31,7 @@ function BCNavbar({
     routes,
     beta,
     headerRightPart,
+    headerUtilityPart,
     menuRightPart
   }
 
@@ -37,7 +39,10 @@ function BCNavbar({
     <BCBox
       py={0}
       className="main-layout-navbar"
-      sx={{ position: 'relative', zIndex: (theme: any) => theme.zIndex.modal + 2 }}
+      sx={{
+        position: 'relative',
+        zIndex: (theme: any) => theme.zIndex.modal + 2
+      }}
     >
       <PopupState variant="popover" popupId="demo-popup-menu">
         {(popupState: PopupStateType) => (

--- a/frontend/src/components/BCNavbar/types.ts
+++ b/frontend/src/components/BCNavbar/types.ts
@@ -21,6 +21,7 @@ export interface NavbarContextData {
   routes: NavbarRoute[]
   beta: boolean
   headerRightPart?: NavbarInjectedComponent
+  headerUtilityPart?: NavbarInjectedComponent
   menuRightPart?: NavbarInjectedComponent
 }
 
@@ -29,5 +30,6 @@ export interface BCNavbarProps {
   routes?: NavbarRoute[]
   beta?: boolean
   headerRightPart?: NavbarInjectedComponent
+  headerUtilityPart?: NavbarInjectedComponent
   menuRightPart?: NavbarInjectedComponent
 }

--- a/frontend/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.tsx
@@ -1,0 +1,1209 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Box,
+  CircularProgress,
+  Dialog,
+  Fade,
+  Button,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  TextField,
+  Tooltip,
+  Typography
+} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
+import CloseIcon from '@mui/icons-material/Close'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import BCButton from '@/components/BCButton'
+import {
+  useGlobalSearch,
+  type SearchGroup,
+  type SearchResultItem
+} from '@/hooks/useSearch'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { findPages } from './pages'
+
+const BC_NAVY = '#013366'
+const BC_GOLD = '#fcba19'
+const TEXT = '#2d2d2d'
+const MUTED = '#474543'
+const BORDER = '#d8d8d8'
+const SURFACE = '#faf9f8'
+const SELECT = 'rgba(56, 89, 138, 0.12)'
+const ACTIVE_BLUE = '#38598a'
+const RADIUS = '4px'
+
+const FILTER_KEYS = ['status', 'year', 'city', 'org', 'type', 'fuel', 'id']
+const FILTER_RE = new RegExp(`\\b(${FILTER_KEYS.join('|')}):(\\S+)`, 'gi')
+
+const STORAGE_KEY = 'lcfs-recent-searches'
+const MAX_RECENT = 5
+const getRecent = (): string[] => {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+const saveRecent = (q: string) =>
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify(
+      [q, ...getRecent().filter((r) => r !== q)].slice(0, MAX_RECENT)
+    )
+  )
+const removeRecent = (q: string) =>
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify(getRecent().filter((r) => r !== q))
+  )
+const clearRecent = () => localStorage.removeItem(STORAGE_KEY)
+
+const SEARCH_GUIDE: Array<{ label: string; tags: string[] }> = [
+  { label: 'Pages', tags: ['Section name', 'Menu item', 'Keyword'] },
+  {
+    label: 'Organizations',
+    tags: ['Name', 'Code', 'City', 'Contact', 'Email']
+  },
+  {
+    label: 'Compliance reports',
+    tags: ['Supplier', 'Year', 'Type', 'Status', 'ID']
+  },
+  { label: 'Transfers', tags: ['Supplier', 'ID', 'Status', 'Year'] },
+  { label: 'Fuel codes', tags: ['Code', 'Company', 'Fuel type', 'Status'] },
+  { label: 'CI applications', tags: ['Supplier', 'ID', 'City', 'Status'] },
+  { label: 'Initiative agreements', tags: ['Supplier', 'ID', 'Status'] },
+  { label: 'Users', tags: ['Name', 'Email', 'Title', 'Role', 'Status'] }
+]
+
+const NO_RESULTS_NOTE =
+  'Try broader terms, or use advanced filters in the relevant section of the portal.'
+const SEARCH_NOTE =
+  'You can also browse or filter records in the relevant section of the portal.'
+
+function Mark({ text, query }: { text: string; query: string }) {
+  if (!query || !text) return <>{text}</>
+  const tokens = query
+    .replace(FILTER_RE, (_match, _key, value) => ` ${value} `)
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length >= 2)
+    .map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+
+  if (!tokens.length) return <>{text}</>
+
+  const matcher = new RegExp(`(${tokens.join('|')})`, 'gi')
+  return (
+    <>
+      {text.split(matcher).map((part, index) =>
+        tokens.some(
+          (token) =>
+            part.toLowerCase() === token.replace(/\\/g, '').toLowerCase()
+        ) ? (
+          <Box
+            key={`${part}-${index}`}
+            component="mark"
+            sx={{
+              bgcolor: '#faedd1',
+              color: 'inherit',
+              fontWeight: 600,
+              px: 0.15,
+              borderRadius: '3px'
+            }}
+          >
+            {part}
+          </Box>
+        ) : (
+          <React.Fragment key={`${part}-${index}`}>{part}</React.Fragment>
+        )
+      )}
+    </>
+  )
+}
+
+const getSearchTokens = (query: string) =>
+  query
+    .replace(FILTER_RE, (_match, _key, value) => ` ${value} `)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length >= 2)
+
+const needsMatchContext = (item: SearchResultItem, query: string) => {
+  if (!item.matchContext) return false
+  const visibleText = [
+    item.title,
+    item.subtitle,
+    item.meta,
+    item.status,
+    ...(item.details ?? []).flatMap(({ label, value }) => [label, value])
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLocaleLowerCase()
+  return getSearchTokens(query).some(
+    (token) => !visibleText.includes(token.toLocaleLowerCase())
+  )
+}
+
+type ResultDetail = { label: string; value: string }
+
+const parseMatchContext = (context: string): ResultDetail => {
+  const separatorIndex = context.indexOf(': ')
+  if (separatorIndex === -1)
+    return { label: 'Additional detail', value: context }
+  return {
+    label: context.slice(0, separatorIndex),
+    value: context.slice(separatorIndex + 2)
+  }
+}
+
+const DetailList = ({
+  details,
+  query
+}: {
+  details: ResultDetail[]
+  query: string
+}) => (
+  <Box
+    component="dl"
+    sx={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      columnGap: 2,
+      rowGap: 0.45,
+      minWidth: 0,
+      m: 0,
+      mt: 0.65
+    }}
+  >
+    {details.map(({ label, value }, index) => (
+      <Box
+        component="div"
+        key={`${label}-${value}-${index}`}
+        sx={{ display: 'flex', minWidth: 0, gap: 0.5 }}
+      >
+        <Typography
+          component="dt"
+          noWrap
+          sx={{
+            color: MUTED,
+            fontSize: '0.8125rem',
+            fontWeight: 600,
+            lineHeight: 1.4
+          }}
+        >
+          {label}:
+        </Typography>
+        <Typography
+          component="dd"
+          noWrap
+          title={value}
+          sx={{
+            m: 0,
+            color: TEXT,
+            fontSize: '0.8125rem',
+            fontWeight: 400,
+            lineHeight: 1.4
+          }}
+        >
+          <Mark text={value} query={query} />
+        </Typography>
+      </Box>
+    ))}
+  </Box>
+)
+
+interface RowProps {
+  title: ReactNode
+  subtitle?: string
+  meta?: string | null
+  status?: string | null
+  matchContext?: string | null
+  details?: ResultDetail[]
+  query: string
+  trailing?: ReactNode
+  isSelected?: boolean
+  onMouseEnter?: () => void
+  onClick: () => void
+}
+
+const ResultRow = forwardRef<HTMLDivElement, RowProps>(
+  (
+    {
+      title,
+      subtitle,
+      meta,
+      status,
+      matchContext,
+      details,
+      query,
+      trailing,
+      isSelected = false,
+      onMouseEnter,
+      onClick
+    },
+    ref
+  ) => (
+    <Box
+      ref={ref}
+      role="option"
+      aria-selected={isSelected}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1.5,
+        px: 2.25,
+        py: 1.5,
+        borderBottom: `1px solid ${BORDER}`,
+        bgcolor: isSelected ? SELECT : '#fff',
+        boxShadow: isSelected
+          ? `inset 4px 0 0 ${ACTIVE_BLUE}`
+          : 'inset 4px 0 0 transparent',
+        transition: 'background-color 120ms ease, box-shadow 120ms ease',
+        '&:last-of-type': { borderBottom: 0 },
+        '&:hover': { bgcolor: SELECT },
+        '& *': { cursor: 'pointer !important' },
+        '&:hover .result-row-arrow': {
+          color: ACTIVE_BLUE,
+          opacity: 1
+        }
+      }}
+    >
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.25 }}>
+          <Typography
+            noWrap
+            sx={{
+              fontWeight: 700,
+              color: TEXT,
+              lineHeight: 1.35,
+              fontSize: '0.9375rem'
+            }}
+          >
+            {title}
+          </Typography>
+          {status && (
+            <Typography
+              noWrap
+              sx={{
+                color: MUTED,
+                fontSize: '0.8125rem',
+                fontWeight: 400,
+                flexShrink: 0,
+                lineHeight: 1.35
+              }}
+            >
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Status:
+              </Box>{' '}
+              <Mark text={status} query={query} />
+            </Typography>
+          )}
+        </Box>
+        {details && details.length > 0 ? (
+          <DetailList
+            details={[
+              ...details,
+              ...(matchContext ? [parseMatchContext(matchContext)] : [])
+            ]}
+            query={query}
+          />
+        ) : subtitle || meta ? (
+          <Typography
+            noWrap
+            sx={{
+              color: MUTED,
+              display: 'block',
+              lineHeight: 1.35,
+              fontSize: '0.8125rem',
+              mt: 0.15
+            }}
+          >
+            {subtitle && <Mark text={subtitle} query={query} />}
+            {subtitle && meta && ' · '}
+            {meta && <Mark text={meta} query={query} />}
+          </Typography>
+        ) : null}
+        {matchContext && (!details || details.length === 0) && (
+          <DetailList
+            details={[parseMatchContext(matchContext)]}
+            query={query}
+          />
+        )}
+      </Box>
+      {trailing ?? (
+        <ChevronRightIcon
+          className="result-row-arrow"
+          aria-hidden="true"
+          sx={{
+            alignSelf: 'center',
+            mr: 0.25,
+            color: isSelected ? ACTIVE_BLUE : MUTED,
+            fontSize: 18,
+            flexShrink: 0,
+            opacity: isSelected ? 1 : 0.45,
+            transition: 'color 120ms ease, opacity 120ms ease'
+          }}
+        />
+      )}
+    </Box>
+  )
+)
+ResultRow.displayName = 'ResultRow'
+
+export const GlobalSearch = () => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebounced] = useState('')
+  const [selectedIndex, setSelected] = useState(0)
+  const [sectionFilter, setSectionFilter] = useState('all')
+  const [recents, setRecents] = useState<string[]>([])
+  const anchorRef = useRef<HTMLButtonElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const selectedRef = useRef<HTMLDivElement>(null)
+  const resultsRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPod|iPad/.test(navigator.platform)
+  const shortcut = isMac ? '⌘ K' : 'Ctrl K'
+  const shortcutAriaLabel = isMac ? 'Command K' : 'Control K'
+  const { data: currentUser, hasAnyRole } = useCurrentUser()
+  const isGov = currentUser?.isGovernmentUser ?? false
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 260)
+    return () => clearTimeout(t)
+  }, [query])
+
+  useEffect(() => {
+    setSelected(0)
+    setSectionFilter('all')
+  }, [debouncedQuery])
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      const hasPlatformModifier = isMac ? e.metaKey : e.ctrlKey
+      if (hasPlatformModifier && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen(true)
+        setTimeout(() => inputRef.current?.focus(), 0)
+      }
+    }
+    document.addEventListener('keydown', h)
+    return () => document.removeEventListener('keydown', h)
+  }, [isMac])
+
+  useEffect(() => {
+    if (open) {
+      setRecents(getRecent())
+      setTimeout(() => inputRef.current?.focus(), 60)
+    }
+  }, [open])
+
+  useEffect(() => {
+    const selected = selectedRef.current
+    const list = resultsRef.current
+    if (!selected || !list) return
+    const selectedBox = selected.getBoundingClientRect()
+    const listBox = list.getBoundingClientRect()
+    if (selectedBox.bottom > listBox.bottom) {
+      list.scrollTop += selectedBox.bottom - listBox.bottom
+    } else if (selectedBox.top < listBox.top) {
+      list.scrollTop -= listBox.top - selectedBox.top
+    }
+  }, [selectedIndex])
+
+  const { data, isFetching } = useGlobalSearch(debouncedQuery)
+
+  useLayoutEffect(() => {
+    const list = resultsRef.current
+    if (list) list.scrollTop = 0
+  }, [debouncedQuery, data, sectionFilter])
+  const hasQuery = debouncedQuery.length >= 2
+  const pageItems: SearchResultItem[] = hasQuery
+    ? findPages(debouncedQuery, isGov, hasAnyRole).map((page, index) => ({
+        entityType: 'page',
+        entityId: index,
+        title: page.label,
+        subtitle: page.section,
+        details: [{ label: 'Section', value: page.section }],
+        route: page.route
+      }))
+    : []
+  const pageGroups: SearchGroup[] = pageItems.length
+    ? [{ entityType: 'page', label: 'Pages', items: pageItems }]
+    : []
+  const groups: SearchGroup[] = [...pageGroups, ...(data?.groups ?? [])]
+  const filteredGroups =
+    sectionFilter === 'all'
+      ? groups
+      : groups.filter((group) => group.entityType === sectionFilter)
+  const allItems: SearchResultItem[] = groups.flatMap((group) => group.items)
+  const visibleItems: SearchResultItem[] = filteredGroups.flatMap(
+    (group) => group.items
+  )
+  const total = allItems.length
+  const visibleTotal = visibleItems.length
+  const activeGroup = groups.find((group) => group.entityType === sectionFilter)
+
+  const close = () => {
+    setOpen(false)
+    setQuery('')
+    setDebounced('')
+    setSelected(0)
+    setSectionFilter('all')
+  }
+
+  const go = (route: string, q?: string) => {
+    if (q) saveRecent(q)
+    close()
+    navigate(route)
+  }
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelected((i) => Math.min(i + 1, visibleItems.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelected((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && visibleItems[selectedIndex]) {
+      e.preventDefault()
+      go(visibleItems[selectedIndex].route, debouncedQuery || undefined)
+    } else if (e.key === 'Escape') {
+      close()
+    }
+  }
+
+  const showNone = hasQuery && total === 0 && !!data && !isFetching
+  const showResults = hasQuery && total > 0
+  const guide = isGov
+    ? SEARCH_GUIDE
+    : SEARCH_GUIDE.filter((row) => row.label !== 'Organizations')
+
+  return (
+    <>
+      <Box
+        sx={{
+          alignSelf: 'stretch',
+          display: 'flex',
+          alignItems: 'center',
+          mx: 0.5
+        }}
+      >
+        <Tooltip title={shortcut} disableInteractive>
+          <BCButton
+            ref={anchorRef}
+            color="light"
+            size="small"
+            variant="outlined"
+            startIcon={<SearchIcon sx={{ width: '18px', height: '18px' }} />}
+            aria-label={`Search portal, keyboard shortcut ${shortcutAriaLabel}`}
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+            onClick={() => {
+              setOpen((current) => !current)
+            }}
+            sx={{
+              maxHeight: '32px',
+              '&:focus:not(:hover)': {
+                boxShadow: 'none'
+              },
+              '&.Mui-focusVisible': {
+                outline: `2px solid ${BC_GOLD}`,
+                outlineOffset: 2
+              },
+              '&:hover': {
+                backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                color: 'rgba(0, 0, 0, 0.8)',
+                borderColor: 'rgba(0, 0, 0, 0.8)'
+              }
+            }}
+          >
+            Search portal
+          </BCButton>
+        </Tooltip>
+      </Box>
+
+      <Dialog
+        open={open}
+        onClose={close}
+        fullWidth
+        maxWidth="md"
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 140 }}
+        sx={{
+          zIndex: (theme) => theme.zIndex.modal + 3,
+          '& .MuiDialog-container': {
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+            pt: { xs: '48px', sm: '72px', md: '96px' },
+            pb: 2,
+            overflow: 'hidden'
+          },
+          '& .MuiBackdrop-root': { bgcolor: 'rgba(49, 49, 50, 0.45)' }
+        }}
+        PaperProps={{
+          elevation: 0,
+          sx: {
+            display: 'flex',
+            flexDirection: 'column',
+            borderRadius: RADIUS,
+            overflow: 'hidden',
+            border: '1px solid #898785',
+            borderTop: `4px solid ${BC_GOLD}`,
+            bgcolor: '#fff',
+            boxShadow: '0 12px 32px rgba(0, 0, 0, 0.24)',
+            m: 0,
+            maxWidth: '1040px',
+            width: { xs: 'calc(100% - 16px)', sm: 'calc(100% - 32px)' },
+            maxHeight: {
+              xs: 'calc(100vh - 64px)',
+              sm: 'calc(100vh - 92px)',
+              md: 'calc(100vh - 116px)'
+            }
+          }
+        }}
+        aria-labelledby="global-search-title"
+      >
+        <Box
+          component="header"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            px: 3,
+            py: 1.4,
+            bgcolor: BC_NAVY,
+            flexShrink: 0
+          }}
+        >
+          <Typography
+            id="global-search-title"
+            component="h2"
+            sx={{
+              fontSize: '1.125rem',
+              fontWeight: 700,
+              color: '#fff',
+              lineHeight: 1.3
+            }}
+          >
+            Search portal
+          </Typography>
+          <IconButton
+            size="small"
+            aria-label="Close search"
+            onClick={close}
+            sx={{
+              color: 'rgba(255, 255, 255, 0.85)',
+              '&:hover': {
+                color: '#fff',
+                bgcolor: 'rgba(255, 255, 255, 0.12)'
+              },
+              '&.Mui-focusVisible': {
+                outline: `2px solid ${BC_GOLD}`,
+                outlineOffset: 1
+              }
+            }}
+          >
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </IconButton>
+        </Box>
+
+        <Box
+          sx={{
+            px: 3,
+            py: 2,
+            bgcolor: '#f5f5f5',
+            flexShrink: 0
+          }}
+        >
+          <TextField
+            inputRef={inputRef}
+            autoFocus
+            fullWidth
+            size="small"
+            variant="outlined"
+            placeholder="Search all portal content"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKey}
+            autoComplete="off"
+            inputProps={{ 'aria-label': 'Search all portal content' }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  {isFetching ? (
+                    <CircularProgress size={18} />
+                  ) : (
+                    <SearchIcon sx={{ fontSize: 20, color: BC_NAVY }} />
+                  )}
+                </InputAdornment>
+              ),
+              endAdornment: query ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    aria-label="Clear search"
+                    onClick={() => {
+                      setQuery('')
+                      inputRef.current?.focus()
+                    }}
+                    sx={{ color: MUTED }}
+                  >
+                    <CloseIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined
+            }}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                height: 46,
+                bgcolor: '#fff',
+                borderRadius: '4px',
+                '& fieldset': { borderColor: '#898785' },
+                '&:hover fieldset': { borderColor: ACTIVE_BLUE },
+                '&.Mui-focused fieldset': {
+                  borderColor: ACTIVE_BLUE,
+                  borderWidth: 2
+                }
+              },
+              '& .MuiInputBase-input': {
+                fontSize: '1rem',
+                fontWeight: 400,
+                lineHeight: 1.4,
+                color: TEXT,
+                '&::placeholder': {
+                  opacity: 1,
+                  color: MUTED
+                }
+              }
+            }}
+          />
+        </Box>
+
+        <Box
+          sx={{
+            flex: '1 1 520px',
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            borderTop: `1px solid ${BORDER}`,
+            bgcolor: '#fff',
+            overflow: 'hidden'
+          }}
+        >
+          {showResults && groups.length > 1 && (
+            <Box
+              component="nav"
+              aria-label="Result type"
+              sx={{
+                display: 'flex',
+                flexDirection: { xs: 'row', sm: 'column' },
+                gap: 0.25,
+                width: { xs: '100%', sm: 200 },
+                p: { xs: 0.75, sm: 1.25 },
+                flexShrink: 0,
+                overflowX: { xs: 'auto', sm: 'visible' },
+                overflowY: { xs: 'hidden', sm: 'auto' },
+                bgcolor: SURFACE,
+                borderBottom: { xs: `1px solid ${BORDER}`, sm: 0 },
+                borderRight: { xs: 0, sm: `1px solid ${BORDER}` }
+              }}
+            >
+              <Typography
+                sx={{
+                  display: { xs: 'none', sm: 'block' },
+                  px: 1,
+                  pt: 0.25,
+                  pb: 0.65,
+                  color: BC_NAVY,
+                  fontSize: '0.8125rem',
+                  fontWeight: 700,
+                  lineHeight: 1.4
+                }}
+              >
+                Result type
+              </Typography>
+              {[
+                { value: 'all', label: 'All results', count: total },
+                ...groups.map((group) => ({
+                  value: group.entityType,
+                  label: group.label,
+                  count: group.items.length
+                }))
+              ].map((option) => {
+                const isActive = sectionFilter === option.value
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    size="small"
+                    aria-pressed={isActive}
+                    onClick={() => {
+                      setSectionFilter(option.value)
+                      setSelected(0)
+                    }}
+                    sx={{
+                      justifyContent: 'space-between',
+                      gap: 1,
+                      minWidth: { xs: 'max-content', sm: 0 },
+                      width: { xs: 'auto', sm: '100%' },
+                      px: 1,
+                      py: 0.6,
+                      border: 0,
+                      borderRadius: '2px',
+                      bgcolor: isActive ? SELECT : 'transparent',
+                      boxShadow: 'none',
+                      color: isActive ? BC_NAVY : TEXT,
+                      fontSize: '0.8125rem',
+                      fontWeight: isActive ? 600 : 400,
+                      lineHeight: 1.35,
+                      letterSpacing: 0,
+                      textTransform: 'none',
+                      '&:hover': {
+                        bgcolor: isActive ? SELECT : 'rgba(56, 89, 138, 0.08)',
+                        color: BC_NAVY
+                      },
+                      '&.Mui-focusVisible': {
+                        outline: `2px solid ${ACTIVE_BLUE}`,
+                        outlineOffset: 1
+                      }
+                    }}
+                  >
+                    <Box
+                      component="span"
+                      sx={{
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        textAlign: 'left'
+                      }}
+                    >
+                      {option.label}
+                    </Box>
+                    <Box
+                      component="span"
+                      sx={{
+                        color: MUTED,
+                        fontSize: '0.75rem',
+                        fontWeight: 400
+                      }}
+                    >
+                      {option.count}
+                    </Box>
+                  </Button>
+                )
+              })}
+            </Box>
+          )}
+
+          <Box
+            ref={resultsRef}
+            role="listbox"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              minHeight: 0,
+              overflowY: 'auto',
+              overflowAnchor: 'none',
+              bgcolor: '#fff',
+              overscrollBehavior: 'contain'
+            }}
+          >
+            {showResults && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  px: 2.5,
+                  py: 1.25,
+                  bgcolor: '#fff',
+                  borderBottom: `1px solid ${BORDER}`
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: BC_NAVY,
+                    fontSize: '0.9375rem',
+                    fontWeight: 700,
+                    lineHeight: 1.35
+                  }}
+                >
+                  {sectionFilter === 'all' ? 'All results' : activeGroup?.label}
+                </Typography>
+                <Typography
+                  aria-live="polite"
+                  sx={{
+                    color: MUTED,
+                    fontSize: '0.8125rem',
+                    lineHeight: 1.35,
+                    flexShrink: 0
+                  }}
+                >
+                  {sectionFilter === 'all'
+                    ? `${total} result${total === 1 ? '' : 's'}`
+                    : `${visibleTotal} of ${total} results`}
+                </Typography>
+              </Box>
+            )}
+
+            {!hasQuery && (
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: {
+                    xs: 'minmax(0, 1fr)',
+                    md: recents.length
+                      ? 'minmax(220px, 0.75fr) minmax(0, 1.75fr)'
+                      : 'minmax(0, 1fr)'
+                  },
+                  gap: 3,
+                  px: 3,
+                  py: 2.25,
+                  alignItems: 'start'
+                }}
+              >
+                {recents.length > 0 && (
+                  <Box component="section" aria-labelledby="recent-heading">
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                        mb: 1.25
+                      }}
+                    >
+                      <Typography
+                        id="recent-heading"
+                        sx={{
+                          fontSize: '0.875rem',
+                          fontWeight: 700,
+                          color: BC_NAVY,
+                          lineHeight: 1.3
+                        }}
+                      >
+                        Recent searches
+                      </Typography>
+                      <Button
+                        type="button"
+                        size="small"
+                        onClick={() => {
+                          clearRecent()
+                          setRecents([])
+                        }}
+                        sx={{
+                          minWidth: 0,
+                          p: 0,
+                          color: BC_NAVY,
+                          fontSize: '0.75rem',
+                          fontWeight: 400,
+                          letterSpacing: 0,
+                          lineHeight: 1.4,
+                          textTransform: 'none',
+                          '&:hover': {
+                            bgcolor: 'transparent',
+                            textDecoration: 'underline'
+                          }
+                        }}
+                      >
+                        Clear
+                      </Button>
+                    </Box>
+                    <List
+                      disablePadding
+                      sx={{
+                        border: `1px solid ${BORDER}`,
+                        borderRadius: RADIUS,
+                        overflow: 'hidden'
+                      }}
+                    >
+                      {recents.map((recent, index) => (
+                        <ListItem
+                          key={recent}
+                          disablePadding
+                          sx={{
+                            borderTop:
+                              index === 0 ? 'none' : `1px solid ${BORDER}`,
+                            '&:hover .recent-search-remove, &:focus-within .recent-search-remove':
+                              { opacity: 1 }
+                          }}
+                          secondaryAction={
+                            <IconButton
+                              className="recent-search-remove"
+                              edge="end"
+                              size="small"
+                              aria-label={`Remove ${recent} from recent searches`}
+                              onClick={() => {
+                                removeRecent(recent)
+                                setRecents(getRecent())
+                              }}
+                              sx={{
+                                color: MUTED,
+                                mr: 0.25,
+                                opacity: { xs: 1, sm: 0 },
+                                transition: 'opacity 120ms ease',
+                                '&:hover': {
+                                  color: BC_NAVY,
+                                  bgcolor: SELECT
+                                }
+                              }}
+                            >
+                              <CloseIcon sx={{ fontSize: 16 }} />
+                            </IconButton>
+                          }
+                        >
+                          <ListItemButton
+                            onClick={() => {
+                              setQuery(recent)
+                              inputRef.current?.focus()
+                            }}
+                            sx={{
+                              minHeight: 42,
+                              px: 1.5,
+                              py: 0.7,
+                              pr: 5,
+                              '&:hover': { bgcolor: SELECT },
+                              '&.Mui-focusVisible': {
+                                bgcolor: SELECT,
+                                outline: `2px solid ${ACTIVE_BLUE}`,
+                                outlineOffset: -2
+                              }
+                            }}
+                          >
+                            <ListItemText
+                              primary={recent}
+                              primaryTypographyProps={{
+                                noWrap: true,
+                                sx: {
+                                  color: TEXT,
+                                  fontSize: '0.875rem',
+                                  lineHeight: 1.4
+                                }
+                              }}
+                            />
+                          </ListItemButton>
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Box>
+                )}
+
+                <Box component="section" aria-labelledby="search-guide-heading">
+                  <Typography
+                    id="search-guide-heading"
+                    sx={{
+                      fontSize: '0.875rem',
+                      fontWeight: 700,
+                      color: BC_NAVY,
+                      mb: 1.25,
+                      lineHeight: 1.3
+                    }}
+                  >
+                    What you can search
+                  </Typography>
+                  <Box
+                    sx={{
+                      border: `1px solid ${BORDER}`,
+                      borderRadius: RADIUS,
+                      overflow: 'hidden'
+                    }}
+                  >
+                    {guide.map(({ label, tags }, index) => (
+                      <Box
+                        key={label}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'baseline',
+                          justifyContent: 'space-between',
+                          gap: 2,
+                          px: 2,
+                          py: 1.25,
+                          bgcolor: index % 2 === 1 ? SURFACE : '#fff',
+                          borderTop:
+                            index === 0 ? 'none' : `1px solid ${BORDER}`
+                        }}
+                      >
+                        <Typography
+                          sx={{
+                            fontSize: '0.875rem',
+                            fontWeight: 700,
+                            color: BC_NAVY,
+                            lineHeight: 1.4,
+                            flexShrink: 0
+                          }}
+                        >
+                          {label}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            fontSize: '0.8125rem',
+                            color: MUTED,
+                            lineHeight: 1.4,
+                            textAlign: 'right'
+                          }}
+                        >
+                          {tags.join(', ')}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Box>
+              </Box>
+            )}
+
+            {showNone && (
+              <Box sx={{ px: 3, py: 6, textAlign: 'center' }}>
+                <Typography
+                  sx={{ fontSize: '1rem', color: BC_NAVY, fontWeight: 700 }}
+                >
+                  No results found for “{debouncedQuery}”
+                </Typography>
+                <Typography
+                  sx={{
+                    mt: 0.75,
+                    fontSize: '0.875rem',
+                    color: MUTED,
+                    lineHeight: 1.5
+                  }}
+                >
+                  {NO_RESULTS_NOTE}
+                </Typography>
+              </Box>
+            )}
+
+            {showResults &&
+              filteredGroups.map((group) => (
+                <Box key={group.entityType}>
+                  {sectionFilter === 'all' && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        px: 2.5,
+                        py: 0.9,
+                        bgcolor: SURFACE,
+                        borderBottom: `1px solid ${BORDER}`,
+                        borderTop: `1px solid ${BORDER}`,
+                        position: 'sticky',
+                        top: 0,
+                        zIndex: 1
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontSize: '0.875rem',
+                          fontWeight: 700,
+                          color: BC_NAVY,
+                          lineHeight: 1.3
+                        }}
+                      >
+                        <Mark text={group.label} query={debouncedQuery} />
+                      </Typography>
+                      <Typography
+                        aria-label={`${group.items.length} results`}
+                        sx={{
+                          fontSize: '0.75rem',
+                          fontWeight: 400,
+                          color: MUTED
+                        }}
+                      >
+                        {group.items.length}{' '}
+                        {group.items.length === 1 ? 'result' : 'results'}
+                      </Typography>
+                    </Box>
+                  )}
+                  {group.items.map((item) => {
+                    const gIdx = visibleItems.indexOf(item)
+                    const isSel = gIdx === selectedIndex
+                    return (
+                      <ResultRow
+                        key={`${item.entityType}-${item.entityId}`}
+                        ref={isSel ? selectedRef : undefined}
+                        isSelected={isSel}
+                        title={
+                          <Mark text={item.title} query={debouncedQuery} />
+                        }
+                        subtitle={item.subtitle || undefined}
+                        meta={item.meta}
+                        status={item.status ?? undefined}
+                        matchContext={
+                          needsMatchContext(item, debouncedQuery)
+                            ? item.matchContext
+                            : undefined
+                        }
+                        details={item.details}
+                        query={debouncedQuery}
+                        onMouseEnter={() => setSelected(gIdx)}
+                        onClick={() =>
+                          go(item.route, debouncedQuery || undefined)
+                        }
+                      />
+                    )
+                  })}
+                </Box>
+              ))}
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            px: 3,
+            py: 1.1,
+            bgcolor: SURFACE,
+            borderTop: `1px solid ${BORDER}`,
+            minHeight: 42,
+            flexShrink: 0
+          }}
+        >
+          <Typography
+            sx={{
+              minWidth: 0,
+              fontSize: '0.75rem',
+              fontWeight: 400,
+              color: MUTED,
+              lineHeight: 1.4
+            }}
+          >
+            {SEARCH_NOTE}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.8125rem',
+              color: MUTED,
+              flexShrink: 0
+            }}
+          >
+            Press Esc to close
+          </Typography>
+        </Box>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/components/GlobalSearch/pages.ts
+++ b/frontend/src/components/GlobalSearch/pages.ts
@@ -1,0 +1,264 @@
+import ROUTES from '@/routes/routes'
+import { roles, type RoleName } from '@/constants/roles'
+
+export interface PageLink {
+  label: string
+  route: string
+  section: string
+  keywords?: string[]
+}
+
+interface PageDefinition extends PageLink {
+  audience?: 'gov' | 'org'
+  anyRole?: RoleName[]
+}
+
+const PAGES: PageDefinition[] = [
+  {
+    label: 'Dashboard',
+    route: ROUTES.DASHBOARD,
+    section: 'Home',
+    keywords: ['home', 'landing', 'overview']
+  },
+  {
+    label: 'Notifications',
+    route: ROUTES.NOTIFICATIONS.LIST,
+    section: 'Notifications',
+    keywords: ['alerts', 'messages', 'inbox']
+  },
+  {
+    label: 'Notification settings',
+    route: ROUTES.NOTIFICATIONS.SETTINGS,
+    section: 'Notifications',
+    keywords: ['configure', 'email', 'subscriptions', 'preferences']
+  },
+  {
+    label: 'Transactions',
+    route: ROUTES.TRANSACTIONS.LIST,
+    section: 'Transactions',
+    keywords: ['credits', 'units', 'ledger']
+  },
+  {
+    label: 'Credit trading market',
+    route: ROUTES.TRANSACTIONS.CREDIT_TRADING_MARKET,
+    section: 'Transactions',
+    keywords: ['market', 'buy', 'sell', 'listings']
+  },
+  {
+    label: 'Credit trading market audit log',
+    route: ROUTES.TRANSACTIONS.CREDIT_TRADING_MARKET_AUDIT_LOG,
+    section: 'Transactions',
+    audience: 'gov',
+    keywords: ['market', 'history']
+  },
+  {
+    label: 'New transfer',
+    route: ROUTES.TRANSFERS.ADD,
+    section: 'Transactions',
+    anyRole: [roles.transfers, roles.government],
+    keywords: ['create transfer', 'send credits']
+  },
+  {
+    label: 'Compliance reporting',
+    route: ROUTES.REPORTS.LIST,
+    section: 'Compliance reporting',
+    keywords: ['reports', 'annual report', 'submissions']
+  },
+  {
+    label: 'Report openings',
+    route: ROUTES.REPORTS.REPORT_OPENINGS,
+    section: 'Compliance reporting',
+    audience: 'gov',
+    keywords: ['periods', 'open reports']
+  },
+  {
+    label: 'Charging sites',
+    route: ROUTES.REPORTS.CHARGING_SITE.INDEX,
+    section: 'Compliance reporting',
+    keywords: ['ev', 'chargers', 'stations']
+  },
+  {
+    label: 'Manage FSE',
+    route: ROUTES.REPORTS.MANAGE_FSE,
+    section: 'Compliance reporting',
+    keywords: ['final supply equipment', 'chargers']
+  },
+  {
+    label: 'FSE map',
+    route: ROUTES.REPORTS.FSE_MAP,
+    section: 'Compliance reporting',
+    keywords: ['final supply equipment', 'map', 'locations']
+  },
+  {
+    label: 'Fuel codes',
+    route: ROUTES.FUEL_CODES.LIST,
+    section: 'Fuel codes',
+    audience: 'gov',
+    keywords: ['carbon intensity', 'ci']
+  },
+  {
+    label: 'Fuel code bulletins',
+    route: ROUTES.FUEL_CODES.BULLETINS,
+    section: 'Fuel codes',
+    keywords: ['bulletins', 'published fuel codes']
+  },
+  {
+    label: 'My fuel codes',
+    route: ROUTES.FUEL_CODES.MY_LIST,
+    section: 'Fuel codes',
+    audience: 'org',
+    keywords: ['my codes']
+  },
+  {
+    label: 'CI applications',
+    route: ROUTES.CI_APPLICATIONS.LIST,
+    section: 'Fuel codes',
+    keywords: ['carbon intensity application', 'apply']
+  },
+  {
+    label: 'Approved carbon intensities',
+    route: ROUTES.APPROVED_CARBON_INTENSITIES,
+    section: 'Reference',
+    keywords: ['ci', 'approved', 'values']
+  },
+  {
+    label: 'Compliance unit calculator',
+    route: ROUTES.CREDIT_CALCULATOR,
+    section: 'Reference',
+    keywords: ['calculator', 'estimate', 'credits']
+  },
+  {
+    label: 'Calculation data',
+    route: ROUTES.CALCULATION_DATA,
+    section: 'Reference',
+    keywords: ['calculator', 'data', 'inputs']
+  },
+  {
+    label: 'Release notes',
+    route: ROUTES.RELEASE_NOTES,
+    section: 'Reference',
+    keywords: ['whats new', 'changes', 'version']
+  },
+  {
+    label: 'Initiative agreements',
+    route: ROUTES.INITIATIVE_AGREEMENTS.LIST,
+    section: 'Initiative agreements',
+    anyRole: [
+      roles.ia_analyst,
+      roles.ia_manager,
+      roles.director,
+      roles.ia_proponent
+    ]
+  },
+  {
+    label: 'Organizations',
+    route: ROUTES.ORGANIZATIONS.LIST,
+    section: 'Organizations',
+    audience: 'gov',
+    keywords: ['suppliers', 'companies']
+  },
+  {
+    label: 'Organization profile',
+    route: ROUTES.ORGANIZATION.ORG,
+    section: 'Organization',
+    audience: 'org',
+    keywords: ['company', 'address', 'details']
+  },
+  {
+    label: 'Organization users',
+    route: ROUTES.ORGANIZATION.USERS,
+    section: 'Organization',
+    audience: 'org',
+    keywords: ['people', 'staff', 'accounts']
+  },
+  {
+    label: 'Credit ledger',
+    route: ROUTES.ORGANIZATION.CREDIT_LEDGER,
+    section: 'Organization',
+    audience: 'org',
+    keywords: ['balance', 'units']
+  },
+  {
+    label: 'Administration',
+    route: ROUTES.ADMIN.MAIN,
+    section: 'Administration',
+    audience: 'gov',
+    anyRole: [roles.administrator, roles.system_admin]
+  },
+  {
+    label: 'IDIR users',
+    route: ROUTES.ADMIN.USERS.LIST,
+    section: 'Administration',
+    audience: 'gov',
+    anyRole: [roles.administrator, roles.system_admin],
+    keywords: ['government users', 'staff', 'accounts']
+  },
+  {
+    label: 'User activity',
+    route: ROUTES.ADMIN.USER_ACTIVITY,
+    section: 'Administration',
+    audience: 'gov',
+    anyRole: [roles.administrator, roles.system_admin]
+  },
+  {
+    label: 'User login history',
+    route: ROUTES.ADMIN.USER_LOGIN_HISTORY,
+    section: 'Administration',
+    audience: 'gov',
+    anyRole: [roles.administrator, roles.system_admin],
+    keywords: ['logins', 'sign in']
+  },
+  {
+    label: 'Audit log',
+    route: ROUTES.ADMIN.AUDIT_LOG.LIST,
+    section: 'Administration',
+    audience: 'gov',
+    anyRole: [roles.administrator, roles.system_admin],
+    keywords: ['history', 'changes']
+  }
+]
+
+type RoleCheck = (...roleNames: RoleName[]) => boolean
+
+export const findPages = (
+  query: string,
+  isGov: boolean,
+  hasAnyRole: RoleCheck,
+  limit = 5
+): PageLink[] => {
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length >= 2)
+  if (!tokens.length) return []
+
+  const scored = PAGES.filter((page) => {
+    if (page.audience === 'gov' && !isGov) return false
+    if (page.audience === 'org' && isGov) return false
+    return !page.anyRole || hasAnyRole(...page.anyRole)
+  })
+    .map((page) => {
+      const label = page.label.toLowerCase()
+      const haystack = [label, page.section, ...(page.keywords ?? [])]
+        .join(' ')
+        .toLowerCase()
+      if (!tokens.every((token) => haystack.includes(token))) return null
+      const joined = tokens.join(' ')
+      const score = label === joined ? 3 : label.startsWith(joined) ? 2 : 1
+      return { page, score }
+    })
+    .filter(
+      (entry): entry is { page: PageDefinition; score: number } =>
+        entry !== null
+    )
+    .sort(
+      (a, b) => b.score - a.score || a.page.label.localeCompare(b.page.label)
+    )
+
+  return scored.slice(0, limit).map(({ page }) => ({
+    label: page.label,
+    route: page.route,
+    section: page.section,
+    keywords: page.keywords
+  }))
+}

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -1,0 +1,42 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import { useApiService } from '@/services/useApiService'
+
+export interface SearchResultItem {
+  entityType: string
+  entityId: number
+  title: string
+  subtitle: string
+  route: string
+  status?: string | null
+  meta?: string | null
+  matchContext?: string | null
+  details?: Array<{ label: string; value: string }>
+}
+
+export interface SearchGroup {
+  entityType: string
+  label: string
+  items: SearchResultItem[]
+}
+
+export interface SearchResponse {
+  query: string
+  groups: SearchGroup[]
+  total: number
+  appliedFilters?: Record<string, string>
+}
+
+export const useGlobalSearch = (q: string) => {
+  const client = useApiService()
+
+  return useQuery<SearchResponse>({
+    queryKey: ['global-search', q],
+    queryFn: async () => {
+      const response = await client.get(`/search/?q=${encodeURIComponent(q)}`)
+      return response.data
+    },
+    enabled: q.trim().length >= 2,
+    staleTime: 30_000,
+    placeholderData: keepPreviousData
+  })
+}

--- a/frontend/src/layouts/MainLayout/components/HeaderComponent.tsx
+++ b/frontend/src/layouts/MainLayout/components/HeaderComponent.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import BCTypography from '@/components/BCTypography'
-import SupplierBalance from './SupplierBalance' // Adjust the import path as necessary
+import SupplierBalance from './SupplierBalance'
 import { NavLink } from 'react-router-dom'
 import { ROUTES } from '@/routes/routes'
 import BCBox from '@/components/BCBox'

--- a/frontend/src/layouts/MainLayout/components/Navbar.tsx
+++ b/frontend/src/layouts/MainLayout/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HeaderComponent } from './HeaderComponent'
 import { UserProfileActions } from './UserProfileActions'
+import { GlobalSearch } from '@/components/GlobalSearch/GlobalSearch'
 import { useMediaQuery, useTheme } from '@mui/material'
 
 type NavItem = {
@@ -107,6 +108,7 @@ export const Navbar = () => {
       beta={false}
       data-test="main-layout-navbar"
       headerRightPart={<HeaderComponent key="headerRight" />}
+      headerUtilityPart={<GlobalSearch key="headerSearch" />}
       menuRightPart={<UserProfileActions key="menuRight" />}
     />
   )

--- a/frontend/src/views/FuelCodes/FuelCodeDetail/FuelCodeDetail.tsx
+++ b/frontend/src/views/FuelCodes/FuelCodeDetail/FuelCodeDetail.tsx
@@ -12,11 +12,12 @@ import BCWidgetCard from '@/components/BCWidgetCard/BCWidgetCard'
 import { BCGridViewer } from '@/components/BCDataGrid/BCGridViewer'
 import { FuelCodesTabs } from '@/views/CarbonIntensity/components/FuelCodesTabs'
 import { ROUTES, buildPath } from '@/routes/routes'
-import { useGetFuelCodeGroup } from '@/hooks/useFuelCode'
+import { useGetFuelCode, useGetFuelCodeGroup } from '@/hooks/useFuelCode'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useFuelCodePageStore } from '@/stores/useFuelCodePageStore'
 import { LinkRenderer } from '@/utils/grid/cellRenderers'
 import withRole from '@/utils/withRole'
-import { govRoles } from '@/constants/roles'
+import { govRoles, nonGovRoles } from '@/constants/roles'
 import { iterationColDefs } from './_schema'
 
 const formatDate = (value) => {
@@ -138,7 +139,6 @@ const IterationCardContent = ({ data, t }) => {
         columnGap={8}
         rowGap={0}
       >
-        {/* Left Column — fuel & feedstock info */}
         <BCBox display="flex" flexDirection="column">
           <DetailRow
             label="Fuel"
@@ -196,7 +196,6 @@ const IterationCardContent = ({ data, t }) => {
           />
         </BCBox>
 
-        {/* Right Column — company, contact, dates */}
         <BCBox display="flex" flexDirection="column">
           {data.company && (
             <BCTypography
@@ -462,6 +461,8 @@ const ComplianceUnitsChart = ({ data, t }) => {
 const FuelCodeDetailBase = () => {
   const { fuelCodeID } = useParams()
   const { t } = useTranslation(['fuelCode', 'common'])
+  const { data: currentUser } = useCurrentUser()
+  const isGovernmentUser = currentUser?.isGovernmentUser === true
   const gridRef = useRef(null)
   const [paginationOptions, setPaginationOptions] = useState({
     page: 1,
@@ -473,7 +474,25 @@ const FuelCodeDetailBase = () => {
     (state) => state.setFuelCodeTitle
   )
 
-  const { data, isLoading, isError, error } = useGetFuelCodeGroup(fuelCodeID)
+  const groupQuery = useGetFuelCodeGroup(fuelCodeID, {
+    enabled: Boolean(fuelCodeID) && isGovernmentUser
+  })
+  const fuelCodeQuery = useGetFuelCode(fuelCodeID, {
+    enabled: Boolean(fuelCodeID) && !isGovernmentUser
+  })
+
+  const activeQuery = isGovernmentUser ? groupQuery : fuelCodeQuery
+  const { isLoading, isError, error } = activeQuery
+  const data = isGovernmentUser
+    ? groupQuery.data
+    : fuelCodeQuery.data
+      ? {
+          latestIteration: fuelCodeQuery.data,
+          iterations: [],
+          volumeOverTime: [],
+          complianceUnitsOverTime: []
+        }
+      : undefined
 
   const latest = data?.latestIteration
   const iterations = data?.iterations ?? []
@@ -486,7 +505,6 @@ const FuelCodeDetailBase = () => {
   const baseTitle = formatFuelCodeLabel(prefix, baseSuffix)
   const iterationLabel = formatFuelCodeLabel(prefix, suffix)
 
-  // Sync the base fuel code title into the breadcrumb store
   useEffect(() => {
     if (baseTitle) {
       setFuelCodeTitle(baseTitle)
@@ -572,10 +590,9 @@ const FuelCodeDetailBase = () => {
 
   return (
     <BCBox mx={-1}>
-      <FuelCodesTabs variant="internal" />
+      <FuelCodesTabs variant={isGovernmentUser ? 'internal' : 'default'} />
 
       <BCBox sx={{ px: 3, pt: 2 }}>
-        {/* Latest iteration card */}
         {isLoading ? (
           <>
             <Skeleton variant="text" width={280} height={42} sx={{ mb: 2 }} />
@@ -615,99 +632,104 @@ const FuelCodeDetailBase = () => {
           </>
         )}
 
-        {/* Iterations table */}
-        <BCTypography variant="h6" color="primary" sx={{ mb: 1 }}>
-          {isLoading
-            ? t('fuelCode:detail.allIterationsTitle')
-            : baseTitle
-              ? `${baseTitle} ${t('fuelCode:detail.iterationsSuffix')}`
-              : t('fuelCode:detail.allIterationsTitle')}
-        </BCTypography>
-        <BCBox sx={{ width: '100%', mb: 4, overflowX: 'auto' }}>
-          {isLoading ? (
-            <Card elevation={1} sx={{ width: '100%', minWidth: 980 }}>
-              <CardContent sx={{ p: 2 }}>
-                <Skeleton variant="rounded" height={38} sx={{ mb: 1 }} />
-                <Skeleton variant="rounded" height={46} sx={{ mb: 1 }} />
-                <Skeleton variant="rounded" height={46} sx={{ mb: 1 }} />
-                <Skeleton variant="rounded" height={46} />
-              </CardContent>
-            </Card>
-          ) : (
-            <BCGridViewer
-              gridRef={gridRef}
-              queryData={queryData}
-              dataKey="fuelCodes"
-              columnDefs={colDefs}
-              gridKey="fuel-code-iterations-grid"
-              gridOptions={iterationGridOptions}
-              defaultColDef={iterationDefaultColDef}
-              paginationOptions={paginationOptions}
-              onPaginationChange={handleIterationPaginationChange}
-              enablePageCaching={false}
-              overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
-              getRowId={(params) =>
-                params.data.id ?? params.data.fuelCodeId?.toString()
-              }
-            />
-          )}
-        </BCBox>
-
-        {/* Charts: side-by-side when ≥750px viewport, stacked below */}
-        {/* Charts: stacked under 750px, side-by-side above */}
-        <BCBox
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: 'minmax(0, 1fr)',
-            '@media (min-width:750px)': {
-              gridTemplateColumns: 'repeat(2, minmax(320px, 1fr))'
-            },
-            columnGap: { xs: 2, md: 3 },
-            rowGap: { xs: 2, md: 3 },
-            mb: 4,
-            width: '100%',
-            maxWidth: '2160px'
-          }}
-        >
-          {/* Volume over time chart */}
-          <BCBox sx={{ minWidth: 0 }}>
+        {isGovernmentUser && (
+          <>
             <BCTypography variant="h6" color="primary" sx={{ mb: 1 }}>
-              {t('fuelCode:detail.volumeOverTimeTitle')}
+              {isLoading
+                ? t('fuelCode:detail.allIterationsTitle')
+                : baseTitle
+                  ? `${baseTitle} ${t('fuelCode:detail.iterationsSuffix')}`
+                  : t('fuelCode:detail.allIterationsTitle')}
             </BCTypography>
-            <Card elevation={1} sx={{ width: '100%', height: '100%' }}>
-              <CardContent>
-                {isLoading ? (
-                  <Skeleton variant="rounded" height={360} />
-                ) : (
-                  <VolumeChart data={volumeOverTime} t={t} />
-                )}
-              </CardContent>
-            </Card>
-          </BCBox>
+            <BCBox sx={{ width: '100%', mb: 4, overflowX: 'auto' }}>
+              {isLoading ? (
+                <Card elevation={1} sx={{ width: '100%', minWidth: 980 }}>
+                  <CardContent sx={{ p: 2 }}>
+                    <Skeleton variant="rounded" height={38} sx={{ mb: 1 }} />
+                    <Skeleton variant="rounded" height={46} sx={{ mb: 1 }} />
+                    <Skeleton variant="rounded" height={46} sx={{ mb: 1 }} />
+                    <Skeleton variant="rounded" height={46} />
+                  </CardContent>
+                </Card>
+              ) : (
+                <BCGridViewer
+                  gridRef={gridRef}
+                  queryData={queryData}
+                  dataKey="fuelCodes"
+                  columnDefs={colDefs}
+                  gridKey="fuel-code-iterations-grid"
+                  gridOptions={iterationGridOptions}
+                  defaultColDef={iterationDefaultColDef}
+                  paginationOptions={paginationOptions}
+                  onPaginationChange={handleIterationPaginationChange}
+                  enablePageCaching={false}
+                  overlayNoRowsTemplate={t('fuelCode:noFuelCodesFound')}
+                  getRowId={(params) =>
+                    params.data.id ?? params.data.fuelCodeId?.toString()
+                  }
+                />
+              )}
+            </BCBox>
 
-          {/* Compliance units over time chart */}
-          <BCBox sx={{ minWidth: 0 }}>
-            <BCTypography variant="h6" color="primary" sx={{ mb: 1 }}>
-              {t('fuelCode:detail.complianceUnitsOverTimeTitle')}
-            </BCTypography>
-            <Card
-              elevation={1}
-              sx={{ width: '100%', height: '100%' }}
-              data-test="compliance-units-chart-card"
+            <BCBox
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'minmax(0, 1fr)',
+                '@media (min-width:750px)': {
+                  gridTemplateColumns: 'repeat(2, minmax(320px, 1fr))'
+                },
+                columnGap: { xs: 2, md: 3 },
+                rowGap: { xs: 2, md: 3 },
+                mb: 4,
+                width: '100%',
+                maxWidth: '2160px'
+              }}
             >
-              <CardContent>
-                {isLoading ? (
-                  <Skeleton variant="rounded" height={360} />
-                ) : (
-                  <ComplianceUnitsChart data={complianceUnitsOverTime} t={t} />
-                )}
-              </CardContent>
-            </Card>
-          </BCBox>
-        </BCBox>
+              <BCBox sx={{ minWidth: 0 }}>
+                <BCTypography variant="h6" color="primary" sx={{ mb: 1 }}>
+                  {t('fuelCode:detail.volumeOverTimeTitle')}
+                </BCTypography>
+                <Card elevation={1} sx={{ width: '100%', height: '100%' }}>
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton variant="rounded" height={360} />
+                    ) : (
+                      <VolumeChart data={volumeOverTime} t={t} />
+                    )}
+                  </CardContent>
+                </Card>
+              </BCBox>
+
+              <BCBox sx={{ minWidth: 0 }}>
+                <BCTypography variant="h6" color="primary" sx={{ mb: 1 }}>
+                  {t('fuelCode:detail.complianceUnitsOverTimeTitle')}
+                </BCTypography>
+                <Card
+                  elevation={1}
+                  sx={{ width: '100%', height: '100%' }}
+                  data-test="compliance-units-chart-card"
+                >
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton variant="rounded" height={360} />
+                    ) : (
+                      <ComplianceUnitsChart
+                        data={complianceUnitsOverTime}
+                        t={t}
+                      />
+                    )}
+                  </CardContent>
+                </Card>
+              </BCBox>
+            </BCBox>
+          </>
+        )}
       </BCBox>
     </BCBox>
   )
 }
 
-export const FuelCodeDetail = withRole(FuelCodeDetailBase, govRoles)
+export const FuelCodeDetail = withRole(FuelCodeDetailBase, [
+  ...govRoles,
+  ...nonGovRoles
+])

--- a/frontend/src/views/FuelCodes/FuelCodeDetail/__tests__/FuelCodeDetail.test.jsx
+++ b/frontend/src/views/FuelCodes/FuelCodeDetail/__tests__/FuelCodeDetail.test.jsx
@@ -67,12 +67,19 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockUseGetFuelCodeGroup = vi.fn()
+const mockUseGetFuelCode = vi.fn()
+const mockUseCurrentUser = vi.fn()
 
 vi.mock('@/hooks/useFuelCode', () => ({
   useGetFuelCodeGroup: (...args) => mockUseGetFuelCodeGroup(...args),
+  useGetFuelCode: (...args) => mockUseGetFuelCode(...args),
   useFuelCodeStatuses: vi.fn(() => ({
     data: [{ status: 'Approved' }, { status: 'Draft' }]
   }))
+}))
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser()
 }))
 
 vi.mock('@/stores/useFuelCodePageStore', () => ({
@@ -147,8 +154,17 @@ const groupData = {
 describe('FuelCodeDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseCurrentUser.mockReturnValue({
+      data: { isGovernmentUser: true }
+    })
     mockUseGetFuelCodeGroup.mockReturnValue({
       data: groupData,
+      isLoading: false,
+      isError: false,
+      error: null
+    })
+    mockUseGetFuelCode.mockReturnValue({
+      data: latestIteration,
       isLoading: false,
       isError: false,
       error: null
@@ -232,5 +248,34 @@ describe('FuelCodeDetail', () => {
     expect(
       screen.queryByText('Zimmerman@fuelproducerltd.ar')
     ).not.toBeInTheDocument()
+  })
+
+  it('uses the single-record endpoint and renders a read-only view for BCeID', () => {
+    mockUseCurrentUser.mockReturnValue({
+      data: { isGovernmentUser: false }
+    })
+
+    render(<FuelCodeDetail />, { wrapper })
+
+    expect(mockUseGetFuelCode).toHaveBeenCalledWith('100', { enabled: true })
+    expect(mockUseGetFuelCodeGroup).toHaveBeenCalledWith('100', {
+      enabled: false
+    })
+    expect(screen.getByText('C-BCLCF-100')).toBeInTheDocument()
+    expect(screen.getByText('Fuel Producer Ltd.')).toBeInTheDocument()
+    expect(screen.queryByTestId('iterations-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('volume-chart')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('compliance-units-chart')
+    ).not.toBeInTheDocument()
+  })
+
+  it('uses the group endpoint for IDIR users', () => {
+    render(<FuelCodeDetail />, { wrapper })
+
+    expect(mockUseGetFuelCodeGroup).toHaveBeenCalledWith('100', {
+      enabled: true
+    })
+    expect(mockUseGetFuelCode).toHaveBeenCalledWith('100', { enabled: false })
   })
 })


### PR DESCRIPTION
This PR adds a global search feature spanning the core LCFS entities.

- Search organizations, reports, transfers, users, fuel codes etc.
- Scope results by organization and government role
- Rank matches and group results per entity type